### PR TITLE
Improve performance by reducing rerenders

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -226,7 +226,7 @@ function App() {
       {
         id: 0, 
         moveInfo: {userID: 1, targetID: 0, options: {crit: false, secondaryEffects: false, roll: "min" }, moveData: {name: "(No Move)" as MoveName}}, 
-        bossMoveInfo: {userID: 0, targetID: 1, options: {crit: false, secondaryEffects: false, roll: "max" }, moveData: {name: "(No Move)" as MoveName}},
+        bossMoveInfo: {userID: 0, targetID: 1, options: {crit: true, secondaryEffects: true, roll: "max" }, moveData: {name: "(No Move)" as MoveName}},
       }
     ],
     groups: [],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,10 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import './App.css';
 
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import TextField from '@mui/material/TextField';
 import Link from '@mui/material/Link';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { createTheme } from '@mui/material/styles';
@@ -30,7 +29,8 @@ function App() {
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
   const [lightMode, setLightMode] = useState<('dark' | 'light')>(prefersDarkMode ? 'dark' : 'light');
   const [prettyMode, setPrettyMode] = useState<boolean>(false);
-  const theme = createTheme({
+  
+  const [theme, setTheme] = useState(createTheme({
     palette: {
       mode: lightMode,
       background: {
@@ -102,7 +102,85 @@ function App() {
         }
       }
     }
-  });  
+  }));  
+
+  useEffect(() => {
+    setTheme(createTheme(
+      {
+        palette: {
+          mode: lightMode,
+          background: {
+            paper: lightMode === 'dark' ? '#4b4b4b' : '#e6e6e6',
+          },
+          primary: {
+            main: lightMode === 'dark' ? "#faa5a0" : "#ed382d",
+          },
+          secondary: {
+            main: lightMode === 'dark' ? "#faa5a0" : "#940f07"
+          },
+          //@ts-ignore
+          modal: {
+            main: lightMode === 'dark' ? "#666666" : "#dedede"
+          },
+          //@ts-ignore
+          group0: {
+            main: lightMode === "dark" ? "#571b20" : "#f7b5ba",
+          },
+          //@ts-ignore
+          group1: {
+            main: lightMode === "dark" ? "#144e52" : "#c5e6e8"
+          },
+          //@ts-ignore
+          group2: {
+            main: lightMode === "dark" ? "#205220" : "#b0f5b0"
+          },
+          //@ts-ignore
+          group3: {
+            main: lightMode === "dark" ? "#443769" : "#ccbff5",
+          },
+          //@ts-ignore
+          group4: {
+            main: lightMode === "dark" ? "#c79240" : "#ffe0b0"
+          },
+          //@ts-ignore
+          group5: {
+            main: lightMode === "dark" ? "#5fa116" : "#d7faaf"
+          },
+          //@ts-ignore
+          group6: {
+            main: lightMode === "dark" ? "#993f64" : "#fccce1"
+          },
+          //@ts-ignore
+          group7: {
+            main: lightMode === "dark" ? "#4f4215": "#d4caa7"
+          },
+          //@ts-ignore
+          group8: {
+            main: lightMode === "dark" ? "#520438": "#c4b1be"
+          },
+          //@ts-ignore
+          group9: {
+            main: lightMode === "dark" ? "#363336": "#b3b3b3"
+          },
+        },
+        typography: {
+          fontSize: 11,
+        },
+        components: {
+          MuiSlider: {
+            styleOverrides: {
+              root: {
+                padding: "0px",
+                '@media (pointer: coarse)': {
+                  padding: "0px",
+                }
+              }
+            }
+          }
+        }
+      }
+    ))
+  }, [lightMode])
 
   const gen = Generations.get(9); 
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,11 +19,9 @@ import LinkButton from './uicomponents/LinkButton.tsx';
 
 import { Generations, Pokemon, Field} from './calc/index.ts';
 import { MoveName } from './calc/data/interface.ts';
-import { Raider, RaidBattleInfo, RaidState } from './raidcalc/interface.ts';
+import { Raider, RaidBattleInfo, RaidState, RaidTurnInfo, RaidStateProps } from './raidcalc/interface.ts';
 import StratHeader from './uicomponents/StratHeader.tsx';
 import StratFooter from './uicomponents/StratFooter.tsx';
-
-// import {BOSS_SETDEX_SV} from './data/sets/raid_bosses.ts'
 
 function App() {
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
@@ -184,68 +182,97 @@ function App() {
 
   const gen = Generations.get(9); 
 
-  const defaultRaiders = [
+  const [raidBoss, setRaidBoss] = useState(
     new Raider(0, "Raid Boss", new Pokemon(gen, "Rillaboom", {
       teraType: "Normal",
       bossMultiplier: 3500,
       nature: "Naughty",
       ability: "Grassy Surge",
       moves: ["Take Down", "Wood Hammer", "Acrobatics", "Drum Beating"]
-    }), ["Noble Roar", "Taunt", "Boomburst", "Body Slam"] as MoveName[]),
+    }), ["Noble Roar", "Taunt", "Boomburst", "Body Slam"] as MoveName[])
+  );
+  const [raider1, setRaider1] = useState(
     new Raider(1, "Raider #1", new Pokemon(gen, "Lucario", {
       nature: "Modest",
       ability: "(No Ability)",
       moves: ["Nasty Plot", "Focus Blast"],
       item: "Weakness Policy",
       evs: {hp: 252, spa: 252},
-    })),
+    }))
+  );
+  const [raider2, setRaider2] = useState(
     new Raider(2, "Raider #2", new Pokemon(gen, "Dachsbun", {
       nature: "Bold",
       ability: "Aroma Veil",
       moves: ["Helping Hand"],
       evs: {hp: 252, def: 252},
-    })),
+    }))
+  );
+  const [raider3, setRaider3] = useState(
     new Raider(3, "Raider #3", new Pokemon(gen, "Corviknight", {
       nature: "Relaxed",
       ability: "(No Ability)",
       moves: ["Defog", "Fake Tears"],
       evs: {hp: 252, def: 252},
-    })),
+    }))
+  );
+  const [raider4, setRaider4] = useState(
     new Raider(4, "Raider #4", new Pokemon(gen, "Corviknight", {
       nature: "Relaxed",
       ability: "(No Ability)",
       moves: ["Defog", "Fake Tears"],
       evs: {hp: 252, def: 252},
-    })),
-  ];
+    }))
+  );
 
-  const [info, setInfo] = useState<RaidBattleInfo>({
-    name: "",
-    startingState: new RaidState(defaultRaiders, defaultRaiders.map((r) => new Field())),
-    turns: [
-      {
-        id: 0, 
-        moveInfo: {userID: 1, targetID: 0, options: {crit: false, secondaryEffects: false, roll: "min" }, moveData: {name: "(No Move)" as MoveName}}, 
-        bossMoveInfo: {userID: 0, targetID: 1, options: {crit: true, secondaryEffects: true, roll: "max" }, moveData: {name: "(No Move)" as MoveName}},
-      }
-    ],
-    groups: [],
-  })
+  const [title, setTitle] = useState<string>("");
+  const [notes, setNotes] = useState<string>("");
+  const [credits, setCredits] = useState<string>("");
+  const [turns, setTurns] = useState<RaidTurnInfo[]>([{
+      id: 0, 
+      moveInfo: {userID: 1, targetID: 0, options: {crit: false, secondaryEffects: false, roll: "min" }, moveData: {name: "(No Move)" as MoveName}}, 
+      bossMoveInfo: {userID: 0, targetID: 1, options: {crit: true, secondaryEffects: true, roll: "max" }, moveData: {name: "(No Move)" as MoveName}},
+    }
+  ]);
+  const [groups, setGroups] = useState<number[][]>([]);
 
-  const raiders = info.startingState.raiders;
+  // const [info, setInfo] = useState<RaidBattleInfo>({
+  //   name: "",
+  //   startingState: new RaidState([raidBoss, raider1, raider2, raider3, raider4], [0,1,2,3,4].map((i) => new Field())),
+  //   turns: [
+  //     {
+  //       id: 0, 
+  //       moveInfo: {userID: 1, targetID: 0, options: {crit: false, secondaryEffects: false, roll: "min" }, moveData: {name: "(No Move)" as MoveName}}, 
+  //       bossMoveInfo: {userID: 0, targetID: 1, options: {crit: true, secondaryEffects: true, roll: "max" }, moveData: {name: "(No Move)" as MoveName}},
+  //     }
+  //   ],
+  //   groups: [],
+  // })
 
