### PR TITLE
Fix end-of-turn behavior for status-causing items

### DIFF
--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -125,10 +125,14 @@ export class RaidMove {
         this.applyAbilityEffects();
         this.setEndOfTurnDamage();
         this.applyEndOfTurnDamage();
-        this.applyItemEffects(!this.movesFirst);
+        this.applyItemEffects();
         this.setFlags();
         this._user.lastMove = this.moveData;
         this._user.lastTarget = this.moveData.target == "user" ? this.userID : this.targetID;
+        return this.output;
+    }
+
+    public get output(): RaidMoveResult {
         return {
             state: this._raidState,
             userID: this.userID,
@@ -589,7 +593,7 @@ export class RaidMove {
         }
     }
 
-    private applyItemEffects(endOfTurn: boolean = false) {
+    public applyItemEffects() {
         /// Item-related effects
         // Focus Sash
         for (let id of this._affectedIDs) {

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -706,30 +706,7 @@ export class RaidMove {
                 pokemon.item = undefined;
             }
         }
-        // Ailment-inducing Items
-        if (hasNoStatus(this._user) && endOfTurn) {
-            switch (this._user.item) {
-                case "Light Ball":
-                    this._user.status = "par";
-                    break;
-                case "Flame Orb":
-                    if (!this._user.types.includes("Fire")) { 
-                        this._user.status = "brn";  
-                    }
-                    break;
-                case "Toxic Orb":
-                    if (!this._user.types.includes("Poison")) { 
-                        this._user.status = "tox"; 
-                    }
-                    break;
-                case "Poison Barb":
-                    if (!this._user.types.includes("Poison")) { 
-                        this._user.status = "psn"; 
-                    }
-                    break;
-                default: break
-            }
-        }
+
         // Other Berry Consumption
         for (let i=0; i<5; i++) {
             if (this._damage[i] > 0) {
@@ -910,8 +887,4 @@ export class RaidMove {
             }
         }
     }
-
-    // private handleFlags() {
-    //     //
-    // }
 }

--- a/src/raidcalc/RaidTurn.ts
+++ b/src/raidcalc/RaidTurn.ts
@@ -157,26 +157,36 @@ export class RaidTurn {
     private applyEndOfTurnItemEffects() {
         for (let id of [0, this.raiderID]) {
             const pokemon = this._raidState.raiders[id];
-
+            const result = this._raiderMovesFirst ? (
+                id === 0 ? this._result2 : this._result1
+            ) : (
+                id === 0 ? this._result1 : this._result2
+            );
             // Ailment-inducing Items
             if (pokemon.status === undefined || pokemon.status === "") {
                 switch (pokemon.item) {
                     case "Light Ball":
-                        pokemon.status = "par";
+                        if (!pokemon.types.includes("Electric")) {
+                            pokemon.status = "par";
+                            result.flags[id].push("par inflicted");
+                        }
                         break;
                     case "Flame Orb":
                         if (!pokemon.types.includes("Fire")) { 
                             pokemon.status = "brn";  
+                            result.flags[id].push("brn inflicted");
                         }
                         break;
                     case "Toxic Orb":
                         if (!pokemon.types.includes("Poison")) { 
                             pokemon.status = "tox"; 
+                            result.flags[id].push("tox inflicted");
                         }
                         break;
                     case "Poison Barb":
                         if (!pokemon.types.includes("Poison")) { 
                             pokemon.status = "psn"; 
+                            result.flags[id].push("psn inflicted");
                         }
                         break;
                     default: break

--- a/src/raidcalc/RaidTurn.ts
+++ b/src/raidcalc/RaidTurn.ts
@@ -119,6 +119,8 @@ export class RaidTurn {
                 this.raiderOptions).result();
             this._raidState = this._result2.state;
         }
+        // item effects
+        this.applyEndOfTurnItemEffects();
         // Clear Endure (since side-attacks are not endured)
         this._raidState.raiders[this.raiderID].isEndure = false;
         this._raidState.raiders[0].isEndure = false; // I am unaware of any raid bosses that have endure
@@ -151,5 +153,35 @@ export class RaidTurn {
             this._raiderMovesFirst = bossField.isTrickRoom ? (raiderSpeed < bossSpeed) : (raiderSpeed > bossSpeed);
         }
     }
-    
+
+    private applyEndOfTurnItemEffects() {
+        for (let id of [0, this.raiderID]) {
+            const pokemon = this._raidState.raiders[id];
+
+            // Ailment-inducing Items
+            if (pokemon.status === undefined || pokemon.status === "") {
+                switch (pokemon.item) {
+                    case "Light Ball":
+                        pokemon.status = "par";
+                        break;
+                    case "Flame Orb":
+                        if (!pokemon.types.includes("Fire")) { 
+                            pokemon.status = "brn";  
+                        }
+                        break;
+                    case "Toxic Orb":
+                        if (!pokemon.types.includes("Poison")) { 
+                            pokemon.status = "tox"; 
+                        }
+                        break;
+                    case "Poison Barb":
+                        if (!pokemon.types.includes("Poison")) { 
+                            pokemon.status = "psn"; 
+                        }
+                        break;
+                    default: break
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fix behavior for items that take effect at the end of a turn.

End-of-turn damage/healing might need to be fixed as well. A more flexible way to apply item effects as a result of damage may be needed.

closes #58