### PR TITLE
Add color-coded move groups, strategy titles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
 import Link from '@mui/material/Link';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { createTheme } from '@mui/material/styles';
@@ -21,8 +22,7 @@ import { Generations, Pokemon, Field} from './calc/index.ts';
 import { MoveName } from './calc/data/interface.ts';
 import { Raider, RaidBattleInfo, RaidState } from './raidcalc/interface.ts';
 
-
-import {BOSS_SETDEX_SV} from './data/sets/raid_bosses.ts'
+// import {BOSS_SETDEX_SV} from './data/sets/raid_bosses.ts'
 
 function App() {
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
@@ -164,6 +164,10 @@ function App() {
     <Box>  
       <CssBaseline />
       <Navbar lightMode={lightMode} setLightMode={setLightMode} prettyMode={prettyMode} setPrettyMode={setPrettyMode} />
+      </Box>
+      <Grid container component='title' justifyContent="center" sx={{ my: 1 }}>
+        <TextField />
+      </Grid>
       <Grid container component='main' justifyContent="left" sx={{ my: 1 }}>
         <Grid item>
           <Stack direction="row">
@@ -184,27 +188,34 @@ function App() {
           <RaidControls info={info} setInfo={setInfo} />
         </Grid>
       </Grid>
-      <Box sx={{ p: 2 }}>
-        <LinkButton info={info} setInfo={setInfo} />
-      </Box>
-      <Stack sx={{ mx: 3, my: 3}}>
-        <Typography variant="h6" sx={{color: "text.secondary"}}>
-          Acknowledgements
-        </Typography>
-        <Typography variant="body2" gutterBottom sx={{color: "text.secondary"}}>
-          Thank you to the <Link href="https://reddit.com/r/pokeportal">r/PokePortal</Link> Event Raid Support team for their help with design and testing!
-        </Typography>
-        <Typography variant="body2" gutterBottom sx={{color: "text.secondary"}}>
-          Damage calculations are based on the <Link href="https://github.com/smogon/damage-calc/tree/master/calc">@smogon/calc</Link> package, with additional changes from <Link href="https://github.com/davbou/damage-calc">davbou's fork</Link>.
-        </Typography>
-        <Typography variant="h6" sx={{color: "text.secondary"}}>
-            Contact
-        </Typography>
-        <Typography variant="body2" gutterBottom sx={{color: "text.secondary"}}>
-          Please submit issues or feature requests at <Link href="https://github.com/theastrogoth/tera-raid-builder/">this project's Github repository</Link>.
-        </Typography>
-      </Stack>
-    </Box>   
+      <Grid container component='footer' justifyContent="left" sx={{ my: 1 }}>
+        <Grid item xs={12}>
+          <Stack >
+            <Stack direction="row" sx={{ p: 2 }}>
+              <Box flexGrow={1} />
+              <LinkButton info={info} setInfo={setInfo} />
+              <Box flexGrow={1} />
+            </Stack>
+            <Stack sx={{ mx: 3, my: 3}}>
+              <Typography variant="h6" sx={{color: "text.secondary"}}>
+                Acknowledgements
+              </Typography>
+              <Typography variant="body2" gutterBottom sx={{color: "text.secondary"}}>
+                Thank you to the <Link href="https://reddit.com/r/pokeportal">r/PokePortal</Link> Event Raid Support team for their help with design and testing!
+              </Typography>
+              <Typography variant="body2" gutterBottom sx={{color: "text.secondary"}}>
+                Damage calculations are based on the <Link href="https://github.com/smogon/damage-calc/tree/master/calc">@smogon/calc</Link> package, with additional changes from <Link href="https://github.com/davbou/damage-calc">davbou's fork</Link>.
+              </Typography>
+              <Typography variant="h6" sx={{color: "text.secondary"}}>
+                  Contact
+              </Typography>
+              <Typography variant="body2" gutterBottom sx={{color: "text.secondary"}}>
+                Please submit issues or feature requests at <Link href="https://github.com/theastrogoth/tera-raid-builder/">this project's Github repository</Link>.
+              </Typography>
+            </Stack>
+          </Stack>
+        </Grid>
+    </Grid>
     </ThemeProvider>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -133,6 +133,7 @@ function App() {
   ];
 
   const [info, setInfo] = useState<RaidBattleInfo>({
+    name: "",
     startingState: new RaidState(defaultRaiders, defaultRaiders.map((r) => new Field())),
     turns: [
       {
@@ -166,9 +167,21 @@ function App() {
       <Navbar lightMode={lightMode} setLightMode={setLightMode} prettyMode={prettyMode} setPrettyMode={setPrettyMode} />
       </Box>
       <Grid container component='title' justifyContent="center" sx={{ my: 1 }}>
-        <TextField />
+        <Grid item xs={10} sm={10} md={10} lg={8} xl={6} justifyContent="center">
+          <Box justifyContent="center">
+            <TextField 
+              variant="standard"
+              placeholder="Give your strategy a name!"
+              value={info.name}
+              inputProps={{
+                style: {fontSize: 24, fontWeight: "bold", textAlign: "center"},
+              }}
+              sx={{ width: "100%" }}
+            />
+          </Box>
+        </Grid>
       </Grid>
-      <Grid container component='main' justifyContent="left" sx={{ my: 1 }}>
+      <Grid container component='main' justifyContent="center" sx={{ my: 1 }}>
         <Grid item>
           <Stack direction="row">
             <PokemonSummary pokemon={raiders[1]} setPokemon={setPokemon(1)} prettyMode={prettyMode} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,46 @@ function App() {
       secondary: {
         main: lightMode === 'dark' ? "#faa5a0" : "#940f07"
       },
+      //@ts-ignore
+      group0: {
+        main: lightMode === "dark" ? "#571b20" : "#f7b5ba",
+      },
+      //@ts-ignore
+      group1: {
+        main: lightMode === "dark" ? "#144e52" : "#c5e6e8"
+      },
+      //@ts-ignore
+      group2: {
+        main: lightMode === "dark" ? "#205220" : "#b0f5b0"
+      },
+      //@ts-ignore
+      group3: {
+        main: lightMode === "dark" ? "#443769" : "#ccbff5",
+      },
+      //@ts-ignore
+      group4: {
+        main: lightMode === "dark" ? "#c79240" : "#ffe0b0"
+      },
+      //@ts-ignore
+      group5: {
+        main: lightMode === "dark" ? "#5fa116" : "#d7faaf"
+      },
+      //@ts-ignore
+      group6: {
+        main: lightMode === "dark" ? "#993f64" : "#fccce1"
+      },
+      //@ts-ignore
+      group7: {
+        main: lightMode === "dark" ? "#4f4215": "#d4caa7"
+      },
+      //@ts-ignore
+      group8: {
+        main: lightMode === "dark" ? "#520438": "#c4b1be"
+      },
+      //@ts-ignore
+      group9: {
+        main: lightMode === "dark" ? "#363336": "#b3b3b3"
+      },
     },
     typography: {
       fontSize: 11,
@@ -85,7 +125,7 @@ function App() {
       moves: ["Defog", "Fake Tears"],
       evs: {hp: 252, spd: 252},
     })),
-    new Raider(4, "Raider #3", new Pokemon(gen, "Corviknight", {
+    new Raider(4, "Raider #4", new Pokemon(gen, "Corviknight", {
       nature: "Relaxed",
       moves: ["Defog", "Fake Tears"],
       evs: {hp: 252, spd: 252},
@@ -101,6 +141,7 @@ function App() {
         bossMoveInfo: {userID: 0, targetID: 1, options: {crit: false, secondaryEffects: false, roll: "max" }, moveData: {name: "(No Move)" as MoveName}},
       }
     ],
+    groups: [],
   })
 
   const raiders = info.startingState.raiders;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -166,18 +166,26 @@ function App() {
       <CssBaseline />
       <Navbar lightMode={lightMode} setLightMode={setLightMode} prettyMode={prettyMode} setPrettyMode={setPrettyMode} />
       </Box>
-      <Grid container component='title' justifyContent="center" sx={{ my: 1 }}>
+      <Grid container justifyContent="center" sx={{ my: 1 }}>
         <Grid item xs={10} sm={10} md={10} lg={8} xl={6} justifyContent="center">
           <Box justifyContent="center">
-            <TextField 
-              variant="standard"
-              placeholder="Give your strategy a name!"
-              value={info.name}
-              inputProps={{
-                style: {fontSize: 24, fontWeight: "bold", textAlign: "center"},
-              }}
-              sx={{ width: "100%" }}
-            />
+            {prettyMode &&
+              <Typography variant="h4" sx={{ textAlign: "center", marginTop: 1 }}>
+                {info.name}
+              </Typography>
+            }
+            {!prettyMode &&
+              <TextField 
+                variant="standard"
+                placeholder="Give your strategy a name!"
+                value={info.name}
+                inputProps={{
+                  style: {fontSize: 24, fontWeight: "bold", textAlign: "center"},
+                }}
+                sx={{ width: "100%" }}
+              />
+            }
+
           </Box>
         </Grid>
       </Grid>
@@ -198,15 +206,15 @@ function App() {
           <BossSummary pokemon={raiders[0]} setPokemon={setPokemon(0)} prettyMode={prettyMode} />
         </Grid>
         <Grid item>
-          <RaidControls info={info} setInfo={setInfo} />
+          <RaidControls info={info} setInfo={setInfo} prettyMode={prettyMode} />
         </Grid>
       </Grid>
-      <Grid container component='footer' justifyContent="left" sx={{ my: 1 }}>
+      <Grid container justifyContent="left" sx={{ my: 1 }}>
         <Grid item xs={12}>
           <Stack >
             <Stack direction="row" sx={{ p: 2 }}>
               <Box flexGrow={1} />
-              <LinkButton info={info} setInfo={setInfo} />
+              <LinkButton info={info} setInfo={setInfo} setPrettyMode={setPrettyMode}/>
               <Box flexGrow={1} />
             </Stack>
             <Stack sx={{ mx: 3, my: 3}}>

--- a/src/data/official_strats/delphox.json
+++ b/src/data/official_strats/delphox.json
@@ -1,4 +1,5 @@
 {
+    "name": "BONK! A 2-Turn 7⭐ Delphox OHKO",
     "pokemon": [
         {
             "id": 0,

--- a/src/data/official_strats/delphox.json
+++ b/src/data/official_strats/delphox.json
@@ -54,6 +54,7 @@
     "turns": [
         {
             "id": 0,
+            "group": 0,
             "moveInfo": {
                 "userID": 1,
                 "targetID": 1,
@@ -73,7 +74,8 @@
             
         },
         {
-            "id": 2,
+            "id": 1,
+            "group": 0,
             "moveInfo": {
                 "userID": 2,
                 "targetID": 1,
@@ -92,7 +94,8 @@
             }
         },
         {
-            "id": 3,
+            "id": 2,
+            "group": 0,
             "moveInfo": {
                 "userID": 3,
                 "targetID": 0,
@@ -111,7 +114,8 @@
             }
         },
         {
-            "id": 4,
+            "id": 3,
+            "group": 0,
             "moveInfo": {
                 "userID": 4,
                 "targetID": 0,
@@ -130,7 +134,8 @@
             }
         },
         {
-            "id": 5,
+            "id": 4,
+            "group": 1,
             "moveInfo": {
                 "userID": 3,
                 "targetID": 3,
@@ -142,6 +147,27 @@
             "bossMoveInfo": {
                 "userID": 0,
                 "targetID": 3,
+                "name": "Psychic",
+                "options": {
+                    "roll": "max",
+                    "crit": true
+                }
+            }
+        },
+        {
+            "id": 5,
+            "group": 1,
+            "moveInfo": {
+                "userID": 4,
+                "targetID": 4,
+                "name": "Heal Cheer",
+                "options": {
+                    "roll": "min"
+                }
+            },
+            "bossMoveInfo": {
+                "userID": 0,
+                "targetID": 4,
                 "name": "Psychic",
                 "options": {
                     "roll": "max",
@@ -151,26 +177,6 @@
         },
         {
             "id": 6,
-            "moveInfo": {
-                "userID": 4,
-                "targetID": 4,
-                "name": "Heal Cheer",
-                "options": {
-                    "roll": "min"
-                }
-            },
-            "bossMoveInfo": {
-                "userID": 0,
-                "targetID": 4,
-                "name": "Psychic",
-                "options": {
-                    "roll": "max",
-                    "crit": true
-                }
-            }
-        },
-        {
-            "id": 7,
             "moveInfo": {
                 "userID": 2,
                 "targetID": 2,
@@ -190,7 +196,7 @@
             }
         },
         {
-            "id": 8,
+            "id": 7,
             "moveInfo": {
                 "userID": 1,
                 "targetID": 0,
@@ -205,5 +211,9 @@
                 "name": "(No Move)"
             }
         }
+    ],
+    "groups": [
+        [0, 1, 2, 3],
+        [4, 5]
     ]
 }

--- a/src/raidcalc/RaidBattle.ts
+++ b/src/raidcalc/RaidBattle.ts
@@ -156,7 +156,6 @@ export class RaidBattle {
             // Protosynthesis and Quark Drive
             } else if (ability === "Protosynthesis" || ability === "Quark Drive") {
                 if (pokemon.item === "Booster Energy") {
-                    console.log("Here in RaidBattle")
                     pokemon.abilityOn = true;
                     const qpStat = getQPBoostedStat (pokemon) as StatIDExceptHP;
                     pokemon.boostedStat = qpStat;

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -322,7 +322,6 @@ export class RaidMove {
 
     private setSelfDamage() {
         const selfDamage = Math.floor(this._user.maxHP() * (this.moveData.selfDamage || 0) / 100);
-        console.log(this.moveData.name, this.moveData.selfDamage, selfDamage)
         if (selfDamage !== 0) {
             const selfDamagePercent = this.moveData.selfDamage;
             this._flags[this.userID].push!(selfDamagePercent + "% self damage from " + this.moveData.name + ".")
@@ -834,7 +833,6 @@ export class RaidMove {
         for (let i=0; i<5; i++) {
             const initialHP = this.raidState.raiders[i].originalCurHP;
             const finalHP = this._raiders[i].originalCurHP;
-            console.log(finalHP)
             if (initialHP !== finalHP) {
                 const initialPercent = Math.floor(initialHP / this.raidState.raiders[i].maxHP() * 100);
                 const finalPercent = Math.floor(finalHP / this._raiders[i].maxHP() * 1000)/10;

--- a/src/raidcalc/hashData.ts
+++ b/src/raidcalc/hashData.ts
@@ -25,6 +25,7 @@ export type LightMoveInfo = {
 
 export type LightTurnInfo = {
     id: number,
+    group?: number,
     moveInfo: LightMoveInfo,
     bossMoveInfo: LightMoveInfo,
 }
@@ -32,5 +33,6 @@ export type LightTurnInfo = {
 export type LightBuildInfo = {
     pokemon: LightPokemon[],
     turns: LightTurnInfo[],
+    groups?: number[][],
 }
 

--- a/src/raidcalc/hashData.ts
+++ b/src/raidcalc/hashData.ts
@@ -31,6 +31,7 @@ export type LightTurnInfo = {
 }
 
 export type LightBuildInfo = {
+    name?: string,
     pokemon: LightPokemon[],
     turns: LightTurnInfo[],
     groups?: number[][],

--- a/src/raidcalc/interface.ts
+++ b/src/raidcalc/interface.ts
@@ -150,6 +150,7 @@ export class RaidState {
 }
 
 export type RaidBattleInfo = {
+    name?: string;
     startingState: RaidState;
     turns: RaidTurnInfo[];
     groups: number[][];
@@ -200,6 +201,7 @@ export type RaidTurnResult = {
 }
 
 export type BuildInfo = {
+    name: string;
     pokemon: Raider[],
     turns: RaidTurnInfo[],
     groups: number[][],

--- a/src/raidcalc/interface.ts
+++ b/src/raidcalc/interface.ts
@@ -152,6 +152,7 @@ export class RaidState {
 export type RaidBattleInfo = {
     startingState: RaidState;
     turns: RaidTurnInfo[];
+    groups: number[][];
 }
 
 export type RaidBattleResults = {
@@ -175,6 +176,7 @@ export type RaidMoveInfo = {
 
 export type RaidTurnInfo ={
     id: number;
+    group?: number;
     moveInfo: RaidMoveInfo;
     bossMoveInfo: RaidMoveInfo;
 }
@@ -200,4 +202,5 @@ export type RaidTurnResult = {
 export type BuildInfo = {
     pokemon: Raider[],
     turns: RaidTurnInfo[],
+    groups: number[][],
 }

--- a/src/uicomponents/BossSummary.tsx
+++ b/src/uicomponents/BossSummary.tsx
@@ -40,7 +40,7 @@ function BossSummary({pokemon, setPokemon, prettyMode}: {pokemon: Raider, setPok
     return (
         <Box>
             <Paper elevation={3} sx={{ mx: 1, my: 1, width: 575, display: "flex", flexDirection: "column", padding: "0px"}}>                
-                <Stack direction="column" spacing={0} alignItems="center" justifyContent="top" height= "600px" sx={{ marginTop: 1 }} >
+                <Stack direction="column" spacing={0} alignItems="center" justifyContent="top" minHeight={prettyMode ? undefined : "600px"} sx={{ marginTop: 1 }} >
                     <Box paddingBottom={0} width="90%">
                         <RoleField pokemon={pokemon} setPokemon={setPokemon} />
                     </Box>
@@ -128,7 +128,7 @@ function BossSummary({pokemon, setPokemon, prettyMode}: {pokemon: Raider, setPok
                     </Box>
                     <Stack direction="row" spacing={0} >
                         <BuildControls pokemon={pokemon} abilities={abilities} moveSet={moveSet} moveLearnTypes={moveLearnTypes} setPokemon={setPokemon} prettyMode={prettyMode} />
-                        <Stack direction="column" spacing={0} justifyContent="center" alignItems="center" sx={{ width: "300px", height: "375px"}}>
+                        <Stack direction="column" spacing={0} justifyContent="center" alignItems="center" sx={{ width: "300px", minHeight:( prettyMode ? undefined : "375px") }}>
                             <BossBuildControls moveSet={moveSet} pokemon={pokemon} setPokemon={setPokemon} prettyMode={prettyMode} />
                             <Box flexGrow={1} />
                             <StatRadarPlot nature={nature} evs={pokemon.evs} stats={pokemon.stats} bossMultiplier={pokemon.bossMultiplier}/>

--- a/src/uicomponents/BuildControls.tsx
+++ b/src/uicomponents/BuildControls.tsx
@@ -139,7 +139,7 @@ const LeftCell = styled(TableCell)(({ theme }) => ({
                 </LeftCell>
                 <RightCell>
                     {prettyMode &&
-                        <Typography variant="body2">
+                        <Typography variant="body1">
                             {value}
                         </Typography>
                     }
@@ -252,7 +252,7 @@ function BuildControls({pokemon, abilities, moveSet, moveLearnTypes, setPokemon,
                                     <LeftCell>Level</LeftCell>
                                     <RightCell>
                                         {prettyMode &&
-                                            <Typography variant="body2">
+                                            <Typography variant="body1">
                                                 {pokemon.level}
                                             </Typography>
                                         }
@@ -365,7 +365,7 @@ export function BossBuildControls({moveSet, pokemon, setPokemon, prettyMode}:
                                 <LeftCell>HP Multiplier (%)</LeftCell>
                                 <RightCell>
                                     {prettyMode &&
-                                        <Typography variant="body2">
+                                        <Typography variant="body1">
                                             {pokemon.bossMultiplier}
                                         </Typography>
                                     }

--- a/src/uicomponents/LinkButton.tsx
+++ b/src/uicomponents/LinkButton.tsx
@@ -59,8 +59,12 @@ function lightToFullBuildInfo(obj: LightBuildInfo): BuildInfo | null {
                 },
             }
         });
+        const groups = obj.groups || [];
+        const name = obj.name || "";
 
-        return {pokemon, turns, groups: obj.groups || []}
+        console.log("obj", obj)
+
+        return {name, pokemon, turns, groups}
     } catch (e) {
         return null;
     }
@@ -68,6 +72,7 @@ function lightToFullBuildInfo(obj: LightBuildInfo): BuildInfo | null {
 
 function serializeInfo(info: RaidBattleInfo): string {
     const obj: LightBuildInfo = {
+        name: info.name || "",
         pokemon: info.startingState.raiders.map(
             (r) => { return {
                 id: r.id,
@@ -103,7 +108,7 @@ function serializeInfo(info: RaidBattleInfo): string {
                 }
             }
         }),
-        groups: info.groups,
+        groups: info.groups || [],
     }
     return serialize(obj);
 }
@@ -124,12 +129,13 @@ function LinkButton({info, setInfo}: {info: RaidBattleInfo, setInfo: React.Dispa
                     res = deserializeInfo(hash);
                 }
                 if (res) {
-                    const {pokemon, turns} = res;
+                    const {name, pokemon, turns, groups} = res;
                     const startingState = new RaidState(pokemon, pokemon.map((r) => new Field()));
                     setInfo({
+                        name: name,
                         startingState: startingState,
                         turns: turns,
-                        groups: [],
+                        groups: groups,
                     })
                 }
             }

--- a/src/uicomponents/LinkButton.tsx
+++ b/src/uicomponents/LinkButton.tsx
@@ -62,8 +62,6 @@ function lightToFullBuildInfo(obj: LightBuildInfo): BuildInfo | null {
         const groups = obj.groups || [];
         const name = obj.name || "";
 
-        console.log("obj", obj)
-
         return {name, pokemon, turns, groups}
     } catch (e) {
         return null;
@@ -113,7 +111,7 @@ function serializeInfo(info: RaidBattleInfo): string {
     return serialize(obj);
 }
 
-function LinkButton({info, setInfo}: {info: RaidBattleInfo, setInfo: React.Dispatch<React.SetStateAction<RaidBattleInfo>>}) {
+function LinkButton({info, setInfo, setPrettyMode}: {info: RaidBattleInfo, setInfo: React.Dispatch<React.SetStateAction<RaidBattleInfo>>, setPrettyMode: React.Dispatch<React.SetStateAction<boolean>>}) {
     const location = useLocation();
     const hash = location.hash
     useEffect(() => {
@@ -137,6 +135,7 @@ function LinkButton({info, setInfo}: {info: RaidBattleInfo, setInfo: React.Dispa
                         turns: turns,
                         groups: groups,
                     })
+                    setPrettyMode(true)
                 }
             }
         } catch (e) {

--- a/src/uicomponents/LinkButton.tsx
+++ b/src/uicomponents/LinkButton.tsx
@@ -44,6 +44,7 @@ function lightToFullBuildInfo(obj: LightBuildInfo): BuildInfo | null {
         const turns = (obj.turns as LightTurnInfo[]).map((t) => {
             return {
                 id: t.id,
+                group: t.group,
                 moveInfo: {
                     userID: t.moveInfo.userID, 
                     targetID: t.moveInfo.targetID, 
@@ -59,7 +60,7 @@ function lightToFullBuildInfo(obj: LightBuildInfo): BuildInfo | null {
             }
         });
 
-        return {pokemon, turns}
+        return {pokemon, turns, groups: obj.groups || []}
     } catch (e) {
         return null;
     }
@@ -87,6 +88,7 @@ function serializeInfo(info: RaidBattleInfo): string {
         turns: info.turns.map((t) => {
             return {
                 id: t.id,
+                group: t.group,
                 moveInfo: {
                     name: t.moveInfo.moveData.name,
                     userID: t.moveInfo.userID,
@@ -101,6 +103,7 @@ function serializeInfo(info: RaidBattleInfo): string {
                 }
             }
         }),
+        groups: info.groups,
     }
     return serialize(obj);
 }
@@ -126,6 +129,7 @@ function LinkButton({info, setInfo}: {info: RaidBattleInfo, setInfo: React.Dispa
                     setInfo({
                         startingState: startingState,
                         turns: turns,
+                        groups: [],
                     })
                 }
             }

--- a/src/uicomponents/MoveDisplay.tsx
+++ b/src/uicomponents/MoveDisplay.tsx
@@ -9,9 +9,7 @@ function MoveText({raiders, turn}: {raiders: Raider[], turn: RaidTurnInfo}) {
     const user = raiders[turn.moveInfo.userID].role;
 
     let target = raiders[turn.moveInfo.targetID].role;
-    const targetType = turn.moveInfo.moveData.target;
-    if (["user", "entire-field", "user-and-allies", "all-allies", "entire-field", "all-pokemon", "all-other-pokemon" ].includes(targetType || "")
-        || target === user) { 
+    if (target === user) { 
         target = ""
     }
 

--- a/src/uicomponents/MoveDisplay.tsx
+++ b/src/uicomponents/MoveDisplay.tsx
@@ -10,7 +10,8 @@ function MoveText({raiders, turn}: {raiders: Raider[], turn: RaidTurnInfo}) {
 
     let target = raiders[turn.moveInfo.targetID].role;
     const targetType = turn.moveInfo.moveData.target;
-    if ([null, undefined, "user", "entire-field", "user-and-allies", "all-allies", "entire-field", "all-pokemon", "all-other-pokemon" ].includes(targetType)) { 
+    if (["user", "entire-field", "user-and-allies", "all-allies", "entire-field", "all-pokemon", "all-other-pokemon" ].includes(targetType || "")
+        || target === user) { 
         target = ""
     }
 
@@ -18,6 +19,8 @@ function MoveText({raiders, turn}: {raiders: Raider[], turn: RaidTurnInfo}) {
     if (move == "(No Move)") {
         move = "";
     }
+
+    console.log("Move Display", turn.id, move, target)
 
     return (
         <>
@@ -66,6 +69,7 @@ function MoveGroup({info, group, index}: {info: RaidBattleInfo, group: number[],
 }
 
 function MoveDisplay({info}: {info: RaidBattleInfo}) { 
+    console.log("Move Display", info)
     const displayGroups: number[][] = [];
     let currentGroupIndex = -1;
     let currentGroupID: number | undefined = -1;

--- a/src/uicomponents/MoveDisplay.tsx
+++ b/src/uicomponents/MoveDisplay.tsx
@@ -18,8 +18,6 @@ function MoveText({raiders, turn}: {raiders: Raider[], turn: RaidTurnInfo}) {
         move = "";
     }
 
-    console.log("Move Display", turn.id, move, target)
-
     return (
         <>
         {move !== "" &&
@@ -55,6 +53,9 @@ function MoveGroup({info, group, index}: {info: RaidBattleInfo, group: number[],
     const color = "group" + index + ".main";
     return (
         <Paper sx={{backgroundColor: color, paddingLeft: 4, paddingRight: 4, paddingTop: 2, paddingBottom: 2}}>
+            <Typography variant="h4" fontWeight="bold" sx={{ position: "absolute", transform: "translate(-60px,-7px)"}}>
+                {index+1}
+            </Typography>
             <Stack direction="column" spacing={1}>
                 {
                     turns.map((t) => (
@@ -67,7 +68,6 @@ function MoveGroup({info, group, index}: {info: RaidBattleInfo, group: number[],
 }
 
 function MoveDisplay({info}: {info: RaidBattleInfo}) { 
-    console.log("Move Display", info)
     const displayGroups: number[][] = [];
     let currentGroupIndex = -1;
     let currentGroupID: number | undefined = -1;
@@ -82,8 +82,6 @@ function MoveDisplay({info}: {info: RaidBattleInfo}) {
         currentGroupID = g;
     })
 
-    console.log("display groups", displayGroups)
-
     return (
         <Stack direction="column" spacing={0} alignItems="center" justifyContent="center">
             {
@@ -91,7 +89,7 @@ function MoveDisplay({info}: {info: RaidBattleInfo}) {
                     <>
                     <MoveGroup info={info} group={g} index={index} />
                     {index !== displayGroups.length - 1  && 
-                        <Typography variant="h4" fontWeight="bold" sx={{ my: 0.25}}>
+                        <Typography variant="h5" fontWeight="bold" sx={{ my: 0.5}}>
                             ↓
                         </Typography>
                     }

--- a/src/uicomponents/MoveDisplay.tsx
+++ b/src/uicomponents/MoveDisplay.tsx
@@ -1,0 +1,105 @@
+import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import { RaidBattleInfo, RaidTurnInfo, Raider } from "../raidcalc/interface";
+import { Paper } from "@mui/material";
+
+function MoveText({raiders, turn}: {raiders: Raider[], turn: RaidTurnInfo}) {
+
+    const user = raiders[turn.moveInfo.userID].role;
+
+    let target = raiders[turn.moveInfo.targetID].role;
+    const targetType = turn.moveInfo.moveData.target;
+    if ([null, undefined, "user", "entire-field", "user-and-allies", "all-allies", "entire-field", "all-pokemon", "all-other-pokemon" ].includes(targetType)) { 
+        target = ""
+    }
+
+    let move: string = turn.moveInfo.moveData.name;
+    if (move == "(No Move)") {
+        move = "";
+    }
+
+    return (
+        <>
+        {move !== "" &&
+            <Stack direction="row" spacing={1} alignItems="center" justifyContent="center">
+                <Typography variant="body1" fontWeight="bold">
+                    {user}
+                </Typography>
+                <Typography variant="body1">
+                    uses
+                </Typography>
+                <Typography variant="body1" fontWeight="bold">
+                    {move}
+                </Typography>
+                {target !== "" &&
+                    <Typography variant="body1">
+                        on
+                    </Typography>
+                }
+                {target !== "" &&
+                    <Typography variant="body1" fontWeight="bold">
+                        {target}
+                    </Typography>
+                }
+            </Stack>
+        }
+        </>
+
+    )
+}
+
+function MoveGroup({info, group, index}: {info: RaidBattleInfo, group: number[], index: number}) {
+    const turns = info.turns.filter((t, i) => group.includes(i));
+    const color = "group" + index + ".main";
+    return (
+        <Paper sx={{backgroundColor: color, paddingLeft: 4, paddingRight: 4, paddingTop: 2, paddingBottom: 2}}>
+            <Stack direction="column" spacing={1}>
+                {
+                    turns.map((t) => (
+                        <MoveText raiders={info.startingState.raiders} turn={t} />
+                    ))
+                }
+            </Stack>
+        </Paper>
+    )
+}
+
+function MoveDisplay({info}: {info: RaidBattleInfo}) { 
+    const displayGroups: number[][] = [];
+    let currentGroupIndex = -1;
+    let currentGroupID: number | undefined = -1;
+    info.turns.forEach((t, index) => {
+        const g = t.group;
+        if (g === undefined || g !== currentGroupID) {
+            currentGroupIndex += 1;
+            displayGroups.push([index]);
+        } else {
+            displayGroups[currentGroupIndex].push(index);
+        }
+        currentGroupID = g;
+    })
+
+    console.log("display groups", displayGroups)
+
+    return (
+        <Stack direction="column" spacing={0} alignItems="center" justifyContent="center">
+            {
+                displayGroups.map((g, index) => (
+                    <>
+                    <MoveGroup info={info} group={g} index={index} />
+                    {index !== displayGroups.length - 1  && 
+                        <Typography variant="h4" fontWeight="bold" sx={{ my: 0.25}}>
+                            ↓
+                        </Typography>
+                    }
+                    </>
+                ))
+
+            }
+        </Stack>
+    )
+}
+
+
+export default MoveDisplay;

--- a/src/uicomponents/Navbar.tsx
+++ b/src/uicomponents/Navbar.tsx
@@ -25,6 +25,9 @@ function Navbar({lightMode, setLightMode, prettyMode, setPrettyMode}: {lightMode
         <Box>
             <AppBar position="static" color="secondary" sx={{ minWidth: "600px"}}>
                 <Toolbar>
+                    <Box paddingRight={2}>
+                        <img src={process.env.PUBLIC_URL + "/logo192.png"} height={50} />
+                    </Box>
                     <Typography 
                         variant="h5"
                         sx={{

--- a/src/uicomponents/PokemonSummary.tsx
+++ b/src/uicomponents/PokemonSummary.tsx
@@ -36,7 +36,7 @@ export function RoleField({pokemon, setPokemon}: {pokemon: Raider, setPokemon: (
         <TextField 
             variant="standard"
             fullWidth
-            inputProps={{style: {fontWeight: "bold",fontSize: 25, textAlign: "center"}}}
+            inputProps={{ maxLength: 20, style: {fontWeight: "bold",fontSize: 25, textAlign: "center"}}}
             margin="dense"
             value={str}
             onChange={(e) => setStr(e.target.value)}

--- a/src/uicomponents/PokemonSummary.tsx
+++ b/src/uicomponents/PokemonSummary.tsx
@@ -67,7 +67,7 @@ function PokemonSummary({pokemon, setPokemon, prettyMode}: {pokemon: Raider, set
     return (
         <Box>
             <Paper elevation={3} sx={{ mx: 1, my: 1, width: 280, display: "flex", flexDirection: "column", padding: "0px"}}>                
-                <Stack direction="column" spacing={0} alignItems="center" justifyContent="top" height= {prettyMode ? "650px" : "800px"} sx={{ marginTop: 1 }} >
+                <Stack direction="column" spacing={0} alignItems="center" justifyContent="top" minHeight= {prettyMode ? "625px" : "800px"} sx={{ marginTop: 1 }} >
                     <Box paddingBottom={0} width="90%">
                         <RoleField pokemon={pokemon} setPokemon={setPokemon} />
                     </Box>

--- a/src/uicomponents/RaidControls.tsx
+++ b/src/uicomponents/RaidControls.tsx
@@ -31,7 +31,7 @@ function RaidControls({info, setInfo, prettyMode}: {info: RaidBattleInfo, setInf
     useEffect(() => {
         raidcalcWorker
             .postMessage({info});
-    }, [info]);
+    }, [info, prettyMode]);
 
     return (
         <Box width={575} sx={{ mx: 1}}>

--- a/src/uicomponents/RaidControls.tsx
+++ b/src/uicomponents/RaidControls.tsx
@@ -6,12 +6,13 @@ import Tab from '@mui/material/Tab';
 
 import MoveSelection from "./MoveSelection";
 import RaidResults from "./RaidResults";
+import MoveDisplay from './MoveDisplay';
 import { RaidBattleInfo, RaidBattleResults } from "../raidcalc/interface";
 
 
 const raidcalcWorker = new Worker(new URL("../workers/raidcalc.worker.ts", import.meta.url));
 
-function RaidControls({info, setInfo}: {info: RaidBattleInfo, setInfo: React.Dispatch<React.SetStateAction<RaidBattleInfo>>}) {
+function RaidControls({info, setInfo, prettyMode}: {info: RaidBattleInfo, setInfo: React.Dispatch<React.SetStateAction<RaidBattleInfo>>, prettyMode: boolean}) {
     const [value, setValue] = useState<number>(1);
     const [results, setResults] = useState<RaidBattleResults | null>(null);
 
@@ -36,14 +37,19 @@ function RaidControls({info, setInfo}: {info: RaidBattleInfo, setInfo: React.Dis
         <Box width={575} sx={{ mx: 1}}>
             <Box paddingBottom={1}>
                 <Tabs value={value} onChange={handleChange} centered>
-                    <Tab label="Move Controls" value={1} />
-                    <Tab label="Move Calc Results" value={2} />
+                    <Tab label="Move Order" value={1} />
+                    <Tab label="Calc Results" value={2} />
                 </Tabs>
             </Box>
             <Box hidden={value !== 1}>
                 <Stack direction="column" spacing={1} >
                     <Box maxHeight={560} sx={{ overflowY: "auto" }}>
-                        <MoveSelection info={info} setInfo={setInfo} />
+                        {!prettyMode &&
+                            <MoveSelection info={info} setInfo={setInfo} />
+                        }
+                        {prettyMode &&
+                            <MoveDisplay info={info} />
+                        }
                     </Box>
                 </Stack>
             </Box>


### PR DESCRIPTION
closes #4, #34 

Allow creating of move groups by dragging + dropping one move card atop another. This will set them to the same color.

Although there isn't any kind of check for this, group colors are intended to indicate when the order of moves (within a group) does not matter.

Grouped moves abide by the following rules:
- Non-adjacent moves cannot be in a group
- Groups must have at least two moves

Moves can be removed from groups (or groups can be removed entirely) by violating one of these rules (e.g. by dragging a move away from a group so that it is no longer adjacent).