-  const setRaiders = (raiders: Raider[]) => {
-    setInfo({
-      ...info,
-      startingState: new RaidState(raiders, info.startingState.fields.map((f) => f.clone())),
-    })
+  // useEffect(() => {
+  //   const newInfo = {
+  //     name: title,
+  //     notes: notes,
+  //     credits: credits,
+  //     startingState: new RaidState([raidBoss, raider1, raider2, raider3, raider4], [0,1,2,3,4].map((i) => new Field())),
+  //     turns: turns,
+  //     groups: groups,
+  //   };
+  //   setInfo(newInfo);
+  // }, 
+  // [raider1, raider2, raider3, raider4, raidBoss, title, credits, notes, turns, groups])
+
+
+  const raidStateProps: RaidStateProps = {
+    pokemon: [raidBoss, raider1, raider2, raider3, raider4],
+    setPokemon: [setRaidBoss, setRaider1, setRaider2, setRaider3, setRaider4],
+    turns: turns,
+    setTurns: setTurns,
+    groups: groups,
+    setGroups: setGroups
   }
 
-  const setPokemon = (index: number) => (r: Raider) => {
-    const newRaiders = [...raiders];
-    newRaiders[index] = r;
-    setRaiders(newRaiders);
-  }
+  console.log(raidStateProps)
 
   return (
   <ThemeProvider theme={theme}> 
@@ -257,36 +284,41 @@ function App() {
       <Stack direction="column" justifyContent="center">
         <Grid container justifyContent="center" sx={{ my: 1 }}>
           <Grid item xs={10} sm={10} md={10} lg={8} xl={6} justifyContent="center">
-            <StratHeader info={info} setInfo={setInfo} prettyMode={prettyMode} />
+            <StratHeader title={title} setTitle={setTitle} prettyMode={prettyMode} />
           </Grid>
         </Grid>
         <Grid container component='main' justifyContent="center" sx={{ my: 1 }}>
           <Grid item>
             <Stack direction="row">
-              <PokemonSummary pokemon={raiders[1]} setPokemon={setPokemon(1)} prettyMode={prettyMode} />
-              <PokemonSummary pokemon={raiders[2]} setPokemon={setPokemon(2)} prettyMode={prettyMode}/>
+              <PokemonSummary pokemon={raider1} setPokemon={setRaider1} prettyMode={prettyMode} />
+              <PokemonSummary pokemon={raider2} setPokemon={setRaider2} prettyMode={prettyMode}/>
             </Stack>
           </Grid>
           <Grid item>
             <Stack direction="row">
-              <PokemonSummary pokemon={raiders[3]} setPokemon={setPokemon(3)} prettyMode={prettyMode} />
-              <PokemonSummary pokemon={raiders[4]} setPokemon={setPokemon(4)} prettyMode={prettyMode} />
+              <PokemonSummary pokemon={raider3} setPokemon={setRaider3} prettyMode={prettyMode} />
+              <PokemonSummary pokemon={raider4} setPokemon={setRaider4} prettyMode={prettyMode} />
             </Stack>
           </Grid>
           <Grid item>
-            <BossSummary pokemon={raiders[0]} setPokemon={setPokemon(0)} prettyMode={prettyMode} />
+            <BossSummary pokemon={raidBoss} setPokemon={setRaidBoss} prettyMode={prettyMode} />
           </Grid>
           <Grid item>
-            <RaidControls info={info} setInfo={setInfo} prettyMode={prettyMode} />
+            <RaidControls raidStateProps={raidStateProps} prettyMode={prettyMode} />
           </Grid>
-          <StratFooter info={info} setInfo={setInfo} prettyMode={prettyMode} />
+          <StratFooter notes={notes} setNotes={setNotes} credits={credits} setCredits={setCredits} prettyMode={prettyMode} />
         </Grid>
         <Grid container justifyContent="left" sx={{ my: 1 }}>
           <Grid item xs={12}>
             <Stack >
               <Stack direction="row" sx={{ p: 2 }}>
                 <Box flexGrow={1} />
-                <LinkButton info={info} setInfo={setInfo} setPrettyMode={setPrettyMode}/>
+                  <LinkButton 
+                    title={title} notes={notes} credits={credits}
+                    raidStateProps={raidStateProps}
+                    setTitle={setTitle} setNotes={setNotes} setCredits={setCredits}
+                    setPrettyMode={setPrettyMode}
+                  />
                 <Box flexGrow={1} />
               </Stack>
               <Stack sx={{ mx: 3, my: 3}}>
@@ -300,7 +332,7 @@ function App() {
                   Damage calculations are based on the <Link href="https://github.com/smogon/damage-calc/tree/master/calc">@smogon/calc</Link> package, with additional changes from <Link href="https://github.com/davbou/damage-calc">davbou's fork</Link>.
                 </Typography>
                 <Typography variant="h6" sx={{color: "text.secondary"}}>
-                    Contact
+                  Contact
                 </Typography>
                 <Typography variant="body2" gutterBottom sx={{color: "text.secondary"}}>
                   Please submit issues or feature requests at <Link href="https://github.com/theastrogoth/tera-raid-builder/">this project's Github repository</Link>.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ import LinkButton from './uicomponents/LinkButton.tsx';
 
 import { Generations, Pokemon, Field} from './calc/index.ts';
 import { MoveName } from './calc/data/interface.ts';
-import { Raider, RaidBattleInfo, RaidState, RaidTurnInfo, RaidStateProps } from './raidcalc/interface.ts';
+import { Raider, RaidBattleInfo, RaidState, RaidTurnInfo, RaidInputProps } from './raidcalc/interface.ts';
 import StratHeader from './uicomponents/StratHeader.tsx';
 import StratFooter from './uicomponents/StratFooter.tsx';
 
@@ -236,34 +236,7 @@ function App() {
   ]);
   const [groups, setGroups] = useState<number[][]>([]);
 
-  // const [info, setInfo] = useState<RaidBattleInfo>({
-  //   name: "",
-  //   startingState: new RaidState([raidBoss, raider1, raider2, raider3, raider4], [0,1,2,3,4].map((i) => new Field())),
-  //   turns: [
-  //     {
-  //       id: 0, 
-  //       moveInfo: {userID: 1, targetID: 0, options: {crit: false, secondaryEffects: false, roll: "min" }, moveData: {name: "(No Move)" as MoveName}}, 
-  //       bossMoveInfo: {userID: 0, targetID: 1, options: {crit: true, secondaryEffects: true, roll: "max" }, moveData: {name: "(No Move)" as MoveName}},
-  //     }
-  //   ],
-  //   groups: [],
-  // })
-
-  // useEffect(() => {
-  //   const newInfo = {
-  //     name: title,
-  //     notes: notes,
-  //     credits: credits,
-  //     startingState: new RaidState([raidBoss, raider1, raider2, raider3, raider4], [0,1,2,3,4].map((i) => new Field())),
-  //     turns: turns,
-  //     groups: groups,
-  //   };
-  //   setInfo(newInfo);
-  // }, 
-  // [raider1, raider2, raider3, raider4, raidBoss, title, credits, notes, turns, groups])
-
-
-  const raidStateProps: RaidStateProps = {
+  const raidInputProps: RaidInputProps = {
     pokemon: [raidBoss, raider1, raider2, raider3, raider4],
     setPokemon: [setRaidBoss, setRaider1, setRaider2, setRaider3, setRaider4],
     turns: turns,
@@ -271,8 +244,6 @@ function App() {
     groups: groups,
     setGroups: setGroups
   }
-
-  console.log(raidStateProps)
 
   return (
   <ThemeProvider theme={theme}> 
@@ -304,7 +275,7 @@ function App() {
             <BossSummary pokemon={raidBoss} setPokemon={setRaidBoss} prettyMode={prettyMode} />
           </Grid>
           <Grid item>
-            <RaidControls raidStateProps={raidStateProps} prettyMode={prettyMode} />
+            <RaidControls raidInputProps={raidInputProps} prettyMode={prettyMode} />
           </Grid>
           <StratFooter notes={notes} setNotes={setNotes} credits={credits} setCredits={setCredits} prettyMode={prettyMode} />
         </Grid>
@@ -315,7 +286,7 @@ function App() {
                 <Box flexGrow={1} />
                   <LinkButton 
                     title={title} notes={notes} credits={credits}
-                    raidStateProps={raidStateProps}
+                    raidInputProps={raidInputProps}
                     setTitle={setTitle} setNotes={setNotes} setCredits={setCredits}
                     setPrettyMode={setPrettyMode}
                   />

--- a/src/raidcalc/interface.ts
+++ b/src/raidcalc/interface.ts
@@ -215,3 +215,13 @@ export type BuildInfo = {
     turns: RaidTurnInfo[],
     groups: number[][],
 }
+
+// used for passing data to React components
+export type RaidStateProps = {
+    pokemon: Raider[],
+    setPokemon: ((r: Raider) => void)[],
+    turns: RaidTurnInfo[],
+    setTurns: (t: RaidTurnInfo[]) => void,
+    groups: number[][],
+    setGroups: (g: number[][]) => void,
+  }

--- a/src/raidcalc/interface.ts
+++ b/src/raidcalc/interface.ts
@@ -217,7 +217,7 @@ export type BuildInfo = {
 }
 
 // used for passing data to React components
-export type RaidStateProps = {
+export type RaidInputProps = {
     pokemon: Raider[],
     setPokemon: ((r: Raider) => void)[],
     turns: RaidTurnInfo[],

--- a/src/uicomponents/BossSummary.tsx
+++ b/src/uicomponents/BossSummary.tsx
@@ -132,4 +132,8 @@ function BossSummary({pokemon, setPokemon, prettyMode}: {pokemon: Raider, setPok
     );
 }
 
-export default React.memo(BossSummary);
+export default React.memo(BossSummary,
+    (prevProps, nextProps) => (
+        JSON.stringify(prevProps.pokemon) === JSON.stringify(nextProps.pokemon) && 
+        prevProps.prettyMode === nextProps.prettyMode)
+    );

--- a/src/uicomponents/BossSummary.tsx
+++ b/src/uicomponents/BossSummary.tsx
@@ -11,7 +11,7 @@ import BuildControls, { BossBuildControlsMemo } from "./BuildControls";
 import { RoleField } from "./PokemonSummary";
 
 import PokedexService, { PokemonData } from '../services/getdata';
-import { getItemSpriteURL, getPokemonArtURL, getTypeIconURL, getTeraTypeIconURL } from "../utils";
+import { getItemSpriteURL, getPokemonArtURL, getTypeIconURL, getTeraTypeIconURL, arraysEqual } from "../utils";
 import StatRadarPlot from "./StatRadarPlot";
 import { MoveSetItem, Raider } from "../raidcalc/interface";
 
@@ -135,5 +135,6 @@ function BossSummary({pokemon, setPokemon, prettyMode}: {pokemon: Raider, setPok
 export default React.memo(BossSummary,
     (prevProps, nextProps) => (
         JSON.stringify(prevProps.pokemon) === JSON.stringify(nextProps.pokemon) && 
+        arraysEqual(prevProps.pokemon.extraMoves || [], nextProps.pokemon.extraMoves || []) &&
         prevProps.prettyMode === nextProps.prettyMode)
     );

--- a/src/uicomponents/BossSummary.tsx
+++ b/src/uicomponents/BossSummary.tsx
@@ -7,7 +7,7 @@ import { Generations, Pokemon } from '../calc';
 import { AbilityName, Generation } from "../calc/data/interface";
 import { toID } from '../calc/util';
 
-import BuildControls, { BossBuildControls } from "./BuildControls";
+import BuildControls, { BossBuildControlsMemo } from "./BuildControls";
 import { RoleField } from "./PokemonSummary";
 
 import PokedexService, { PokemonData } from '../services/getdata';
@@ -121,7 +121,7 @@ function BossSummary({pokemon, setPokemon, prettyMode}: {pokemon: Raider, setPok
                     <Stack direction="row" spacing={-5} >
                         <BuildControls pokemon={pokemon} abilities={abilities} moveSet={moveSet} setPokemon={setPokemon} prettyMode={prettyMode} />
                         <Stack direction="column" spacing={0} justifyContent="center" alignItems="center" sx={{ width: "300px", minHeight:( prettyMode ? undefined : "375px") }}>
-                            <BossBuildControls moveSet={moveSet} pokemon={pokemon} setPokemon={setPokemon} prettyMode={prettyMode} />
+                            <BossBuildControlsMemo moveSet={moveSet} pokemon={pokemon} setPokemon={setPokemon} prettyMode={prettyMode} />
                             <Box flexGrow={1} />
                             <StatRadarPlot nature={nature} evs={pokemon.evs} stats={pokemon.stats} bossMultiplier={pokemon.bossMultiplier}/>
                         </Stack>

--- a/src/uicomponents/BuildControls.tsx
+++ b/src/uicomponents/BuildControls.tsx
@@ -27,7 +27,7 @@ import ImportExportArea from "./ImportExportArea";
 
 import { MoveData, MoveSetItem, Raider } from "../raidcalc/interface";
 import PokedexService from "../services/getdata";
-import { getItemSpriteURL, getMoveMethodIconURL, getPokemonSpriteURL, getTeraTypeIconURL, getTypeIconURL, getAilmentReadableName, getLearnMethodReadableName } from "../utils";
+import { getItemSpriteURL, getMoveMethodIconURL, getPokemonSpriteURL, getTeraTypeIconURL, getTypeIconURL, getAilmentReadableName, getLearnMethodReadableName, arraysEqual } from "../utils";
 
 import { BOSS_SETDEX_SV } from "../data/sets/raid_bosses";
 
@@ -823,10 +823,11 @@ function BossBuildControls({moveSet, pokemon, setPokemon, prettyMode}:
         }), []));
     }
 
-    const setBMove = (index: number) => (move: string) => {
+    const setBMove = (index: number) => (move: MoveName) => {
         const newPoke = pokemon.clone();
-        //@ts-ignore
-        newPoke.extraMoves[index] = move;
+        const newExtraMoves = [...newPoke.extraMoves!]
+        newExtraMoves[index] = move;
+        newPoke.extraMoves = newExtraMoves;
         setPokemon(newPoke);
     }
 
@@ -923,14 +924,14 @@ function BossBuildControls({moveSet, pokemon, setPokemon, prettyMode}:
 }
 export const BossBuildControlsMemo = React.memo(BossBuildControls, 
     (prevProps, nextProps) => 
-        prevProps.setPokemon === nextProps.setPokemon &&
         JSON.stringify(prevProps.pokemon) === JSON.stringify(nextProps.pokemon) && 
-        JSON.stringify(prevProps.moveSet) === JSON.stringify(nextProps.moveSet) &&
+        arraysEqual(prevProps.pokemon.extraMoves!, nextProps.pokemon.extraMoves!) &&
+        arraysEqual(prevProps.moveSet, nextProps.moveSet) &&
         prevProps.prettyMode === nextProps.prettyMode);
 
 export default React.memo(BuildControls, 
     (prevProps, nextProps) => 
         JSON.stringify(prevProps.pokemon) === JSON.stringify(nextProps.pokemon) && 
-        JSON.stringify(prevProps.abilities) === JSON.stringify(nextProps.abilities) &&
-        JSON.stringify(prevProps.moveSet) === JSON.stringify(nextProps.moveSet) &&
+        arraysEqual(prevProps.abilities, nextProps.abilities) &&
+        arraysEqual(prevProps.moveSet, nextProps.moveSet) &&
         prevProps.prettyMode === nextProps.prettyMode);

--- a/src/uicomponents/BuildControls.tsx
+++ b/src/uicomponents/BuildControls.tsx
@@ -769,7 +769,7 @@ function BuildControls({pokemon, abilities, moveSet, setPokemon, prettyMode}:
     )
 }
 
-export function BossBuildControls({moveSet, pokemon, setPokemon, prettyMode}: 
+function BossBuildControls({moveSet, pokemon, setPokemon, prettyMode}: 
     {pokemon: Raider, moveSet: MoveSetItem[], setPokemon: (r: Raider) => void, prettyMode: boolean}) 
 {
     const setHPMultiplier = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -919,8 +919,8 @@ export function BossBuildControls({moveSet, pokemon, setPokemon, prettyMode}:
                 </TableContainer>
             </Stack>
         </Box>
-
     )
 }
+export const BossBuildControlsMemo = React.memo(BossBuildControls, (prevProps, nextProps) => JSON.stringify(prevProps.pokemon) === JSON.stringify(nextProps.pokemon) && prevProps.prettyMode === nextProps.prettyMode);
 
-export default React.memo(BuildControls);
+export default React.memo(BuildControls, (prevProps, nextProps) => JSON.stringify(prevProps.pokemon) === JSON.stringify(nextProps.pokemon) && prevProps.prettyMode === nextProps.prettyMode);

--- a/src/uicomponents/BuildControls.tsx
+++ b/src/uicomponents/BuildControls.tsx
@@ -921,6 +921,15 @@ function BossBuildControls({moveSet, pokemon, setPokemon, prettyMode}:
         </Box>
     )
 }
-export const BossBuildControlsMemo = React.memo(BossBuildControls, (prevProps, nextProps) => JSON.stringify(prevProps.pokemon) === JSON.stringify(nextProps.pokemon) && prevProps.prettyMode === nextProps.prettyMode);
+export const BossBuildControlsMemo = React.memo(BossBuildControls, 
+    (prevProps, nextProps) => 
+        JSON.stringify(prevProps.pokemon) === JSON.stringify(nextProps.pokemon) && 
+        JSON.stringify(prevProps.moveSet) === JSON.stringify(nextProps.moveSet) &&
+        prevProps.prettyMode === nextProps.prettyMode);
 
-export default React.memo(BuildControls, (prevProps, nextProps) => JSON.stringify(prevProps.pokemon) === JSON.stringify(nextProps.pokemon) && prevProps.prettyMode === nextProps.prettyMode);
+export default React.memo(BuildControls, 
+    (prevProps, nextProps) => 
+        JSON.stringify(prevProps.pokemon) === JSON.stringify(nextProps.pokemon) && 
+        JSON.stringify(prevProps.abilities) === JSON.stringify(nextProps.abilities) &&
+        JSON.stringify(prevProps.moveSet) === JSON.stringify(nextProps.moveSet) &&
+        prevProps.prettyMode === nextProps.prettyMode);

--- a/src/uicomponents/BuildControls.tsx
+++ b/src/uicomponents/BuildControls.tsx
@@ -930,7 +930,6 @@ export const BossBuildControlsMemo = React.memo(BossBuildControls,
 
 export default React.memo(BuildControls, 
     (prevProps, nextProps) => 
-        prevProps.setPokemon === nextProps.setPokemon &&
         JSON.stringify(prevProps.pokemon) === JSON.stringify(nextProps.pokemon) && 
         JSON.stringify(prevProps.abilities) === JSON.stringify(nextProps.abilities) &&
         JSON.stringify(prevProps.moveSet) === JSON.stringify(nextProps.moveSet) &&

--- a/src/uicomponents/BuildControls.tsx
+++ b/src/uicomponents/BuildControls.tsx
@@ -923,12 +923,14 @@ function BossBuildControls({moveSet, pokemon, setPokemon, prettyMode}:
 }
 export const BossBuildControlsMemo = React.memo(BossBuildControls, 
     (prevProps, nextProps) => 
+        prevProps.setPokemon === nextProps.setPokemon &&
         JSON.stringify(prevProps.pokemon) === JSON.stringify(nextProps.pokemon) && 
         JSON.stringify(prevProps.moveSet) === JSON.stringify(nextProps.moveSet) &&
         prevProps.prettyMode === nextProps.prettyMode);
 
 export default React.memo(BuildControls, 
     (prevProps, nextProps) => 
+        prevProps.setPokemon === nextProps.setPokemon &&
         JSON.stringify(prevProps.pokemon) === JSON.stringify(nextProps.pokemon) && 
         JSON.stringify(prevProps.abilities) === JSON.stringify(nextProps.abilities) &&
         JSON.stringify(prevProps.moveSet) === JSON.stringify(nextProps.moveSet) &&

--- a/src/uicomponents/LinkButton.tsx
+++ b/src/uicomponents/LinkButton.tsx
@@ -6,7 +6,7 @@ import Button from "@mui/material/Button";
 
 import { Pokemon, Generations, Field } from "../calc";
 import { MoveName, TypeName } from "../calc/data/interface";
-import { RaidBattleInfo, Raider, RaidState, BuildInfo } from "../raidcalc/interface";
+import { RaidBattleInfo, Raider, RaidState, BuildInfo, RaidTurnInfo, RaidStateProps } from "../raidcalc/interface";
 import { LightBuildInfo, LightPokemon, LightTurnInfo } from "../raidcalc/hashData";
 
 import delphox from "../data/official_strats/delphox.json"
@@ -115,7 +115,10 @@ function serializeInfo(info: RaidBattleInfo): string {
     return serialize(obj);
 }
 
-function LinkButton({info, setInfo, setPrettyMode}: {info: RaidBattleInfo, setInfo: React.Dispatch<React.SetStateAction<RaidBattleInfo>>, setPrettyMode: React.Dispatch<React.SetStateAction<boolean>>}) {
+function LinkButton({title, notes, credits, raidStateProps, setTitle, setNotes, setCredits, setPrettyMode}: 
+    { title: string, notes: string, credits: string, raidStateProps: RaidStateProps, 
+      setTitle: (t: string) => void, setNotes: (t: string) => void, setCredits: (t: string) => void, 
+      setPrettyMode: (p: boolean) => void}) {
     const [hasLoadedInfo, setHasLoadedInfo] = useState(false);
     const location = useLocation();
     const hash = location.hash
@@ -134,14 +137,24 @@ function LinkButton({info, setInfo, setPrettyMode}: {info: RaidBattleInfo, setIn
                 if (res) {
                     const {name, notes, credits, pokemon, turns, groups} = res;
                     const startingState = new RaidState(pokemon, pokemon.map((r) => new Field()));
-                    setInfo({
-                        name: name,
-                        notes: notes,
-                        credits: credits,
-                        startingState: startingState,
-                        turns: turns,
-                        groups: groups,
-                    })
+                    // setInfo({
+                    //     name: name,
+                    //     notes: notes,
+                    //     credits: credits,
+                    //     startingState: startingState,
+                    //     turns: turns,
+                    //     groups: groups,
+                    // })
+                    setTitle(name);
+                    setNotes(notes);
+                    setCredits(credits);
+                    raidStateProps.setPokemon[0](pokemon[0]);
+                    raidStateProps.setPokemon[1](pokemon[1]);
+                    raidStateProps.setPokemon[2](pokemon[2]);
+                    raidStateProps.setPokemon[3](pokemon[3]);
+                    raidStateProps.setPokemon[4](pokemon[4]);
+                    raidStateProps.setTurns(turns);
+                    raidStateProps.setGroups(groups);
                     setHasLoadedInfo(true);
                 }
             }
@@ -160,7 +173,14 @@ function LinkButton({info, setInfo, setPrettyMode}: {info: RaidBattleInfo, setIn
         <Button
             variant="outlined"
             onClick={() => {
-                const link = window.location.href.split("#")[0] + "#" + serializeInfo(info);
+                const link = window.location.href.split("#")[0] + "#" + serializeInfo({
+                    name: title,
+                    notes: notes,
+                    credits: credits,
+                    startingState: new RaidState(raidStateProps.pokemon, [new Field(), new Field(), new Field(), new Field(), new Field()]),
+                    turns: raidStateProps.turns,
+                    groups: raidStateProps.groups,
+                });
                 navigator.clipboard.writeText(link)
             }}
         >

--- a/src/uicomponents/LinkButton.tsx
+++ b/src/uicomponents/LinkButton.tsx
@@ -6,7 +6,7 @@ import Button from "@mui/material/Button";
 
 import { Pokemon, Generations, Field } from "../calc";
 import { MoveName, TypeName } from "../calc/data/interface";
-import { RaidBattleInfo, Raider, RaidState, BuildInfo, RaidTurnInfo, RaidStateProps } from "../raidcalc/interface";
+import { RaidBattleInfo, Raider, RaidState, BuildInfo, RaidTurnInfo, RaidInputProps } from "../raidcalc/interface";
 import { LightBuildInfo, LightPokemon, LightTurnInfo } from "../raidcalc/hashData";
 
 import delphox from "../data/official_strats/delphox.json"
@@ -115,8 +115,8 @@ function serializeInfo(info: RaidBattleInfo): string {
     return serialize(obj);
 }
 
-function LinkButton({title, notes, credits, raidStateProps, setTitle, setNotes, setCredits, setPrettyMode}: 
-    { title: string, notes: string, credits: string, raidStateProps: RaidStateProps, 
+function LinkButton({title, notes, credits, raidInputProps, setTitle, setNotes, setCredits, setPrettyMode}: 
+    { title: string, notes: string, credits: string, raidInputProps: RaidInputProps, 
       setTitle: (t: string) => void, setNotes: (t: string) => void, setCredits: (t: string) => void, 
       setPrettyMode: (p: boolean) => void}) {
     const [hasLoadedInfo, setHasLoadedInfo] = useState(false);
@@ -148,13 +148,13 @@ function LinkButton({title, notes, credits, raidStateProps, setTitle, setNotes, 
                     setTitle(name);
                     setNotes(notes);
                     setCredits(credits);
-                    raidStateProps.setPokemon[0](pokemon[0]);
-                    raidStateProps.setPokemon[1](pokemon[1]);
-                    raidStateProps.setPokemon[2](pokemon[2]);
-                    raidStateProps.setPokemon[3](pokemon[3]);
-                    raidStateProps.setPokemon[4](pokemon[4]);
-                    raidStateProps.setTurns(turns);
-                    raidStateProps.setGroups(groups);
+                    raidInputProps.setPokemon[0](pokemon[0]);
+                    raidInputProps.setPokemon[1](pokemon[1]);
+                    raidInputProps.setPokemon[2](pokemon[2]);
+                    raidInputProps.setPokemon[3](pokemon[3]);
+                    raidInputProps.setPokemon[4](pokemon[4]);
+                    raidInputProps.setTurns(turns);
+                    raidInputProps.setGroups(groups);
                     setHasLoadedInfo(true);
                 }
             }
@@ -177,9 +177,9 @@ function LinkButton({title, notes, credits, raidStateProps, setTitle, setNotes, 
                     name: title,
                     notes: notes,
                     credits: credits,
-                    startingState: new RaidState(raidStateProps.pokemon, [new Field(), new Field(), new Field(), new Field(), new Field()]),
-                    turns: raidStateProps.turns,
-                    groups: raidStateProps.groups,
+                    startingState: new RaidState(raidInputProps.pokemon, [new Field(), new Field(), new Field(), new Field(), new Field()]),
+                    turns: raidInputProps.turns,
+                    groups: raidInputProps.groups,
                 });
                 navigator.clipboard.writeText(link)
             }}

--- a/src/uicomponents/MoveDisplay.tsx
+++ b/src/uicomponents/MoveDisplay.tsx
@@ -11,7 +11,6 @@ function MoveText({raiders, turn}: {raiders: Raider[], turn: RaidTurnInfo}) {
     const name = raiders[turn.moveInfo.userID].name;
     const user = raiders[turn.moveInfo.userID].role;
 
-    console.log("Move Display", turn.moveInfo.moveData.name, turn.moveInfo.targetID,  turn.moveInfo.moveData.target)
     let target = raiders[turn.moveInfo.targetID].role;
     if (target === user) { 
         target = ""

--- a/src/uicomponents/MoveDisplay.tsx
+++ b/src/uicomponents/MoveDisplay.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
@@ -10,6 +11,7 @@ function MoveText({raiders, turn}: {raiders: Raider[], turn: RaidTurnInfo}) {
     const name = raiders[turn.moveInfo.userID].name;
     const user = raiders[turn.moveInfo.userID].role;
 
+    console.log("Move Display", turn.moveInfo.moveData.name, turn.moveInfo.targetID,  turn.moveInfo.moveData.target)
     let target = raiders[turn.moveInfo.targetID].role;
     if (target === user) { 
         target = ""
@@ -74,8 +76,8 @@ function MoveText({raiders, turn}: {raiders: Raider[], turn: RaidTurnInfo}) {
     )
 }
 
-function MoveGroup({info, group, index}: {info: RaidBattleInfo, group: number[], index: number}) {
-    const turns = info.turns.filter((t, i) => group.includes(i));
+function MoveGroup({turns, group, raiders, index}: {turns: RaidTurnInfo[], group: number[], raiders: Raider[], index: number}) {
+    const newTurns = turns.filter((t, i) => group.includes(i));
     const color = "group" + index + ".main";
     return (
         <Paper sx={{backgroundColor: color, paddingLeft: 4, paddingRight: 4, paddingTop: 2, paddingBottom: 2}}>
@@ -84,8 +86,8 @@ function MoveGroup({info, group, index}: {info: RaidBattleInfo, group: number[],
             </Typography>
             <Stack direction="column" spacing={1}>
                 {
-                    turns.map((t, i) => (
-                        <MoveText key={i} raiders={info.startingState.raiders} turn={t} />
+                    newTurns.map((t, i) => (
+                        <MoveText key={i} raiders={raiders} turn={t} />
                     ))
                 }
             </Stack>
@@ -93,11 +95,11 @@ function MoveGroup({info, group, index}: {info: RaidBattleInfo, group: number[],
     )
 }
 
-function MoveDisplay({info}: {info: RaidBattleInfo}) { 
+function MoveDisplay({turns, raiders}: {turns: RaidTurnInfo[], raiders: Raider[]}) { 
     const displayGroups: number[][] = [];
     let currentGroupIndex = -1;
     let currentGroupID: number | undefined = -1;
-    info.turns.forEach((t, index) => {
+    turns.forEach((t, index) => {
         const g = t.group;
         if (g === undefined || g !== currentGroupID) {
             currentGroupIndex += 1;
@@ -113,7 +115,7 @@ function MoveDisplay({info}: {info: RaidBattleInfo}) {
             {
                 displayGroups.map((g, index) => (
                     <Box key={index}>
-                        <MoveGroup info={info} group={g} index={index} />
+                        <MoveGroup turns={turns} group={g} raiders={raiders} index={index} />
                         {index !== displayGroups.length - 1  && 
                             <Typography align="center" variant="h5" fontWeight="bold" sx={{ my: 0.5}}>
                                 ↓
@@ -128,4 +130,4 @@ function MoveDisplay({info}: {info: RaidBattleInfo}) {
 }
 
 
-export default MoveDisplay;
+export default React.memo(MoveDisplay);

--- a/src/uicomponents/MoveSelection.tsx
+++ b/src/uicomponents/MoveSelection.tsx
@@ -22,7 +22,7 @@ import Collapse from '@mui/material/Collapse';
 import { DragDropContext, DropResult, Droppable, Draggable } from "react-beautiful-dnd";
 
 import { MoveName } from "../calc/data/interface";
-import { MoveData, RaidMoveInfo, RaidMoveOptions, RaidStateProps, RaidTurnInfo, Raider } from "../raidcalc/interface";
+import { MoveData, RaidMoveInfo, RaidMoveOptions, RaidInputProps, RaidTurnInfo, Raider } from "../raidcalc/interface";
 import PokedexService from "../services/getdata";
 import { getPokemonSpriteURL, arraysEqual } from "../utils";
 
@@ -201,7 +201,6 @@ function MoveDropdown({index, raiders, turns, setTurns}: {index: number, raiders
     }, [moves])
 
     useEffect(() => {
-        console.log("Load data for", moveName)
         if (moveName === "(No Move)") {
             setMoveInfo({...moveInfo, moveData: {name: moveName}});
         } else if (moveName === "Attack Cheer" || moveName === "Defense Cheer") {
@@ -211,7 +210,6 @@ function MoveDropdown({index, raiders, turns, setTurns}: {index: number, raiders
         } else {
             async function fetchData() {
                 let mData = await PokedexService.getMoveByName(moveName) as MoveData;     
-                console.log(moveName, mData)
                 setMoveInfo({...moveInfo, moveData: mData});
             }
             fetchData().catch((e) => console.log(e));
@@ -322,7 +320,6 @@ function BossMoveDropdown({index, boss, turns, setTurns}: {index: number, boss: 
     const [options, setOptions] = useState(moveInfo.options || {crit: true, secondaryEffects: true, roll: "max"});
 
     const setMoveInfo = (newMoveInfo: RaidMoveInfo) => {
-        console.log("New Boss Move Info", newMoveInfo)
         let newTurns = [...turns];
         newTurns[index].bossMoveInfo = newMoveInfo;
         setTurns(newTurns);
@@ -342,7 +339,6 @@ function BossMoveDropdown({index, boss, turns, setTurns}: {index: number, boss: 
         }
       }, [moveName, turnID])
     
-    console.log("Boss Move", moveName)
     return (
         <Stack direction="row" spacing={-0.5} alignItems="center" justifyContent="right">
             <Stack direction="row" width="510px" spacing={0.5} alignItems="center" justifyContent="right">
@@ -512,6 +508,7 @@ const MoveSelectionCardMemo = React.memo(MoveSelectionCard, (prevProps, nextProp
     arraysEqual(prevProps.raiders.map((r) => r.name), nextProps.raiders.map((r) => r.name)) &&
     arraysEqual(prevProps.raiders[prevProps.turns[prevProps.index].moveInfo.userID].moves, nextProps.raiders[nextProps.turns[nextProps.index].moveInfo.userID].moves) &&
     arraysEqual(prevProps.raiders[0].moves, nextProps.raiders[0].moves) &&  
+    arraysEqual(prevProps.raiders[0].extraMoves!, nextProps.raiders[0].extraMoves!) &&
     prevProps.buttonsVisible === nextProps.buttonsVisible &&
     prevProps.turns.length === nextProps.turns.length
 ));
@@ -549,8 +546,7 @@ function prepareGroups(turns: RaidTurnInfo[], groups: number[][]) {
     return {turns: newTurns, groups: newGroups};
 }
 
-function MoveSelection({raidStateProps}: {raidStateProps: RaidStateProps}) {
-        
+function MoveSelection({raidInputProps}: {raidInputProps: RaidInputProps}) {
     const [buttonsVisible, setButtonsVisible] = useState(true);
     const [transitionIn, setTransitionIn] = useState(-1);
     const [transitionOut, setTransitionOut] = useState(-1);
@@ -562,8 +558,8 @@ function MoveSelection({raidStateProps}: {raidStateProps: RaidStateProps}) {
     const onDragEnd = (result: DropResult) => {
         setButtonsVisible(true);
         const {destination, source, draggableId, combine} = result;
-        const newTurns = [...raidStateProps.turns];
-        const newGroups = [...raidStateProps.groups];
+        const newTurns = [...raidInputProps.turns];
+        const newGroups = [...raidInputProps.groups];
         let destinationIndex = destination ? destination.index : source.index;
         if (combine) {
             const movedIndex = result.source.index;
@@ -597,8 +593,8 @@ function MoveSelection({raidStateProps}: {raidStateProps: RaidStateProps}) {
         const movedTurn = newTurns.splice(source.index, 1)[0];
         newTurns.splice(destinationIndex, 0, movedTurn);
         const preparedGroups = prepareGroups(newTurns, newGroups);
-        raidStateProps.setTurns(preparedGroups.turns);
-        raidStateProps.setGroups(preparedGroups.groups);
+        raidInputProps.setTurns(preparedGroups.turns);
+        raidInputProps.setGroups(preparedGroups.groups);
     };
     return (
         <Box>
@@ -613,17 +609,17 @@ function MoveSelection({raidStateProps}: {raidStateProps: RaidStateProps}) {
                             ref={provided.innerRef}
                             {...provided.droppableProps} 
                         >
-                            <AddButton onClick={handleAddTurn(raidStateProps.turns, raidStateProps.groups, raidStateProps.setTurns, raidStateProps.setGroups, setTransitionIn)(0)} visible={buttonsVisible}/>
+                            <AddButton onClick={handleAddTurn(raidInputProps.turns, raidInputProps.groups, raidInputProps.setTurns, raidInputProps.setGroups, setTransitionIn)(0)} visible={buttonsVisible}/>
                             {
-                                raidStateProps.turns.map((turn, index) => (
+                                raidInputProps.turns.map((turn, index) => (
                                     <MoveSelectionContainer 
                                         key={index}
-                                        raiders={raidStateProps.pokemon} 
+                                        raiders={raidInputProps.pokemon} 
                                         index={index} 
-                                        turns={raidStateProps.turns}
-                                        setTurns={raidStateProps.setTurns}
-                                        groups={raidStateProps.groups}
-                                        setGroups={raidStateProps.setGroups}
+                                        turns={raidInputProps.turns}
+                                        setTurns={raidInputProps.setTurns}
+                                        groups={raidInputProps.groups}
+                                        setGroups={raidInputProps.setGroups}
                                         buttonsVisible={buttonsVisible}
                                         transitionIn={transitionIn}
                                         setTransitionIn={setTransitionIn}

--- a/src/uicomponents/MoveSelection.tsx
+++ b/src/uicomponents/MoveSelection.tsx
@@ -380,7 +380,7 @@ function MoveSelectionContainer({raiders, index, info, setInfo, buttonsVisible, 
                     {...provided.dragHandleProps}
                 >
                     <Collapse in={collapseIn} timeout={250}>
-                        <MoveSelectionCard raiders={raiders} index={index} info={info} setInfo={setInfo} buttonsVisible={buttonsVisible} setTransitionIn={setTransitionIn} setTransitionOut={setTransitionOut} />
+                        <MoveSelectionCardMemo raiders={raiders} index={index} info={info} setInfo={setInfo} buttonsVisible={buttonsVisible} setTransitionIn={setTransitionIn} setTransitionOut={setTransitionOut} />
                     </Collapse>
                     {/* <MoveSelectionCard raiders={raiders} index={index} info={info} setInfo={setInfo} buttonsVisible={buttonsVisible} /> */}
 
@@ -474,6 +474,12 @@ function MoveSelectionCard({raiders, index, info, setInfo, buttonsVisible, setTr
         </Stack>
     )
 }
+const MoveSelectionCardMemo = React.memo(MoveSelectionCard, (prevProps, nextProps) => (
+    prevProps.index === nextProps.index && 
+    JSON.stringify(prevProps.raiders[prevProps.index]) === JSON.stringify(nextProps.raiders[nextProps.index]) &&
+    JSON.stringify(prevProps.info.turns[prevProps.index]) === JSON.stringify(nextProps.info.turns[nextProps.index]) &&    
+    prevProps.buttonsVisible === nextProps.buttonsVisible
+));
 
 function prepareGroups(info: RaidBattleInfo) {
     const newInfo = {...info};

--- a/src/uicomponents/MoveSelection.tsx
+++ b/src/uicomponents/MoveSelection.tsx
@@ -315,14 +315,17 @@ function MoveDropdown({index, raiders, turns, setTurns}: {index: number, raiders
 
 function BossMoveDropdown({index, boss, turns, setTurns}: {index: number, boss: Raider, turns: RaidTurnInfo[], setTurns: (t: RaidTurnInfo[]) => void}) {
     const moveInfo = turns[index].bossMoveInfo;
-    const moveName = moveInfo.moveData.name;
     const turnID = turns[index].id;
     const moveSet = ["(No Move)", ...boss.moves, ...(boss.extraMoves) || []];
 
-    const setMoveInfo = (moveInfo: RaidMoveInfo) => {
+    const [moveName, setMoveName] = useState<MoveName>(moveInfo.moveData.name);
+
+    const setMoveInfo = (newMoveInfo: RaidMoveInfo) => {
+        console.log("New Boss Move Info", newMoveInfo)
         let newTurns = [...turns];
-        newTurns[index].bossMoveInfo = moveInfo;
+        newTurns[index].bossMoveInfo = newMoveInfo;
         setTurns(newTurns);
+        setMoveName(newMoveInfo.moveData.name);
     }
 
     useEffect(() => {
@@ -337,6 +340,7 @@ function BossMoveDropdown({index, boss, turns, setTurns}: {index: number, boss: 
         }
       }, [moveName, turnID])
     
+    console.log("Boss Move", moveName)
     return (
         <Stack direction="row" spacing={-0.5} alignItems="center" justifyContent="right">
             <Stack direction="row" width="510px" spacing={0.5} alignItems="center" justifyContent="right">
@@ -496,10 +500,12 @@ const MoveSelectionCardMemo = React.memo(MoveSelectionCard, (prevProps, nextProp
     prevProps.turns[prevProps.index].moveInfo.userID === nextProps.turns[nextProps.index].moveInfo.userID &&
     prevProps.turns[prevProps.index].moveInfo.targetID === nextProps.turns[nextProps.index].moveInfo.targetID &&
     prevProps.turns[prevProps.index].moveInfo.moveData.name === nextProps.turns[nextProps.index].moveInfo.moveData.name &&
+    prevProps.turns[prevProps.index].bossMoveInfo.moveData.name === nextProps.turns[nextProps.index].bossMoveInfo.moveData.name &&
     arraysEqual(prevProps.raiders.map((r) => r.name), nextProps.raiders.map((r) => r.name)) &&
     arraysEqual(prevProps.raiders[prevProps.turns[prevProps.index].moveInfo.userID].moves, nextProps.raiders[nextProps.turns[nextProps.index].moveInfo.userID].moves) &&
-    arraysEqual(prevProps.raiders[0].moves, nextProps.raiders[0].moves) &&
-    prevProps.buttonsVisible === nextProps.buttonsVisible
+    arraysEqual(prevProps.raiders[0].moves, nextProps.raiders[0].moves) &&  
+    prevProps.buttonsVisible === nextProps.buttonsVisible &&
+    prevProps.turns.length === nextProps.turns.length
 ));
 
 function prepareGroups(turns: RaidTurnInfo[], groups: number[][]) {

--- a/src/uicomponents/MoveSelection.tsx
+++ b/src/uicomponents/MoveSelection.tsx
@@ -22,7 +22,7 @@ import Collapse from '@mui/material/Collapse';
 import { DragDropContext, DropResult, Droppable, Draggable } from "react-beautiful-dnd";
 
 import { MoveName } from "../calc/data/interface";
-import { MoveData, RaidMoveInfo, RaidStateProps, RaidTurnInfo, Raider } from "../raidcalc/interface";
+import { MoveData, RaidMoveInfo, RaidMoveOptions, RaidStateProps, RaidTurnInfo, Raider } from "../raidcalc/interface";
 import PokedexService from "../services/getdata";
 import { getPokemonSpriteURL, arraysEqual } from "../utils";
 
@@ -319,6 +319,7 @@ function BossMoveDropdown({index, boss, turns, setTurns}: {index: number, boss: 
     const moveSet = ["(No Move)", ...boss.moves, ...(boss.extraMoves) || []];
 
     const [moveName, setMoveName] = useState<MoveName>(moveInfo.moveData.name);
+    const [options, setOptions] = useState(moveInfo.options || {crit: true, secondaryEffects: true, roll: "max"});
 
     const setMoveInfo = (newMoveInfo: RaidMoveInfo) => {
         console.log("New Boss Move Info", newMoveInfo)
@@ -326,6 +327,7 @@ function BossMoveDropdown({index, boss, turns, setTurns}: {index: number, boss: 
         newTurns[index].bossMoveInfo = newMoveInfo;
         setTurns(newTurns);
         setMoveName(newMoveInfo.moveData.name);
+        setOptions(newMoveInfo.options as RaidMoveOptions);
     }
 
     useEffect(() => {
@@ -501,6 +503,12 @@ const MoveSelectionCardMemo = React.memo(MoveSelectionCard, (prevProps, nextProp
     prevProps.turns[prevProps.index].moveInfo.targetID === nextProps.turns[nextProps.index].moveInfo.targetID &&
     prevProps.turns[prevProps.index].moveInfo.moveData.name === nextProps.turns[nextProps.index].moveInfo.moveData.name &&
     prevProps.turns[prevProps.index].bossMoveInfo.moveData.name === nextProps.turns[nextProps.index].bossMoveInfo.moveData.name &&
+    prevProps.turns[prevProps.index].moveInfo.options?.crit === nextProps.turns[nextProps.index].moveInfo.options?.crit &&
+    prevProps.turns[prevProps.index].moveInfo.options?.secondaryEffects === nextProps.turns[nextProps.index].moveInfo.options?.secondaryEffects &&
+    prevProps.turns[prevProps.index].moveInfo.options?.roll === nextProps.turns[nextProps.index].moveInfo.options?.roll &&
+    prevProps.turns[prevProps.index].bossMoveInfo.options?.crit === nextProps.turns[nextProps.index].bossMoveInfo.options?.crit &&
+    prevProps.turns[prevProps.index].bossMoveInfo.options?.secondaryEffects === nextProps.turns[nextProps.index].bossMoveInfo.options?.secondaryEffects &&
+    prevProps.turns[prevProps.index].bossMoveInfo.options?.roll === nextProps.turns[nextProps.index].bossMoveInfo.options?.roll &&
     arraysEqual(prevProps.raiders.map((r) => r.name), nextProps.raiders.map((r) => r.name)) &&
     arraysEqual(prevProps.raiders[prevProps.turns[prevProps.index].moveInfo.userID].moves, nextProps.raiders[nextProps.turns[nextProps.index].moveInfo.userID].moves) &&
     arraysEqual(prevProps.raiders[0].moves, nextProps.raiders[0].moves) &&  

--- a/src/uicomponents/MoveSelection.tsx
+++ b/src/uicomponents/MoveSelection.tsx
@@ -380,7 +380,7 @@ function MoveSelectionContainer({raiders, index, info, setInfo, buttonsVisible, 
                     {...provided.dragHandleProps}
                 >
                     <Collapse in={collapseIn} timeout={250}>
-                        <MoveSelectionCardMemo raiders={raiders} index={index} info={info} setInfo={setInfo} buttonsVisible={buttonsVisible} setTransitionIn={setTransitionIn} setTransitionOut={setTransitionOut} />
+                        <MoveSelectionCard raiders={raiders} index={index} info={info} setInfo={setInfo} buttonsVisible={buttonsVisible} setTransitionIn={setTransitionIn} setTransitionOut={setTransitionOut} />
                     </Collapse>
                     {/* <MoveSelectionCard raiders={raiders} index={index} info={info} setInfo={setInfo} buttonsVisible={buttonsVisible} /> */}
 
@@ -474,12 +474,6 @@ function MoveSelectionCard({raiders, index, info, setInfo, buttonsVisible, setTr
         </Stack>
     )
 }
-const MoveSelectionCardMemo = React.memo(MoveSelectionCard, (prevProps, nextProps) => (
-    prevProps.index === nextProps.index && 
-    JSON.stringify(prevProps.raiders[prevProps.index]) === JSON.stringify(nextProps.raiders[nextProps.index]) &&
-    JSON.stringify(prevProps.info.turns[prevProps.index]) === JSON.stringify(nextProps.info.turns[nextProps.index]) &&    
-    prevProps.buttonsVisible === nextProps.buttonsVisible
-));
 
 function prepareGroups(info: RaidBattleInfo) {
     const newInfo = {...info};

--- a/src/uicomponents/PokemonSummary.tsx
+++ b/src/uicomponents/PokemonSummary.tsx
@@ -159,4 +159,9 @@ function PokemonSummary({pokemon, setPokemon, prettyMode}: {pokemon: Raider, set
     );
 }
 
-export default React.memo(PokemonSummary, (prevProps, nextProps) => (JSON.stringify(prevProps.pokemon) === JSON.stringify(nextProps.pokemon) && prevProps.prettyMode === nextProps.prettyMode));
+export default React.memo(PokemonSummary, 
+    (prevProps, nextProps) => (
+        prevProps.setPokemon === nextProps.setPokemon &&
+        JSON.stringify(prevProps.pokemon) === JSON.stringify(nextProps.pokemon) && 
+        prevProps.prettyMode === nextProps.prettyMode)
+    );

--- a/src/uicomponents/PokemonSummary.tsx
+++ b/src/uicomponents/PokemonSummary.tsx
@@ -159,4 +159,4 @@ function PokemonSummary({pokemon, setPokemon, prettyMode}: {pokemon: Raider, set
     );
 }
 
-export default React.memo(PokemonSummary);
+export default React.memo(PokemonSummary, (prevProps, nextProps) => (JSON.stringify(prevProps.pokemon) === JSON.stringify(nextProps.pokemon) && prevProps.prettyMode === nextProps.prettyMode));

--- a/src/uicomponents/PokemonSummary.tsx
+++ b/src/uicomponents/PokemonSummary.tsx
@@ -161,7 +161,6 @@ function PokemonSummary({pokemon, setPokemon, prettyMode}: {pokemon: Raider, set
 
 export default React.memo(PokemonSummary, 
     (prevProps, nextProps) => (
-        prevProps.setPokemon === nextProps.setPokemon &&
         JSON.stringify(prevProps.pokemon) === JSON.stringify(nextProps.pokemon) && 
         prevProps.prettyMode === nextProps.prettyMode)
     );

--- a/src/uicomponents/RaidControls.tsx
+++ b/src/uicomponents/RaidControls.tsx
@@ -7,12 +7,12 @@ import Tab from '@mui/material/Tab';
 import MoveSelection from "./MoveSelection";
 import RaidResults from "./RaidResults";
 import MoveDisplay from './MoveDisplay';
-import { RaidBattleInfo, RaidBattleResults, RaidStateProps } from "../raidcalc/interface";
+import { RaidBattleInfo, RaidBattleResults, RaidInputProps } from "../raidcalc/interface";
 
 
 const raidcalcWorker = new Worker(new URL("../workers/raidcalc.worker.ts", import.meta.url));
 
-function RaidControls({raidStateProps, prettyMode}: {raidStateProps: RaidStateProps, prettyMode: boolean}) {
+function RaidControls({raidInputProps, prettyMode}: {raidInputProps: RaidInputProps, prettyMode: boolean}) {
     const [value, setValue] = useState<number>(1);
     const [results, setResults] = useState<RaidBattleResults | null>(null);
 
@@ -29,14 +29,13 @@ function RaidControls({raidStateProps, prettyMode}: {raidStateProps: RaidStatePr
     }, [raidcalcWorker]);
 
     useEffect(() => {
-        console.log(raidStateProps)
         const info = {
-            raiders: raidStateProps.pokemon,
-            turns: raidStateProps.turns,
+            raiders: raidInputProps.pokemon,
+            turns: raidInputProps.turns,
         }
         raidcalcWorker
             .postMessage(info);
-    }, [raidStateProps.pokemon, raidStateProps.turns, prettyMode]);
+    }, [raidInputProps.pokemon, raidInputProps.turns, prettyMode]);
 
     return (
         <Box width={610} sx={{ mx: 1}}>
@@ -50,10 +49,10 @@ function RaidControls({raidStateProps, prettyMode}: {raidStateProps: RaidStatePr
                 <Stack direction="column" spacing={1} >
                     <Box maxHeight={560} sx={{ overflowY: "auto" }}>
                         {!prettyMode &&
-                            <MoveSelection raidStateProps={raidStateProps} />
+                            <MoveSelection raidInputProps={raidInputProps} />
                         }
                         {prettyMode &&
-                            <MoveDisplay turns={raidStateProps.turns} raiders={raidStateProps.pokemon} />
+                            <MoveDisplay turns={raidInputProps.turns} raiders={raidInputProps.pokemon} />
                         }
                     </Box>
                 </Stack>

--- a/src/uicomponents/RaidControls.tsx
+++ b/src/uicomponents/RaidControls.tsx
@@ -7,12 +7,12 @@ import Tab from '@mui/material/Tab';
 import MoveSelection from "./MoveSelection";
 import RaidResults from "./RaidResults";
 import MoveDisplay from './MoveDisplay';
-import { RaidBattleInfo, RaidBattleResults } from "../raidcalc/interface";
+import { RaidBattleInfo, RaidBattleResults, RaidStateProps } from "../raidcalc/interface";
 
 
 const raidcalcWorker = new Worker(new URL("../workers/raidcalc.worker.ts", import.meta.url));
 
-function RaidControls({info, setInfo, prettyMode}: {info: RaidBattleInfo, setInfo: React.Dispatch<React.SetStateAction<RaidBattleInfo>>, prettyMode: boolean}) {
+function RaidControls({raidStateProps, prettyMode}: {raidStateProps: RaidStateProps, prettyMode: boolean}) {
     const [value, setValue] = useState<number>(1);
     const [results, setResults] = useState<RaidBattleResults | null>(null);
 
@@ -29,9 +29,14 @@ function RaidControls({info, setInfo, prettyMode}: {info: RaidBattleInfo, setInf
     }, [raidcalcWorker]);
 
     useEffect(() => {
+        console.log(raidStateProps)
+        const info = {
+            raiders: raidStateProps.pokemon,
+            turns: raidStateProps.turns,
+        }
         raidcalcWorker
-            .postMessage({info});
-    }, [info, prettyMode]);
+            .postMessage(info);
+    }, [raidStateProps.pokemon, raidStateProps.turns, prettyMode]);
 
     return (
         <Box width={610} sx={{ mx: 1}}>
@@ -45,10 +50,10 @@ function RaidControls({info, setInfo, prettyMode}: {info: RaidBattleInfo, setInf
                 <Stack direction="column" spacing={1} >
                     <Box maxHeight={560} sx={{ overflowY: "auto" }}>
                         {!prettyMode &&
-                            <MoveSelection info={info} setInfo={setInfo} />
+                            <MoveSelection raidStateProps={raidStateProps} />
                         }
                         {prettyMode &&
-                            <MoveDisplay info={info} />
+                            <MoveDisplay turns={raidStateProps.turns} raiders={raidStateProps.pokemon} />
                         }
                     </Box>
                 </Stack>
@@ -60,4 +65,4 @@ function RaidControls({info, setInfo, prettyMode}: {info: RaidBattleInfo, setInf
     )
 }
 
-export default RaidControls;
+export default React.memo(RaidControls);

--- a/src/uicomponents/RaidResults.tsx
+++ b/src/uicomponents/RaidResults.tsx
@@ -1,3 +1,4 @@
+import React from "react"
 import Box from "@mui/material/Box"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
@@ -67,4 +68,4 @@ function RaidResults({results}: {results: RaidBattleResults | null}) {
     )
 }
 
-export default RaidResults;
+export default React.memo(RaidResults);

--- a/src/uicomponents/StatsControls.tsx
+++ b/src/uicomponents/StatsControls.tsx
@@ -203,4 +203,4 @@ function StatsControls({ pokemon, setPokemon}: { pokemon: Raider, setPokemon: (r
     );
 }
 
-export default React.memo(StatsControls, (prev, next) => (prev.pokemon.ivs === next.pokemon.ivs && prev.pokemon.evs === next.pokemon.evs))
+export default React.memo(StatsControls, (prev, next) => (JSON.stringify(prev.pokemon.ivs) === JSON.stringify(next.pokemon.ivs) && JSON.stringify(prev.pokemon.evs) === JSON.stringify(next.pokemon.evs)))

--- a/src/uicomponents/StratFooter.tsx
+++ b/src/uicomponents/StratFooter.tsx
@@ -1,39 +1,37 @@
 import React, { useState, useEffect } from "react";
-import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
 import Grid from '@mui/material/Grid';
-import { RaidBattleInfo } from "../raidcalc/interface";
 
-function StratFooter({info, setInfo, prettyMode}: {info: RaidBattleInfo, setInfo: (i: RaidBattleInfo) => void, prettyMode: boolean}) {
-    const [notes, setNotes] = useState(info.notes);
-    const [credits, setCredits] = useState(info.credits);
-
-    useEffect(() => {
-        if (info.notes !== notes) {
-            setNotes(info.notes);
-        }
-    }, [info.notes])
+function StratFooter({notes, setNotes, credits, setCredits, prettyMode}: {notes: string, setNotes: (n: string) => void, credits: string, setCredits: (c: string) => void, prettyMode: boolean}) {
+    const [fieldNotes, setFieldNotes] = useState(notes);
+    const [fieldCredits, setFieldCredits] = useState(credits);
 
     useEffect(() => {
-        if (info.credits !== credits) {
-            setCredits(info.credits);
+        if (notes !== fieldNotes) {
+            setFieldNotes(notes);
         }
-    }, [info.credits])
+    }, [notes])
+
+    useEffect(() => {
+        if (credits !== fieldCredits) {
+            setFieldCredits(credits);
+        }
+    }, [credits])
     
     return (
         <>
             <Grid item>
                 <Stack width="575px" sx={{ mx: 1, my: 1}} >
-                    { (!prettyMode || (info.notes && info.notes.length > 0 )) &&
+                    { (!prettyMode || (notes && notes.length > 0 )) &&
                         <Typography variant="h5" sx={{ textAlign: "left" }}>
                             Notes:
                         </Typography>
                     }
                     { prettyMode &&
                         <Typography variant="body1" style={{whiteSpace: 'pre-line'}} sx={{ textAlign: "left" }}>
-                            {info.notes}
+                            {notes}
                         </Typography>
                     }
                     { !prettyMode &&
@@ -49,23 +47,23 @@ function StratFooter({info, setInfo, prettyMode}: {info: RaidBattleInfo, setInfo
                                 alignSelf: "center",
                                 width: "100%",
                             }}
-                            value={notes}
-                            onChange={(e) => setNotes(e.target.value)}
-                            onBlur={(e) => setInfo({...info, notes: e.target.value})}
+                            value={fieldNotes}
+                            onChange={(e) => setFieldNotes(e.target.value)}
+                            onBlur={(e) => setNotes(e.target.value)}
                         />
                     }
                 </Stack>
             </Grid>
             <Grid item>
                 <Stack width="575px" sx={{ mx: 1, my: 1}} >
-                    { (!prettyMode || (info.credits && info.credits.length > 0 )) &&
+                    { (!prettyMode || (credits && credits.length > 0 )) &&
                         <Typography variant="h5" sx={{ textAlign: "left" }}>
                             Credits:
                         </Typography>
                     }
                     { prettyMode &&
                         <Typography variant="body1" style={{whiteSpace: 'pre-line'}} sx={{ textAlign: "left" }}>
-                            {info.credits}
+                            {credits}
                         </Typography>
                     }
                     { !prettyMode &&
@@ -81,9 +79,9 @@ function StratFooter({info, setInfo, prettyMode}: {info: RaidBattleInfo, setInfo
                                 alignSelf: "center",
                                 width: "100%",
                             }}
-                            value={credits}
-                            onChange={(e) => setCredits(e.target.value)}
-                            onBlur={(e) => setInfo({...info, credits: e.target.value})}
+                            value={fieldCredits}
+                            onChange={(e) => setFieldCredits(e.target.value)}
+                            onBlur={(e) => setCredits(e.target.value)}
                         />
                     }
                 </Stack>
@@ -92,4 +90,4 @@ function StratFooter({info, setInfo, prettyMode}: {info: RaidBattleInfo, setInfo
     )
 }
 
-export default StratFooter;
+export default React.memo(StratFooter);

--- a/src/uicomponents/StratHeader.tsx
+++ b/src/uicomponents/StratHeader.tsx
@@ -2,32 +2,31 @@ import React, { useState, useEffect } from "react";
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
-import { RaidBattleInfo } from "../raidcalc/interface";
 
 
-function StratHeader({info, setInfo, prettyMode}: {info: RaidBattleInfo, setInfo: (r: RaidBattleInfo) => void, prettyMode: boolean}) {
-    const [title, setTitle] = useState(info.name);
+function StratHeader({title, setTitle, prettyMode}: {title: string, setTitle: (t: string) => void, prettyMode: boolean}) {
+    const [fieldTitle, setFieldTitle] = useState(title);
 
     useEffect(() => {
-        if (info.name !== title) {
-            setTitle(info.name);
+        if (title !== fieldTitle) {
+            setFieldTitle(title);
         }
-    }, [info.name])
+    }, [title])
 
   return (
     <Box justifyContent="center">
       {prettyMode &&
         <Typography variant="h4" fontWeight="bold" sx={{ textAlign: "center", my: 1 }}>
-          {info.name}
+          {title}
         </Typography>
       }
       {!prettyMode &&
         <TextField 
           variant="standard"
           placeholder="Give your strategy a name!"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          onBlur={(e) => setInfo({...info, name: e.target.value})}
+          value={fieldTitle}
+          onChange={(e) => setFieldTitle(e.target.value)}
+          onBlur={(e) => setTitle(e.target.value)}
           inputProps={{
             style: {fontSize: 24, fontWeight: "bold", textAlign: "center"},
           }}
@@ -38,4 +37,4 @@ function StratHeader({info, setInfo, prettyMode}: {info: RaidBattleInfo, setInfo
   )
 }
 
-export default StratHeader;
+export default React.memo(StratHeader);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,3 +109,19 @@ export function getLearnMethodReadableName(learnMethod: string) {
         "Special"
     )
 }
+
+export function arraysEqual(a: any[], b: any[]) {
+    if (a === b) return true;
+    if (a == null || b == null) return false;
+    if (a.length !== b.length) return false;
+  
+    // If you don't care about the order of the elements inside
+    // the array, you should sort both arrays here.
+    // Please note that calling sort on an array will modify that array.
+    // you might want to clone your array first.
+  
+    for (var i = 0; i < a.length; ++i) {
+      if (a[i] !== b[i]) return false;
+    }
+    return true;
+  }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -121,6 +121,10 @@ export function arraysEqual(a: any[], b: any[]) {
     // you might want to clone your array first.
   
     for (var i = 0; i < a.length; ++i) {
+        //@ts-ignore
+        if (b === "Branch Poke") {
+            console.log(a[i], b[i], a[i] === b[i])
+        }
       if (a[i] !== b[i]) return false;
     }
     return true;

--- a/src/workers/raidcalc.worker.ts
+++ b/src/workers/raidcalc.worker.ts
@@ -1,5 +1,5 @@
 import { RaidBattle } from "../raidcalc/RaidBattle";
-import { RaidBattleInfo, Raider } from "../raidcalc/interface";
+import { RaidBattleInfo, RaidTurnInfo, Raider } from "../raidcalc/interface";
 import { RaidState } from "../raidcalc/interface";
 import { Field, Pokemon, Generations } from "../calc";
 
@@ -8,8 +8,9 @@ export {};
 
 const gen = Generations.get(9);
 
-self.onmessage = (event: MessageEvent<{info: RaidBattleInfo}>) => {
-    const raidersMessage = event.data.info.startingState.raiders;
+self.onmessage = (event: MessageEvent<{raiders: Raider[], turns: RaidTurnInfo[]}>) => {
+    console.log(event.data)
+    const raidersMessage = event.data.raiders;
     const raiders = raidersMessage.map((r) => new Raider(r.id, r.role, new Pokemon(gen, r.name, {
         level: r.level,
         bossMultiplier: r.bossMultiplier,
@@ -22,13 +23,13 @@ self.onmessage = (event: MessageEvent<{info: RaidBattleInfo}>) => {
         moves: r.moves,
     }), r.extraMoves))
 
-    const fieldsMessage = event.data.info.startingState.fields;
-    const fields = fieldsMessage.map((f) => new Field({...f}));
+    const fields = raiders.map((r) => new Field());
 
     const state = new RaidState(raiders, fields);
     const info: RaidBattleInfo = {
         startingState: state,
-        turns: event.data.info.turns,
+        turns: event.data.turns,
+        groups: []
     }
 
     const battle = new RaidBattle(info);


### PR DESCRIPTION
The UI was getting sluggish as we added more components. The Material UI `ThemeProvider` that wrapped the entire app was to blame, as it was causing all MUI components to rerender to due to a shallow comparison of the `theme` object, which was given a new reference every time the `App` component was rendered.

These rerenders have been largely eliminated by making use of `useState()` and `useEffect()`. Additional savings have come from better use of `React.memo` around expensive components. 

A first pass has brought response times from ~150ms to ~50ms for making a change with the UI (changing a Pokemon's nature).