### PR TITLE
Reorganize raidcalc classes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,9 +19,11 @@ import LinkButton from './uicomponents/LinkButton.tsx';
 import StratHeader from './uicomponents/StratHeader.tsx';
 import StratFooter from './uicomponents/StratFooter.tsx';
 
-import { Generations, Pokemon } from './calc/index.ts';
+import { Generations, Pokemon, Field } from './calc/index.ts';
 import { MoveName } from './calc/data/interface.ts';
-import { Raider, RaidTurnInfo, RaidInputProps } from './raidcalc/interface.ts';
+import { RaidTurnInfo } from './raidcalc/interface.ts';
+import { Raider } from './raidcalc/Raider.ts';
+import { RaidInputProps } from './raidcalc/inputs.ts';
 
 function App() {
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
@@ -183,7 +185,7 @@ function App() {
   const gen = Generations.get(9); 
 
   const [raidBoss, setRaidBoss] = useState(
-    new Raider(0, "Raid Boss", new Pokemon(gen, "Rillaboom", {
+    new Raider(0, "Raid Boss", new Field(), new Pokemon(gen, "Rillaboom", {
       teraType: "Normal",
       bossMultiplier: 3500,
       nature: "Jolly",
@@ -192,7 +194,7 @@ function App() {
     }), ["Growth", "Boomburst", "Bulk Up"] as MoveName[])
   );
   const [raider1, setRaider1] = useState(
-    new Raider(1, "Raider #1", new Pokemon(gen, "Koraidon", {
+    new Raider(1, "Koraidon", new Field(), new Pokemon(gen, "Koraidon", {
       nature: "Adamant",
       ability: "Orichalcum Pulse",
       moves: ["Swords Dance", "Collision Course"],
@@ -201,7 +203,7 @@ function App() {
     }))
   );
   const [raider2, setRaider2] = useState(
-    new Raider(2, "Raider #2", new Pokemon(gen, "Arcanine", {
+    new Raider(2, "Arcanine", new Field(), new Pokemon(gen, "Arcanine", {
       nature: "Jolly",
       ability: "Intimidate",
       moves: ["Charm", "Helping Hand"],
@@ -209,7 +211,7 @@ function App() {
     }))
   );
   const [raider3, setRaider3] = useState(
-    new Raider(3, "Raider #3", new Pokemon(gen, "Corviknight", {
+    new Raider(3, "Corviknight", new Field(), new Pokemon(gen, "Corviknight", {
       nature: "Relaxed",
       ability: "(No Ability)",
       moves: ["Screech"],
@@ -218,7 +220,7 @@ function App() {
     }))
   );
   const [raider4, setRaider4] = useState(
-    new Raider(4, "Raider #4", new Pokemon(gen, "Umbreon", {
+    new Raider(4, "Umbreon", new Field(), new Pokemon(gen, "Umbreon", {
       nature: "Relaxed",
       ability: "(No Ability)",
       moves: ["Screech"],

--- a/src/calc/mechanics/gen789.ts
+++ b/src/calc/mechanics/gen789.ts
@@ -657,7 +657,7 @@ export function calculateBasePowerSMSSSV(
     desc.moveBP = basePower;
     break;
   case 'Punishment':
-    basePower = Math.min(200, 60 + 20 * countBoosts(gen, defender.boosts));
+    basePower = Math.min(200, 60 + 20 * countBoosts(gen, defender.boosts, defender.randomBoosts));
     desc.moveBP = basePower;
     break;
   case 'Low Kick':
@@ -686,7 +686,7 @@ export function calculateBasePowerSMSSSV(
     break;
   case 'Stored Power':
   case 'Power Trip':
-    basePower = 20 + 20 * countBoosts(gen, attacker.boosts);
+    basePower = 20 + 20 * countBoosts(gen, attacker.boosts, attacker.randomBoosts);
     desc.moveBP = basePower;
     break;
   case 'Acrobatics':
@@ -881,7 +881,7 @@ export function calculateBPModsSMSSSV(
   if ((move.named('Facade') && attacker.hasStatus('brn', 'par', 'psn', 'tox')) ||
     (move.named('Brine') && defender.curHP() <= defender.maxHP() / 2) ||
     (move.named('Venoshock') && defender.hasStatus('psn', 'tox')) ||
-    (move.named('Lash Out') && (countBoosts(gen, attacker.boosts) < 0))
+    (move.named('Lash Out') && (countBoosts(gen, attacker.boosts, attacker.randomBoosts) < 0))
   ) {
     bpMods.push(8192);
     desc.moveBP = basePower * 2;

--- a/src/calc/mechanics/util.ts
+++ b/src/calc/mechanics/util.ts
@@ -473,7 +473,7 @@ export function getWeightFactor(pokemon: Pokemon) {
     : (pokemon.hasAbility('Light Metal') || pokemon.hasItem('Float Stone')) ? 0.5 : 1;
 }
 
-export function countBoosts(gen: Generation, boosts: StatsTable) {
+export function countBoosts(gen: Generation, boosts: StatsTable, randomBoosts: number = 0) {
   let sum = 0;
 
   const STATS: StatID[] = gen.num === 1
@@ -485,7 +485,7 @@ export function countBoosts(gen: Generation, boosts: StatsTable) {
     const boost = boosts[stat];
     if (boost && boost > 0) sum += boost;
   }
-  return sum;
+  return sum + randomBoosts;
 }
 
 export function getEVDescriptionText(

--- a/src/calc/pokemon.ts
+++ b/src/calc/pokemon.ts
@@ -34,6 +34,7 @@ export class Pokemon implements State.Pokemon {
   ivs: I.StatsTable;
   evs: I.StatsTable;
   boosts: I.StatsTable;
+  randomBoosts: number;
   rawStats: I.StatsTable;
   stats: I.StatsTable;
 
@@ -81,6 +82,7 @@ export class Pokemon implements State.Pokemon {
     this.ivs = Pokemon.withDefault(gen, options.ivs, 31);
     this.evs = Pokemon.withDefault(gen, options.evs, gen.num >= 3 ? 0 : 252);
     this.boosts = Pokemon.withDefault(gen, options.boosts, 0, false);
+    this.randomBoosts = options.randomBoosts || 0;
 
     // Gigantamax 'forms' inherit weight from their base species when not dynamaxed
     // TODO: clean this up with proper Gigantamax support
@@ -183,6 +185,7 @@ export class Pokemon implements State.Pokemon {
       ivs: extend(true, {}, this.ivs),
       evs: extend(true, {}, this.evs),
       boosts: extend(true, {}, this.boosts),
+      randomBoosts: this.randomBoosts,
       originalCurHP: this.originalCurHP,
       status: this.status,
       volatileStatus: this.volatileStatus,

--- a/src/calc/state.ts
+++ b/src/calc/state.ts
@@ -19,6 +19,7 @@ export namespace State {
     ivs?: Partial<I.StatsTable>;
     evs?: Partial<I.StatsTable>;
     boosts?: Partial<I.StatsTable>;
+    randomBoosts?: number;
     originalCurHP?: number;
     status?: I.StatusName | '';
     volatileStatus?: string[];

--- a/src/data/strats/chesnaught/gholdengo.json
+++ b/src/data/strats/chesnaught/gholdengo.json
@@ -3,342 +3,365 @@
   "notes": "",
   "credits": "r/PokePortal Event Raid Support Team",
   "pokemon": [
-    {
-      "id": 0,
-      "role": "7⭐event",
-      "name": "Chesnaught",
-      "ability": "Bulletproof",
-      "nature": "Impish",
-      "evs": {
-        "hp": 0,
-        "atk": 0,
-        "def": 0,
-        "spa": 0,
-        "spd": 0,
-        "spe": 0
+      {
+          "id": 0,
+          "role": "7⭐event",
+          "name": "Chesnaught",
+          "ability": "Bulletproof",
+          "nature": "Impish",
+          "evs": {
+              "hp": 0,
+              "atk": 0,
+              "def": 0,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "teraType": "Rock",
+          "moves": [
+              "Earthquake",
+              "Hammer Arm",
+              "Stone Edge",
+              "Wood Hammer"
+          ],
+          "bossMultiplier": 3500,
+          "extraMoves": [
+              "Iron Defense",
+              "Bulk Up",
+              "Curse"
+          ]
       },
-      "ivs": {
-        "hp": 31,
-        "atk": 31,
-        "def": 31,
-        "spa": 31,
-        "spd": 31,
-        "spe": 31
+      {
+          "id": 1,
+          "role": "Gholdengo",
+          "name": "Gholdengo",
+          "ability": "Good As Gold",
+          "item": "Life Orb",
+          "nature": "Modest",
+          "evs": {
+              "hp": 252,
+              "atk": 0,
+              "def": 0,
+              "spa": 252,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "moves": [
+              "Nasty Plot",
+              "Make It Rain"
+          ],
+          "bossMultiplier": 100,
+          "extraMoves": []
       },
-      "level": 100,
-      "teraType": "Rock",
-      "moves": [
-        "Earthquake",
-        "Hammer Arm",
-        "Stone Edge",
-        "Wood Hammer"
-      ],
-      "bossMultiplier": 3500,
-      "extraMoves": [
-        "Iron Defense",
-        "Bulk Up",
-        "Curse"
-      ]
-    },
-    {
-      "id": 1,
-      "role": "Gholdengo",
-      "name": "Gholdengo",
-      "ability": "Good As Gold",
-      "item": "Life Orb",
-      "nature": "Modest",
-      "evs": {
-        "hp": 252,
-        "atk": 0,
-        "def": 0,
-        "spa": 252,
-        "spd": 0,
-        "spe": 0
+      {
+          "id": 2,
+          "role": "Stonjourner",
+          "name": "Stonjourner",
+          "ability": "Power Spot",
+          "item": "Focus Sash",
+          "nature": "Hardy",
+          "evs": {
+              "hp": 0,
+              "atk": 0,
+              "def": 0,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 1,
+          "moves": [],
+          "bossMultiplier": 100,
+          "extraMoves": []
       },
-      "ivs": {
-        "hp": 31,
-        "atk": 31,
-        "def": 31,
-        "spa": 31,
-        "spd": 31,
-        "spe": 31
+      {
+          "id": 3,
+          "role": "Fake Tears",
+          "name": "Corviknight",
+          "ability": "(No Ability)",
+          "nature": "Hardy",
+          "evs": {
+              "hp": 252,
+              "atk": 0,
+              "def": 0,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "moves": [
+              "Fake Tears",
+              "(No Move)"
+          ],
+          "bossMultiplier": 100,
+          "extraMoves": []
       },
-      "level": 100,
-      "moves": [
-        "Nasty Plot",
-        "Make It Rain"
-      ],
-      "bossMultiplier": 100,
-      "extraMoves": []
-    },
-    {
-      "id": 2,
-      "role": "Stonjourner",
-      "name": "Stonjourner",
-      "ability": "Power Spot",
-      "item": "Focus Sash",
-      "nature": "Hardy",
-      "evs": {
-        "hp": 0,
-        "atk": 0,
-        "def": 0,
-        "spa": 0,
-        "spd": 0,
-        "spe": 0
-      },
-      "ivs": {
-        "hp": 31,
-        "atk": 31,
-        "def": 31,
-        "spa": 31,
-        "spd": 31,
-        "spe": 31
-      },
-      "level": 1,
-      "moves": [],
-      "bossMultiplier": 100,
-      "extraMoves": []
-    },
-    {
-      "id": 3,
-      "role": "Fake Tears",
-      "name": "Corviknight",
-      "ability": "(No Ability)",
-      "nature": "Hardy",
-      "evs": {
-        "hp": 252,
-        "atk": 0,
-        "def": 0,
-        "spa": 0,
-        "spd": 0,
-        "spe": 0
-      },
-      "ivs": {
-        "hp": 31,
-        "atk": 31,
-        "def": 31,
-        "spa": 31,
-        "spd": 31,
-        "spe": 31
-      },
-      "level": 100,
-      "moves": [
-        "Fake Tears",
-        "(No Move)"
-      ],
-      "bossMultiplier": 100,
-      "extraMoves": []
-    },
-    {
-      "id": 4,
-      "role": "Fake Tears",
-      "name": "Corviknight",
-      "ability": "(No Ability)",
-      "nature": "Hardy",
-      "evs": {
-        "hp": 252,
-        "atk": 0,
-        "def": 0,
-        "spa": 0,
-        "spd": 0,
-        "spe": 0
-      },
-      "ivs": {
-        "hp": 31,
-        "atk": 31,
-        "def": 31,
-        "spa": 31,
-        "spd": 31,
-        "spe": 31
-      },
-      "level": 100,
-      "moves": [
-        "Fake Tears",
-        "(No Move)"
-      ],
-      "bossMultiplier": 100,
-      "extraMoves": []
-    }
+      {
+          "id": 4,
+          "role": "Fake Tears",
+          "name": "Corviknight",
+          "ability": "(No Ability)",
+          "nature": "Hardy",
+          "evs": {
+              "hp": 252,
+              "atk": 0,
+              "def": 0,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "moves": [
+              "Fake Tears",
+              "(No Move)"
+          ],
+          "bossMultiplier": 100,
+          "extraMoves": []
+      }
   ],
   "turns": [
-    {
-      "id": 0,
-      "group": 0,
-      "moveInfo": {
-        "name": "Nasty Plot",
-        "userID": 1,
-        "targetID": 0,
-        "options": {
-          "crit": false,
-          "secondaryEffects": false,
-          "roll": "min"
-        }
+      {
+          "id": 7,
+          "moveInfo": {
+              "name": "(No Move)",
+              "userID": 1,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Iron Defense",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
+          }
       },
-      "bossMoveInfo": {
-        "name": "Earthquake",
-        "userID": 0,
-        "targetID": 1,
-        "options": {
-          "crit": true,
-          "secondaryEffects": true,
-          "roll": "max"
-        }
-      }
-    },
-    {
-      "id": 1,
-      "group": 0,
-      "moveInfo": {
-        "name": "Attack Cheer",
-        "userID": 2,
-        "targetID": 0,
-        "options": {
-          "crit": false,
-          "secondaryEffects": false,
-          "roll": "min"
-        }
+      {
+          "id": 0,
+          "group": 0,
+          "moveInfo": {
+              "name": "Nasty Plot",
+              "userID": 1,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Earthquake",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
+          }
       },
-      "bossMoveInfo": {
-        "name": "Earthquake",
-        "userID": 0,
-        "targetID": 1,
-        "options": {
-          "crit": true,
-          "secondaryEffects": true,
-          "roll": "max"
-        }
-      }
-    },
-    {
-      "id": 3,
-      "group": 0,
-      "moveInfo": {
-        "name": "Fake Tears",
-        "userID": 4,
-        "targetID": 0,
-        "options": {
-          "crit": false,
-          "secondaryEffects": false,
-          "roll": "min"
-        }
+      {
+          "id": 1,
+          "group": 0,
+          "moveInfo": {
+              "name": "Attack Cheer",
+              "userID": 2,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Earthquake",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
+          }
       },
-      "bossMoveInfo": {
-        "name": "Wood Hammer",
-        "userID": 0,
-        "targetID": 1,
-        "options": {
-          "crit": true,
-          "secondaryEffects": true,
-          "roll": "max"
-        }
-      }
-    },
-    {
-      "id": 2,
-      "group": 0,
-      "moveInfo": {
-        "name": "Fake Tears",
-        "userID": 3,
-        "targetID": 0,
-        "options": {
-          "crit": false,
-          "secondaryEffects": false,
-          "roll": "min"
-        }
+      {
+          "id": 3,
+          "group": 0,
+          "moveInfo": {
+              "name": "Fake Tears",
+              "userID": 4,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Wood Hammer",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
+          }
       },
-      "bossMoveInfo": {
-        "name": "Wood Hammer",
-        "userID": 0,
-        "targetID": 1,
-        "options": {
-          "crit": true,
-          "secondaryEffects": true,
-          "roll": "max"
-        }
-      }
-    },
-    {
-      "id": 6,
-      "group": 1,
-      "moveInfo": {
-        "name": "Fake Tears",
-        "userID": 4,
-        "targetID": 0,
-        "options": {
-          "crit": false,
-          "secondaryEffects": false,
-          "roll": "min"
-        }
+      {
+          "id": 2,
+          "group": 0,
+          "moveInfo": {
+              "name": "Fake Tears",
+              "userID": 3,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Wood Hammer",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
+          }
       },
-      "bossMoveInfo": {
-        "name": "(No Move)",
-        "userID": 0,
-        "targetID": 1,
-        "options": {
-          "crit": true,
-          "secondaryEffects": true,
-          "roll": "max"
-        }
-      }
-    },
-    {
-      "id": 5,
-      "group": 1,
-      "moveInfo": {
-        "name": "Fake Tears",
-        "userID": 3,
-        "targetID": 0,
-        "options": {
-          "crit": false,
-          "secondaryEffects": false,
-          "roll": "min"
-        }
+      {
+          "id": 6,
+          "group": 1,
+          "moveInfo": {
+              "name": "Fake Tears",
+              "userID": 4,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "(No Move)",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
+          }
       },
-      "bossMoveInfo": {
-        "name": "(No Move)",
-        "userID": 0,
-        "targetID": 1,
-        "options": {
-          "crit": true,
-          "secondaryEffects": true,
-          "roll": "max"
-        }
-      }
-    },
-    {
-      "id": 4,
-      "moveInfo": {
-        "name": "Make It Rain",
-        "userID": 1,
-        "targetID": 0,
-        "options": {
-          "crit": false,
-          "secondaryEffects": false,
-          "roll": "min"
-        }
+      {
+          "id": 5,
+          "group": 1,
+          "moveInfo": {
+              "name": "Fake Tears",
+              "userID": 3,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "(No Move)",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
+          }
       },
-      "bossMoveInfo": {
-        "name": "(No Move)",
-        "userID": 0,
-        "targetID": 1,
-        "options": {
-          "crit": true,
-          "secondaryEffects": true,
-          "roll": "max"
-        }
+      {
+          "id": 4,
+          "moveInfo": {
+              "name": "Make It Rain",
+              "userID": 1,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "(No Move)",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
+          }
       }
-    }
   ],
   "groups": [
-    [
-      1,
-      0,
-      2,
-      3
-    ],
-    [
-      5,
-      6
-    ]
+      [
+          1,
+          0,
+          2,
+          3
+      ],
+      [
+          5,
+          6
+      ]
   ]
 }

--- a/src/data/strats/chesnaught/main.json
+++ b/src/data/strats/chesnaught/main.json
@@ -1,368 +1,391 @@
 {
-    "name": "Flower Power: OHKO Chesnaught Strategy",
-    "notes": "",
-    "credits": "r/PokePortal Event Raid Support Team",
-    "pokemon": [
+  "name": "Flower Power: OHKO Chesnaught Strategy",
+  "notes": "",
+  "credits": "r/PokePortal Event Raid Support Team",
+  "pokemon": [
       {
-        "id": 0,
-        "role": "7⭐event",
-        "name": "Chesnaught",
-        "ability": "Bulletproof",
-        "nature": "Impish",
-        "evs": {
-          "hp": 0,
-          "atk": 0,
-          "def": 0,
-          "spa": 0,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 100,
-        "teraType": "Rock",
-        "moves": [
-          "Earthquake",
-          "Hammer Arm",
-          "Stone Edge",
-          "Wood Hammer"
-        ],
-        "bossMultiplier": 3500,
-        "extraMoves": [
-          "Iron Defense",
-          "Bulk Up",
-          "Curse"
-        ]
+          "id": 0,
+          "role": "7⭐event",
+          "name": "Chesnaught",
+          "ability": "Bulletproof",
+          "nature": "Impish",
+          "evs": {
+              "hp": 0,
+              "atk": 0,
+              "def": 0,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "teraType": "Rock",
+          "moves": [
+              "Earthquake",
+              "Hammer Arm",
+              "Stone Edge",
+              "Wood Hammer"
+          ],
+          "bossMultiplier": 3500,
+          "extraMoves": [
+              "Iron Defense",
+              "Bulk Up",
+              "Curse"
+          ]
       },
       {
-        "id": 1,
-        "role": "Lilligant",
-        "name": "Lilligant",
-        "ability": "(No Ability)",
-        "item": "Life Orb",
-        "nature": "Modest",
-        "evs": {
-          "hp": 252,
-          "atk": 0,
-          "def": 0,
-          "spa": 252,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 100,
-        "moves": [
-          "Growth",
-          "Solar Beam"
-        ],
-        "bossMultiplier": 100,
-        "extraMoves": []
+          "id": 1,
+          "role": "Lilligant",
+          "name": "Lilligant",
+          "ability": "(No Ability)",
+          "item": "Life Orb",
+          "nature": "Modest",
+          "evs": {
+              "hp": 252,
+              "atk": 0,
+              "def": 0,
+              "spa": 252,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "moves": [
+              "Growth",
+              "Solar Beam"
+          ],
+          "bossMultiplier": 100,
+          "extraMoves": []
       },
       {
-        "id": 2,
-        "role": "Sun Support",
-        "name": "Koraidon",
-        "ability": "Orichalcum Pulse",
-        "nature": "Hardy",
-        "evs": {
-          "hp": 252,
-          "atk": 0,
-          "def": 0,
-          "spa": 0,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 100,
-        "moves": [
-          "Helping Hand"
-        ],
-        "bossMultiplier": 100,
-        "extraMoves": []
+          "id": 2,
+          "role": "Sun Support",
+          "name": "Koraidon",
+          "ability": "Orichalcum Pulse",
+          "nature": "Hardy",
+          "evs": {
+              "hp": 252,
+              "atk": 0,
+              "def": 0,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "moves": [
+              "Helping Hand"
+          ],
+          "bossMultiplier": 100,
+          "extraMoves": []
       },
       {
-        "id": 3,
-        "role": "Fake Tears",
-        "name": "Corviknight",
-        "ability": "(No Ability)",
-        "nature": "Hardy",
-        "evs": {
-          "hp": 252,
-          "atk": 0,
-          "def": 0,
-          "spa": 0,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 100,
-        "moves": [
-          "Fake Tears"
-        ],
-        "bossMultiplier": 100,
-        "extraMoves": []
+          "id": 3,
+          "role": "Fake Tears",
+          "name": "Corviknight",
+          "ability": "(No Ability)",
+          "nature": "Hardy",
+          "evs": {
+              "hp": 252,
+              "atk": 0,
+              "def": 0,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "moves": [
+              "Fake Tears"
+          ],
+          "bossMultiplier": 100,
+          "extraMoves": []
       },
       {
-        "id": 4,
-        "role": "Fake Tears",
-        "name": "Corviknight",
-        "ability": "(No Ability)",
-        "nature": "Hardy",
-        "evs": {
-          "hp": 252,
-          "atk": 0,
-          "def": 0,
-          "spa": 0,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 100,
-        "moves": [
-          "Fake Tears"
-        ],
-        "bossMultiplier": 100,
-        "extraMoves": []
+          "id": 4,
+          "role": "Fake Tears",
+          "name": "Corviknight",
+          "ability": "(No Ability)",
+          "nature": "Hardy",
+          "evs": {
+              "hp": 252,
+              "atk": 0,
+              "def": 0,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "moves": [
+              "Fake Tears"
+          ],
+          "bossMultiplier": 100,
+          "extraMoves": []
       }
-    ],
-    "turns": [
+  ],
+  "turns": [
       {
-        "id": 3,
-        "group": 0,
-        "moveInfo": {
-          "name": "Growth",
-          "userID": 1,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 10,
+          "moveInfo": {
+              "name": "(No Move)",
+              "userID": 1,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Iron Defense",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Hammer Arm",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 0,
-        "group": 0,
-        "moveInfo": {
-          "name": "Attack Cheer",
-          "userID": 2,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 3,
+          "group": 0,
+          "moveInfo": {
+              "name": "Growth",
+              "userID": 1,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Hammer Arm",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Wood Hammer",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 5,
-        "group": 0,
-        "moveInfo": {
-          "name": "Fake Tears",
-          "userID": 4,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 0,
+          "group": 0,
+          "moveInfo": {
+              "name": "Attack Cheer",
+              "userID": 2,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Wood Hammer",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Wood Hammer",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 2,
-        "group": 0,
-        "moveInfo": {
-          "name": "Fake Tears",
-          "userID": 3,
-          "targetID": 1,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 5,
+          "group": 0,
+          "moveInfo": {
+              "name": "Fake Tears",
+              "userID": 4,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Wood Hammer",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Wood Hammer",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 6,
-        "group": 1,
-        "moveInfo": {
-          "name": "Helping Hand",
-          "userID": 2,
-          "targetID": 1,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 2,
+          "group": 0,
+          "moveInfo": {
+              "name": "Fake Tears",
+              "userID": 3,
+              "targetID": 1,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Wood Hammer",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Wood Hammer",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 8,
-        "group": 1,
-        "moveInfo": {
-          "name": "Fake Tears",
-          "userID": 4,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 6,
+          "group": 1,
+          "moveInfo": {
+              "name": "Helping Hand",
+              "userID": 2,
+              "targetID": 1,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Wood Hammer",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Wood Hammer",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 7,
-        "group": 1,
-        "moveInfo": {
-          "name": "Fake Tears",
-          "userID": 3,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 8,
+          "group": 1,
+          "moveInfo": {
+              "name": "Fake Tears",
+              "userID": 4,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Wood Hammer",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Wood Hammer",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 9,
-        "moveInfo": {
-          "name": "Solar Beam",
-          "userID": 1,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 7,
+          "group": 1,
+          "moveInfo": {
+              "name": "Fake Tears",
+              "userID": 3,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Wood Hammer",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "(No Move)",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
+      },
+      {
+          "id": 9,
+          "moveInfo": {
+              "name": "Solar Beam",
+              "userID": 1,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "(No Move)",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        }
       }
-    ],
-    "groups": [
+  ],
+  "groups": [
       [
-        5,
-        3,
-        2,
-        0
+          5,
+          3,
+          2,
+          0
       ],
       [
-        7,
-        8,
-        6
+          7,
+          8,
+          6
       ]
-    ]
-  }
+  ]
+}

--- a/src/data/strats/delphox/main.json
+++ b/src/data/strats/delphox/main.json
@@ -162,6 +162,29 @@
     ],
     "turns": [
         {
+            "id": 8,
+            "moveInfo": {
+                "name": "(No Move)",
+                "userID": 1,
+                "targetID": 0,
+                "options": {
+                    "crit": false,
+                    "secondaryEffects": false,
+                    "roll": "min"
+                }
+            },
+            "bossMoveInfo": {
+                "name": "Dazzling Gleam",
+                "userID": 0,
+                "targetID": 1,
+                "options": {
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "roll": "max"
+                }
+            }
+        },
+        {
             "id": 0,
             "group": 0,
             "moveInfo": {

--- a/src/data/strats/delphox/rain&sustain.json
+++ b/src/data/strats/delphox/rain&sustain.json
@@ -163,6 +163,29 @@
     ],
     "turns": [
         {
+            "id": 8,
+            "moveInfo": {
+                "name": "(No Move)",
+                "userID": 1,
+                "targetID": 0,
+                "options": {
+                    "crit": false,
+                    "secondaryEffects": false,
+                    "roll": "min"
+                }
+            },
+            "bossMoveInfo": {
+                "name": "Dazzling Gleam",
+                "userID": 0,
+                "targetID": 1,
+                "options": {
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "roll": "max"
+                }
+            }
+        },
+        {
             "id": 0,
             "group": 0,
             "moveInfo": {

--- a/src/data/strats/inteleon/main.json
+++ b/src/data/strats/inteleon/main.json
@@ -1,258 +1,311 @@
 {
-    "name": "Official OHKO Inteleon Strategy",
-    "notes": "",
-    "credits": "r/PokemonScarletViolet Event Raid Support Team",
-    "pokemon": [
+  "name": "Official OHKO Inteleon Strategy",
+  "notes": "",
+  "credits": "r/PokemonScarletViolet Event Raid Support Team",
+  "pokemon": [
       {
-        "id": 0,
-        "role": "7⭐event",
-        "name": "Inteleon",
-        "ability": "Sniper",
-        "nature": "Quiet",
-        "evs": {
-          "hp": 0,
-          "atk": 0,
-          "def": 0,
-          "spa": 0,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 100,
-        "teraType": "Ice",
-        "moves": [
-          "Blizzard",
-          "Snipe Shot",
-          "Dark Pulse",
-          "Tearful Look"
-        ],
-        "bossMultiplier": 3000,
-        "extraMoves": [
-          "Mist",
-          "Snowscape"
-        ]
+          "id": 0,
+          "role": "Inteleon",
+          "name": "Inteleon",
+          "ability": "Sniper",
+          "nature": "Quiet",
+          "evs": {
+              "hp": 0,
+              "atk": 0,
+              "def": 0,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "teraType": "Ice",
+          "moves": [
+              "Blizzard",
+              "Snipe Shot",
+              "Dark Pulse",
+              "Tearful Look"
+          ],
+          "bossMultiplier": 3000,
+          "extraMoves": [
+              "Mist",
+              "Snowscape"
+          ]
       },
       {
-        "id": 1,
-        "role": "Tauros-Blaze",
-        "name": "Tauros-Paldea-Blaze-Breed",
-        "ability": "Anger Point",
-        "item": "Choice Band",
-        "nature": "Jolly",
-        "evs": {
-          "hp": 0,
-          "atk": 252,
-          "def": 0,
-          "spa": 0,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 100,
-        "moves": [
-          "Flare Blitz",
-          "(No Move)",
-          "(No Move)"
-        ],
-        "bossMultiplier": 100,
-        "extraMoves": []
+          "id": 1,
+          "role": "Tauros-Blaze",
+          "name": "Tauros-Paldea-Blaze-Breed",
+          "ability": "Anger Point",
+          "item": "Choice Band",
+          "nature": "Jolly",
+          "evs": {
+              "hp": 0,
+              "atk": 252,
+              "def": 0,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "moves": [
+              "Flare Blitz",
+              "(No Move)",
+              "(No Move)"
+          ],
+          "bossMultiplier": 100,
+          "extraMoves": []
       },
       {
-        "id": 2,
-        "role": "Sunny Day",
-        "name": "Klefki",
-        "ability": "Prankster",
-        "item": "Focus Sash",
-        "nature": "Hardy",
-        "evs": {
-          "hp": 0,
-          "atk": 0,
-          "def": 0,
-          "spa": 0,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 1,
-        "moves": [
-          "Sunny Day"
-        ],
-        "bossMultiplier": 100,
-        "extraMoves": []
+          "id": 2,
+          "role": "Sunny Day",
+          "name": "Klefki",
+          "ability": "Prankster",
+          "item": "Focus Sash",
+          "nature": "Hardy",
+          "evs": {
+              "hp": 0,
+              "atk": 0,
+              "def": 0,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 1,
+          "moves": [
+              "Sunny Day"
+          ],
+          "bossMultiplier": 100,
+          "extraMoves": []
       },
       {
-        "id": 3,
-        "role": "Critter",
-        "name": "Meowscarada",
-        "ability": "(No Ability)",
-        "item": "Focus Sash",
-        "nature": "Hardy",
-        "evs": {
-          "hp": 0,
-          "atk": 0,
-          "def": 0,
-          "spa": 0,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 36,
-        "moves": [
-          "Flower Trick"
-        ],
-        "bossMultiplier": 100,
-        "extraMoves": []
+          "id": 3,
+          "role": "Critter",
+          "name": "Meowscarada",
+          "ability": "(No Ability)",
+          "item": "Focus Sash",
+          "nature": "Hardy",
+          "evs": {
+              "hp": 0,
+              "atk": 0,
+              "def": 0,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 36,
+          "moves": [
+              "Flower Trick"
+          ],
+          "bossMultiplier": 100,
+          "extraMoves": []
       },
       {
-        "id": 4,
-        "role": "Power Spot",
-        "name": "Stonjourner",
-        "ability": "Power Spot",
-        "item": "Focus Sash",
-        "nature": "Hardy",
-        "evs": {
-          "hp": 0,
-          "atk": 0,
-          "def": 0,
-          "spa": 0,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 1,
-        "moves": [],
-        "bossMultiplier": 100,
-        "extraMoves": []
+          "id": 4,
+          "role": "Power Spot",
+          "name": "Stonjourner",
+          "ability": "Power Spot",
+          "item": "Focus Sash",
+          "nature": "Hardy",
+          "evs": {
+              "hp": 0,
+              "atk": 0,
+              "def": 0,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 1,
+          "moves": [],
+          "bossMultiplier": 100,
+          "extraMoves": []
       }
-    ],
-    "turns": [
+  ],
+  "turns": [
       {
-        "id": 0,
-        "moveInfo": {
-          "name": "Sunny Day",
-          "userID": 2,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 7,
+          "group": 0,
+          "moveInfo": {
+              "name": "(No Move)",
+              "userID": 1,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Mist",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Blizzard",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 2,
-        "moveInfo": {
-          "name": "Flower Trick",
-          "userID": 3,
-          "targetID": 1,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 6,
+          "group": 0,
+          "moveInfo": {
+              "name": "(No Move)",
+              "userID": 1,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Snowscape",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Snipe Shot",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 5,
-        "moveInfo": {
-          "name": "Attack Cheer",
-          "userID": 4,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 0,
+          "moveInfo": {
+              "name": "Sunny Day",
+              "userID": 2,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Blizzard",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Snipe Shot",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 3,
-        "moveInfo": {
-          "name": "Flare Blitz",
-          "userID": 1,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 2,
+          "moveInfo": {
+              "name": "Flower Trick",
+              "userID": 3,
+              "targetID": 1,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Snipe Shot",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "(No Move)",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
+      },
+      {
+          "id": 5,
+          "moveInfo": {
+              "name": "Attack Cheer",
+              "userID": 4,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Snipe Shot",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        }
+      },
+      {
+          "id": 3,
+          "moveInfo": {
+              "name": "Flare Blitz",
+              "userID": 1,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "(No Move)",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
+          }
       }
-    ],
-    "groups": []
-  }
+  ],
+  "groups": [
+      [
+          7,
+          6
+      ]
+  ]
+}

--- a/src/data/strats/rillaboom/tickle_squad.json
+++ b/src/data/strats/rillaboom/tickle_squad.json
@@ -162,6 +162,29 @@
     ],
     "turns": [
         {
+            "id": 9,
+            "moveInfo": {
+                "name": "(No Move)",
+                "userID": 1,
+                "targetID": 0,
+                "options": {
+                    "crit": false,
+                    "secondaryEffects": false,
+                    "roll": "min"
+                }
+            },
+            "bossMoveInfo": {
+                "name": "Growth",
+                "userID": 0,
+                "targetID": 1,
+                "options": {
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "roll": "max"
+                }
+            }
+        },
+        {
             "id": 8,
             "moveInfo": {
                 "name": "Defense Cheer",

--- a/src/data/strats/samurott/main.json
+++ b/src/data/strats/samurott/main.json
@@ -1,380 +1,403 @@
 {
-    "name": "Official OHKO Samurott Strategy",
-    "notes": "",
-    "credits": "r/PokemonScarletViolet Event Raid Support Team",
-    "pokemon": [
+  "name": "Official OHKO Samurott Strategy",
+  "notes": "",
+  "credits": "r/PokemonScarletViolet Event Raid Support Team",
+  "pokemon": [
       {
-        "id": 0,
-        "role": "7⭐event",
-        "name": "Samurott",
-        "ability": "Shell Armor",
-        "nature": "Lonely",
-        "evs": {
-          "hp": 0,
-          "atk": 0,
-          "def": 0,
-          "spa": 0,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 100,
-        "teraType": "Bug",
-        "moves": [
-          "Aqua Cutter",
-          "Megahorn",
-          "Night Slash",
-          "Drill Run"
-        ],
-        "bossMultiplier": 3500,
-        "extraMoves": [
-          "Focus Energy",
-          "Swords Dance",
-          "Bulldoze"
-        ]
+          "id": 0,
+          "role": "7⭐event",
+          "name": "Samurott",
+          "ability": "Shell Armor",
+          "nature": "Lonely",
+          "evs": {
+              "hp": 0,
+              "atk": 0,
+              "def": 0,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "teraType": "Bug",
+          "moves": [
+              "Aqua Cutter",
+              "Megahorn",
+              "Night Slash",
+              "Drill Run"
+          ],
+          "bossMultiplier": 3500,
+          "extraMoves": [
+              "Focus Energy",
+              "Swords Dance",
+              "Bulldoze"
+          ]
       },
       {
-        "id": 1,
-        "role": "Koraidon",
-        "name": "Koraidon",
-        "ability": "Orichalcum Pulse",
-        "item": "Life Orb",
-        "nature": "Adamant",
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "def": 0,
-          "spa": 0,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 100,
-        "moves": [
-          "Swords Dance",
-          "Flare Blitz",
-          "Flame Charge",
-          "Drain Punch"
-        ],
-        "bossMultiplier": 100,
-        "extraMoves": []
+          "id": 1,
+          "role": "Koraidon",
+          "name": "Koraidon",
+          "ability": "Orichalcum Pulse",
+          "item": "Life Orb",
+          "nature": "Adamant",
+          "evs": {
+              "hp": 252,
+              "atk": 252,
+              "def": 0,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "moves": [
+              "Swords Dance",
+              "Flare Blitz",
+              "Flame Charge",
+              "Drain Punch"
+          ],
+          "bossMultiplier": 100,
+          "extraMoves": []
       },
       {
-        "id": 2,
-        "role": "Screecher",
-        "name": "Corviknight",
-        "ability": "(No Ability)",
-        "item": "Zoom Lens",
-        "nature": "Relaxed",
-        "evs": {
-          "hp": 252,
-          "atk": 0,
-          "def": 252,
-          "spa": 0,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 100,
-        "moves": [
-          "Screech",
-          "Taunt",
-          "Drill Peck"
-        ],
-        "bossMultiplier": 100,
-        "extraMoves": []
+          "id": 2,
+          "role": "Screecher",
+          "name": "Corviknight",
+          "ability": "(No Ability)",
+          "item": "Zoom Lens",
+          "nature": "Relaxed",
+          "evs": {
+              "hp": 252,
+              "atk": 0,
+              "def": 252,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "moves": [
+              "Screech",
+              "Taunt",
+              "Drill Peck"
+          ],
+          "bossMultiplier": 100,
+          "extraMoves": []
       },
       {
-        "id": 3,
-        "role": "Screecher",
-        "name": "Dudunsparce",
-        "ability": "(No Ability)",
-        "item": "Zoom Lens",
-        "nature": "Relaxed",
-        "evs": {
-          "hp": 252,
-          "atk": 0,
-          "def": 252,
-          "spa": 0,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 100,
-        "moves": [
-          "Screech",
-          "Helping Hand",
-          "Sunny Day",
-          "Chilling Water"
-        ],
-        "bossMultiplier": 100,
-        "extraMoves": []
+          "id": 3,
+          "role": "Screecher",
+          "name": "Dudunsparce",
+          "ability": "(No Ability)",
+          "item": "Zoom Lens",
+          "nature": "Relaxed",
+          "evs": {
+              "hp": 252,
+              "atk": 0,
+              "def": 252,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "moves": [
+              "Screech",
+              "Helping Hand",
+              "Sunny Day",
+              "Chilling Water"
+          ],
+          "bossMultiplier": 100,
+          "extraMoves": []
       },
       {
-        "id": 4,
-        "role": "Screecher",
-        "name": "Perrserker",
-        "ability": "Battle Armor",
-        "item": "Zoom Lens",
-        "nature": "Relaxed",
-        "evs": {
-          "hp": 252,
-          "atk": 0,
-          "def": 252,
-          "spa": 0,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 100,
-        "moves": [
-          "Screech",
-          "Helping Hand",
-          "Chilling Water"
-        ],
-        "bossMultiplier": 100,
-        "extraMoves": []
+          "id": 4,
+          "role": "Screecher",
+          "name": "Perrserker",
+          "ability": "Battle Armor",
+          "item": "Zoom Lens",
+          "nature": "Relaxed",
+          "evs": {
+              "hp": 252,
+              "atk": 0,
+              "def": 252,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "moves": [
+              "Screech",
+              "Helping Hand",
+              "Chilling Water"
+          ],
+          "bossMultiplier": 100,
+          "extraMoves": []
       }
-    ],
-    "turns": [
+  ],
+  "turns": [
       {
-        "id": 1,
-        "group": 0,
-        "moveInfo": {
-          "name": "Swords Dance",
-          "userID": 1,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 8,
+          "moveInfo": {
+              "name": "(No Move)",
+              "userID": 1,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Focus Energy",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Megahorn",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 0,
-        "group": 0,
-        "moveInfo": {
-          "name": "Screech",
-          "userID": 2,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 1,
+          "group": 0,
+          "moveInfo": {
+              "name": "Swords Dance",
+              "userID": 1,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Megahorn",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Aqua Cutter",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 2,
-        "group": 0,
-        "moveInfo": {
-          "name": "Screech",
-          "userID": 3,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 0,
+          "group": 0,
+          "moveInfo": {
+              "name": "Screech",
+              "userID": 2,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Aqua Cutter",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Megahorn",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 3,
-        "group": 0,
-        "moveInfo": {
-          "name": "Screech",
-          "userID": 4,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 2,
+          "group": 0,
+          "moveInfo": {
+              "name": "Screech",
+              "userID": 3,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Megahorn",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Drill Run",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 5,
-        "group": 1,
-        "moveInfo": {
-          "name": "Attack Cheer",
-          "userID": 2,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 3,
+          "group": 0,
+          "moveInfo": {
+              "name": "Screech",
+              "userID": 4,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Drill Run",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Aqua Cutter",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 6,
-        "group": 1,
-        "moveInfo": {
-          "name": "Attack Cheer",
-          "userID": 3,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 5,
+          "group": 1,
+          "moveInfo": {
+              "name": "Attack Cheer",
+              "userID": 2,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Aqua Cutter",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Megahorn",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 7,
-        "group": 1,
-        "moveInfo": {
-          "name": "Attack Cheer",
-          "userID": 4,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 6,
+          "group": 1,
+          "moveInfo": {
+              "name": "Attack Cheer",
+              "userID": 3,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Megahorn",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Drill Run",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 4,
-        "moveInfo": {
-          "name": "Flare Blitz",
-          "userID": 1,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 7,
+          "group": 1,
+          "moveInfo": {
+              "name": "Attack Cheer",
+              "userID": 4,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Drill Run",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "(No Move)",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
+      },
+      {
+          "id": 4,
+          "moveInfo": {
+              "name": "Flare Blitz",
+              "userID": 1,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "(No Move)",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        }
       }
-    ],
-    "groups": [
+  ],
+  "groups": [
       [
-        0,
-        1,
-        2,
-        3
+          0,
+          1,
+          2,
+          3
       ],
       [
-        6,
-        5,
-        7
+          6,
+          5,
+          7
       ]
-    ]
-  }
+  ]
+}

--- a/src/data/strats/samurott/tauros.json
+++ b/src/data/strats/samurott/tauros.json
@@ -1,379 +1,402 @@
 {
-    "name": "Alternate OHKO Samurott Strategy",
-    "notes": "",
-    "credits": "r/PokemonScarletViolet Event Raid Support Team",
-    "pokemon": [
+  "name": "Alternate OHKO Samurott Strategy",
+  "notes": "",
+  "credits": "r/PokemonScarletViolet Event Raid Support Team",
+  "pokemon": [
       {
-        "id": 0,
-        "role": "7⭐event",
-        "name": "Samurott",
-        "ability": "Shell Armor",
-        "nature": "Lonely",
-        "evs": {
-          "hp": 0,
-          "atk": 0,
-          "def": 0,
-          "spa": 0,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 100,
-        "teraType": "Bug",
-        "moves": [
-          "Aqua Cutter",
-          "Megahorn",
-          "Night Slash",
-          "Drill Run"
-        ],
-        "bossMultiplier": 3500,
-        "extraMoves": [
-          "Focus Energy",
-          "Swords Dance",
-          "Bulldoze"
-        ]
+          "id": 0,
+          "role": "7⭐event",
+          "name": "Samurott",
+          "ability": "Shell Armor",
+          "nature": "Lonely",
+          "evs": {
+              "hp": 0,
+              "atk": 0,
+              "def": 0,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "teraType": "Bug",
+          "moves": [
+              "Aqua Cutter",
+              "Megahorn",
+              "Night Slash",
+              "Drill Run"
+          ],
+          "bossMultiplier": 3500,
+          "extraMoves": [
+              "Focus Energy",
+              "Swords Dance",
+              "Bulldoze"
+          ]
       },
       {
-        "id": 1,
-        "role": "Tauros-Blaze",
-        "name": "Tauros-Paldea-Blaze-Breed",
-        "ability": "Anger Point",
-        "item": "Life Orb",
-        "nature": "Adamant",
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "def": 0,
-          "spa": 0,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 100,
-        "moves": [
-          "Sunny Day",
-          "Flare Blitz",
-          "Raging Bull"
-        ],
-        "bossMultiplier": 100,
-        "extraMoves": []
+          "id": 1,
+          "role": "Tauros-Blaze",
+          "name": "Tauros-Paldea-Blaze-Breed",
+          "ability": "Anger Point",
+          "item": "Life Orb",
+          "nature": "Adamant",
+          "evs": {
+              "hp": 252,
+              "atk": 252,
+              "def": 0,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "moves": [
+              "Sunny Day",
+              "Flare Blitz",
+              "Raging Bull"
+          ],
+          "bossMultiplier": 100,
+          "extraMoves": []
       },
       {
-        "id": 2,
-        "role": "Screecher",
-        "name": "Corviknight",
-        "ability": "(No Ability)",
-        "item": "Zoom Lens",
-        "nature": "Relaxed",
-        "evs": {
-          "hp": 252,
-          "atk": 0,
-          "def": 252,
-          "spa": 0,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 100,
-        "moves": [
-          "Screech",
-          "Taunt",
-          "Drill Peck"
-        ],
-        "bossMultiplier": 100,
-        "extraMoves": []
+          "id": 2,
+          "role": "Screecher",
+          "name": "Corviknight",
+          "ability": "(No Ability)",
+          "item": "Zoom Lens",
+          "nature": "Relaxed",
+          "evs": {
+              "hp": 252,
+              "atk": 0,
+              "def": 252,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "moves": [
+              "Screech",
+              "Taunt",
+              "Drill Peck"
+          ],
+          "bossMultiplier": 100,
+          "extraMoves": []
       },
       {
-        "id": 3,
-        "role": "Screecher",
-        "name": "Dudunsparce",
-        "ability": "(No Ability)",
-        "item": "Zoom Lens",
-        "nature": "Relaxed",
-        "evs": {
-          "hp": 252,
-          "atk": 0,
-          "def": 252,
-          "spa": 0,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 100,
-        "moves": [
-          "Screech",
-          "Helping Hand",
-          "Sunny Day",
-          "Chilling Water"
-        ],
-        "bossMultiplier": 100,
-        "extraMoves": []
+          "id": 3,
+          "role": "Screecher",
+          "name": "Dudunsparce",
+          "ability": "(No Ability)",
+          "item": "Zoom Lens",
+          "nature": "Relaxed",
+          "evs": {
+              "hp": 252,
+              "atk": 0,
+              "def": 252,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "moves": [
+              "Screech",
+              "Helping Hand",
+              "Sunny Day",
+              "Chilling Water"
+          ],
+          "bossMultiplier": 100,
+          "extraMoves": []
       },
       {
-        "id": 4,
-        "role": "Screecher",
-        "name": "Perrserker",
-        "ability": "Battle Armor",
-        "item": "Zoom Lens",
-        "nature": "Relaxed",
-        "evs": {
-          "hp": 252,
-          "atk": 0,
-          "def": 252,
-          "spa": 0,
-          "spd": 0,
-          "spe": 0
-        },
-        "ivs": {
-          "hp": 31,
-          "atk": 31,
-          "def": 31,
-          "spa": 31,
-          "spd": 31,
-          "spe": 31
-        },
-        "level": 100,
-        "moves": [
-          "Screech",
-          "Helping Hand",
-          "Chilling Water"
-        ],
-        "bossMultiplier": 100,
-        "extraMoves": []
+          "id": 4,
+          "role": "Screecher",
+          "name": "Perrserker",
+          "ability": "Battle Armor",
+          "item": "Zoom Lens",
+          "nature": "Relaxed",
+          "evs": {
+              "hp": 252,
+              "atk": 0,
+              "def": 252,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+          },
+          "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+          },
+          "level": 100,
+          "moves": [
+              "Screech",
+              "Helping Hand",
+              "Chilling Water"
+          ],
+          "bossMultiplier": 100,
+          "extraMoves": []
       }
-    ],
-    "turns": [
+  ],
+  "turns": [
       {
-        "id": 1,
-        "group": 0,
-        "moveInfo": {
-          "name": "Sunny Day",
-          "userID": 1,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 8,
+          "moveInfo": {
+              "name": "(No Move)",
+              "userID": 1,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Focus Energy",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Aqua Cutter",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 0,
-        "group": 0,
-        "moveInfo": {
-          "name": "Screech",
-          "userID": 2,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 1,
+          "group": 0,
+          "moveInfo": {
+              "name": "Sunny Day",
+              "userID": 1,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Aqua Cutter",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Aqua Cutter",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 2,
-        "group": 0,
-        "moveInfo": {
-          "name": "Screech",
-          "userID": 3,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 0,
+          "group": 0,
+          "moveInfo": {
+              "name": "Screech",
+              "userID": 2,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Aqua Cutter",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Megahorn",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 3,
-        "group": 0,
-        "moveInfo": {
-          "name": "Screech",
-          "userID": 4,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 2,
+          "group": 0,
+          "moveInfo": {
+              "name": "Screech",
+              "userID": 3,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Megahorn",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Drill Run",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 5,
-        "group": 1,
-        "moveInfo": {
-          "name": "Attack Cheer",
-          "userID": 2,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 3,
+          "group": 0,
+          "moveInfo": {
+              "name": "Screech",
+              "userID": 4,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Drill Run",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Aqua Cutter",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 6,
-        "group": 1,
-        "moveInfo": {
-          "name": "Attack Cheer",
-          "userID": 3,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 5,
+          "group": 1,
+          "moveInfo": {
+              "name": "Attack Cheer",
+              "userID": 2,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Aqua Cutter",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Megahorn",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 7,
-        "group": 1,
-        "moveInfo": {
-          "name": "Attack Cheer",
-          "userID": 4,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 6,
+          "group": 1,
+          "moveInfo": {
+              "name": "Attack Cheer",
+              "userID": 3,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Megahorn",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "Drill Run",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
-          }
-        }
       },
       {
-        "id": 4,
-        "moveInfo": {
-          "name": "Flare Blitz",
-          "userID": 1,
-          "targetID": 0,
-          "options": {
-            "crit": false,
-            "secondaryEffects": false,
-            "roll": "min"
+          "id": 7,
+          "group": 1,
+          "moveInfo": {
+              "name": "Attack Cheer",
+              "userID": 4,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "Drill Run",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        },
-        "bossMoveInfo": {
-          "name": "(No Move)",
-          "userID": 0,
-          "targetID": 1,
-          "options": {
-            "crit": true,
-            "secondaryEffects": true,
-            "roll": "max"
+      },
+      {
+          "id": 4,
+          "moveInfo": {
+              "name": "Flare Blitz",
+              "userID": 1,
+              "targetID": 0,
+              "options": {
+                  "crit": false,
+                  "secondaryEffects": false,
+                  "roll": "min"
+              }
+          },
+          "bossMoveInfo": {
+              "name": "(No Move)",
+              "userID": 0,
+              "targetID": 1,
+              "options": {
+                  "crit": true,
+                  "secondaryEffects": true,
+                  "roll": "max"
+              }
           }
-        }
       }
-    ],
-    "groups": [
+  ],
+  "groups": [
       [
-        0,
-        1,
-        2,
-        3
+          0,
+          1,
+          2,
+          3
       ],
       [
-        6,
-        5,
-        7
+          6,
+          5,
+          7
       ]
-    ]
-  }
+  ]
+}

--- a/src/raidcalc/RaidBattle.ts
+++ b/src/raidcalc/RaidBattle.ts
@@ -1,11 +1,29 @@
 import { Move, Generations } from "../calc";
 import { StatIDExceptHP, MoveName, AbilityName, ItemName } from "../calc/data/interface";
 import { getQPBoostedStat } from "../calc/mechanics/util";
-import { RaidState, RaidBattleInfo, RaidTurnInfo, RaidTurnResult, RaidBattleResults } from "./interface";
-import { getBoostCoefficient, RaidMove, safeStatStage } from "./RaidMove";
-import { RaidTurn } from "./RaidTurn";
+import { RaidTurnInfo } from "./interface";
+import { RaidState } from "./RaidState";
+import { RaidMove } from "./RaidMove";
+import { getBoostCoefficient, safeStatStage } from "./util";
+import { RaidTurn, RaidTurnResult } from "./RaidTurn";
 
 const gen = Generations.get(9);
+
+export type RaidBattleInfo = {
+    name?: string;
+    notes?: string;
+    credits?: string;
+    startingState: RaidState;
+    turns: RaidTurnInfo[];
+    groups: number[][];
+}
+
+export type RaidBattleResults = {
+    endState: RaidState;
+    turnResults: RaidTurnResult[]; 
+    turnZeroFlags: string[][];
+    turnZeroOrder: number[];
+}
 
 export class RaidBattle {
     startingState: RaidState;

--- a/src/raidcalc/RaidBattle.ts
+++ b/src/raidcalc/RaidBattle.ts
@@ -1,6 +1,5 @@
 import { Move, Generations } from "../calc";
-import { StatIDExceptHP, MoveName, AbilityName, ItemName } from "../calc/data/interface";
-import { getQPBoostedStat } from "../calc/mechanics/util";
+import { MoveName, ItemName } from "../calc/data/interface";
 import { RaidTurnInfo } from "./interface";
 import { RaidState } from "./RaidState";
 import { RaidMove } from "./RaidMove";
@@ -75,12 +74,7 @@ export class RaidBattle {
     private calculateTurnZero(){
         this._turnZeroFlags = [[],[],[],[],[],[],[],[],[],[]];  // each pokemon gets two sets of flags, one for switch-in effects, one for item/ability effects as a result of the first round of effects
         // sort pokemon by speed to see what happens first
-        const speeds = this._state.raiders.map(raider => {
-            let s = raider.stats.spe;
-            s = this.modifyPokemonSpeedByAbility(s, raider.ability);
-            s = this.modifyPokemonSpeedByItem(s, raider.item);
-            return s;
-        });
+        const speeds = this._state.raiders.map(raider => raider.effectiveSpeed);
         const speedOrder = speeds.map((speed, index) => [speed, index]).sort((a, b) => b[0] - a[0]).map(pair => pair[1]);
         this._turnZeroOrder = speedOrder;
         for (let id of speedOrder) {
@@ -89,29 +83,19 @@ export class RaidBattle {
             //// Abilites That Take Effect at the start of the battle
             /// Weather Abilities
             if (ability === "Drought") {
-                for (let field of this._state.fields) {
-                    field.weather = "Sun";
-                }
+                this._state.applyWeather("Sun");
                 this._turnZeroFlags[id].push("Drought summons the Sun");
             } else if (ability === "Drizzle") {
-                for (let field of this._state.fields) {
-                    field.weather = "Rain";
-                }
+                this._state.applyWeather("Rain");
                 this._turnZeroFlags[id].push("Drizzle summons the Rain");
             } else if (ability === "Sand Stream") {
-                for (let field of this._state.fields) {
-                    field.weather = "Sand";
-                }
+                this._state.applyWeather("Sand");
                 this._turnZeroFlags[id].push("Sand Stream summons a Sandstorm");
             } else if (ability === "Snow Warning") {
-                for (let field of this._state.fields) {
-                    field.weather = "Snow";
-                }
+                this._state.applyWeather("Snow");
                 this._turnZeroFlags[id].push("Snow Warning summons a Snowstorm");
             } else if (ability === "Orichalcum Pulse") {
-                for (let field of this._state.fields) {
-                    field.weather = "Sun";
-                }
+                this._state.applyWeather("Sun");
                 this._turnZeroFlags[id].push("Orichalcum Pulse summons the Sun");
             } else if (ability === "Cloud Nine" || ability === "Air Lock") {
                 for (let field of this._state.fields) {
@@ -120,29 +104,19 @@ export class RaidBattle {
                 this._turnZeroFlags[id].push("Cloud Nine negates the weather");
             /// Terrain Abilities
             } else if (ability === "Grassy Surge") {
-                for (let field of this._state.fields) {
-                    field.terrain = "Grassy";
-                }
+                this._state.applyTerrain("Grassy");
                 this._turnZeroFlags[id].push("Grassy Surge summons Grassy Terrain");
             } else if (ability === "Electric Surge") {
-                for (let field of this._state.fields) {
-                    field.terrain = "Electric";
-                }
+                this._state.applyTerrain("Electric");
                 this._turnZeroFlags[id].push("Electric Surge summons Electric Terrain");
             } else if (ability === "Misty Surge") {
-                for (let field of this._state.fields) {
-                    field.terrain = "Misty";
-                }
+                this._state.applyTerrain("Misty");
                 this._turnZeroFlags[id].push("Misty Surge summons Misty Terrain");
             } else if (ability === "Psychic Surge") {
-                for (let field of this._state.fields) {
-                    field.terrain = "Psychic";
-                }
+                this._state.applyTerrain("Psychic");
                 this._turnZeroFlags[id].push("Psychic Surge summons Psychic Terrain");
             } else if (ability === "Hadron Engine") {
-                for (let field of this._state.fields) {
-                    field.terrain = "Electric";
-                }
+                this._state.applyTerrain("Electric");
                 this._turnZeroFlags[id].push("Hadron Engine summons Electric Terrain");
             /// Ruin Abilities
             } else if (ability === "Sword of Ruin") {
@@ -210,13 +184,8 @@ export class RaidBattle {
                 this._turnZeroFlags[id].push("Friend Guard reduces allies' damage taken");
             // Protosynthesis and Quark Drive
             } else if (ability === "Protosynthesis" || ability === "Quark Drive") {
-                if (pokemon.item === "Booster Energy") {
-                    pokemon.abilityOn = true;
-                    const qpStat = getQPBoostedStat (pokemon) as StatIDExceptHP;
-                    pokemon.boostedStat = qpStat;
-                    pokemon.item = undefined;
-                    pokemon.usedBoosterEnergy = true;
-                    this._turnZeroFlags[id].push("Booster Energy consumed");
+                if (pokemon.item === "Booster Energy" && !pokemon.abilityOn) {
+                    this._state.recieveItem(id, "Booster Energy" as ItemName); // consume Booster Energy
                 }
             // Intimidate
             } else if (ability === "Intimidate") {
@@ -269,35 +238,5 @@ export class RaidBattle {
                 this._turnZeroFlags[i+5] = this._turnZeroFlags[i+5].concat(moveResult.flags[i]);
             }
         } 
-    }
-
-    private modifyPokemonSpeedByItem(speed : number, item?: ItemName) {
-        switch(item) {
-            case "Choice Scarf":
-                return speed * 1.5;
-            case "Iron Ball":
-            case "Macho Brace":
-            case "Power Anklet":
-            case "Power Band":
-            case "Power Belt":
-            case "Power Bracer":
-            case "Power Lens":
-            case "Power Weight":
-                return speed * .5;
-            case "Lagging Tail":
-            case "Full Incense":
-                return 0;
-            // TODO: Quick Powder doubles the speed of untransformed Ditto
-            default:
-                return speed;
-        }
-    }
-    private modifyPokemonSpeedByAbility(speed: number, ability?: AbilityName, abilityOn?: boolean, status?: string) {
-        switch(ability) {
-            case "Slow Start":
-                return abilityOn ? speed * .5 : speed;
-            default:
-                return speed;
-        }
     }
 }

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -392,7 +392,7 @@ export class RaidMove {
         if (drainPercent) {
             // draining moves should only ever hit a single target in raids
             if (this._damage) {
-                this._drain[this.userID] = Math.floor(this._damage[this.userID] * drainPercent/100);
+                this._drain[this.userID] = Math.floor(this._damage[this.targetID] * drainPercent/100);
             }
             
         }
@@ -830,6 +830,7 @@ export class RaidMove {
             this._raidState.applyDamage(id, damage, this.move.hits, this.move.isCrit, isSuperEffective(this.move, pokemon.field, this._user, pokemon), this.move.type)
             // apply damage/healing from recoil/drain
             if (pokemon.originalCurHP !== 0) {
+                console.log(this.move.name, drain)
                 this._raidState.applyDamage(id, -drain);
             }
             // apply healing from move

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -662,7 +662,6 @@ export class RaidMove {
                 this._raidState.recieveItem(this.userID, tempTargetItem);
                 break;
             case "Fling":
-                const boostCoefficient = target.boostCoefficient;
                 const flingItem = this._user.item;
                 switch (flingItem) {
                     case "Light Ball":
@@ -791,6 +790,9 @@ export class RaidMove {
                 this._user.stats.atk = this._user.stats.def;
                 this._user.stats.def = tempAtk;
                 break;
+            case "Acupressure":
+                target.randomBoosts += 2;
+                break;
             default: break;
             }
     }
@@ -899,6 +901,11 @@ export class RaidMove {
                 if (diff !== 0) {
                     boostStr.push(stat + " " + (origStat > 0 ? "+" : "") + origStat + " -> " + (newStat > 0 ? "+" : "") + newStat);
                 }
+            }
+            // acupressure check
+            if (pokemon.randomBoosts !== origPokemon.randomBoosts) {
+                const diff = pokemon.randomBoosts - origPokemon.randomBoosts;
+                boostStr.push("random stat " + (origPokemon.randomBoosts > 0 ? "+" : "") + origPokemon.randomBoosts + " -> " + (pokemon.randomBoosts > 0 ? "+" : "") + pokemon.randomBoosts);
             }
             if (boostStr.length > 0) {
                 const displayStr = "Stat changes: (" + boostStr.join(", ") + ")";

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -842,7 +842,6 @@ export class RaidMove {
     private applyEndOfTurnDamage() {
         for (let i=0; i<5; i++) {
             const damage = this._eot[i] ? -this._eot[i]!.damage : 0;
-            console.log("EOT", this._raidState.raiders[i].role, damage)
             this._raidState.applyDamage(i, damage);
         }
     }

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -521,7 +521,7 @@ export class RaidMove {
         if (selfDamage !== 0) {
             const selfDamagePercent = this.moveData.selfDamage;
             this._flags[this.userID].push!(selfDamagePercent + "% self damage from " + this.moveData.name + ".")
-            this._damage[this.userID] = this._damage[this.userID] + selfDamage;
+            this._raidState.applyDamage(this.userID, selfDamage);
         }
     }
 

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -841,8 +841,8 @@ export class RaidMove {
 
     private applyEndOfTurnDamage() {
         for (let i=0; i<5; i++) {
-            const pokemon = this.getPokemon(i);
             const damage = this._eot[i] ? -this._eot[i]!.damage : 0;
+            console.log("EOT", this._raidState.raiders[i].role, damage)
             this._raidState.applyDamage(i, damage);
         }
     }

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -203,7 +203,6 @@ export class RaidState implements State.RaidState{
                             isPositiveBoost = true;
                         }
                     }
-                    console.log(positiveDiff, isPositiveBoost)
                     if (isPositiveBoost) {
                         this.applyStatChange(opponentId, positiveDiff, false);
                         if (opponent.item === "Mirror Herb") { this.loseItem(opponentId); }

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -29,10 +29,10 @@ export class RaidState implements State.RaidState{
     }
 
     public applyDamage(id: number, damage: number, nHits: number = 0, isCrit: boolean = false, isSuperEffective: boolean = false, moveType?: TypeName) {
-        if (damage <= 0) { return; }
         const pokemon = this.getPokemon(id);
-        const originalHP = pokemon.originalCurHP;
         pokemon.applyDamage(damage);
+        if (damage <= 0) { return; } // For healing / no damage, we don't need to make the following checks
+        const originalHP = pokemon.originalCurHP;
         const finalHP = pokemon.originalCurHP;
         const maxHP = pokemon.maxHP();
         /// Berry Consumption triggered by damage

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -197,7 +197,6 @@ export class RaidState implements State.RaidState{
                             isPositiveBoost = true;
                         }
                     }
-                    console.log(positiveDiff, isPositiveBoost)
                     if (isPositiveBoost) {
                         this.applyStatChange(opponentId, positiveDiff, false);
                         if (opponent.item === "Mirror Herb") { this.loseItem(opponentId); }

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -1,9 +1,9 @@
 import { Field, Generations, Move, StatsTable } from "../calc";
 import { Raider } from "./Raider";
-import { getModifiedStat } from "../calc/mechanics/util";
+import { getModifiedStat, getQPBoostedStat } from "../calc/mechanics/util";
 import { safeStatStage } from "./util";
 import * as State from "./interface";
-import { StatIDExceptHP } from "../calc/data/interface";
+import { ItemName, StatIDExceptHP, StatusName, Terrain, TypeName, Weather } from "../calc/data/interface";
 
 const gen = Generations.get(9);
 
@@ -28,83 +28,232 @@ export class RaidState implements State.RaidState{
         return this.raiders[id];
     }
 
-    public applyDamage(id: number, move: Move, damage: number) {
+    public applyDamage(id: number, damage: number, nHits: number = 0, isCrit: boolean = false, isSuperEffective: boolean = false, moveType?: TypeName) {
         if (damage <= 0) { return; }
         const pokemon = this.getPokemon(id);
         const originalHP = pokemon.originalCurHP;
         pokemon.applyDamage(damage);
         const finalHP = pokemon.originalCurHP;
-        // abilities triggered by damage
-        // Anger Point
-        if (pokemon.ability === "Anger Point") { pokemon.boosts.atk = 6 };
-        // Justified
-        if (move.type === "Dark") {
-            if (pokemon.ability === "Justified" && damage>0) { 
-                const boost = {atk: 1};
-                pokemon.boosts.atk = safeStatStage(pokemon.boosts.atk + move.hits); 
+        /// Berry Consumption triggered by damage
+        if (pokemon.item && pokemon.item?.includes("Berry")) {
+            // 50% HP Berries
+            if (finalHP <= pokemon.maxHP() / 2) {
+                if (pokemon.item === "Sitrus Berry") {
+                    pokemon.originalCurHP += Math.floor(pokemon.maxHP() / 4);
+                    this.loseItem(id);
+                }
             }
-        }    
-        // Weak Armor
-        if (pokemon.ability === "Weak Armor") {
-            pokemon.boosts.def = safeStatStage(pokemon.boosts.def - 1);
-            pokemon.boosts.spe = safeStatStage(pokemon.boosts.spe + 2);
-        }
+            // 33% HP Berries
+            // TO DO
+            // if (finalHP <= pokemon.maxHP() / 3) {
+            //     switch (pokemon.item) {
 
-        // Electromorphosis
-        if (pokemon.ability ===  "Electromorphosis") {
-            pokemon.field.attackerSide.isCharged = true;
+            //     }
+            // }
+            // 25% HP Berries
+            if (finalHP <= pokemon.maxHP() / 4) {
+                switch (pokemon.item) {
+                    case "Liechi Berry":
+                        this.applyStatChange(id, {atk: 1});
+                        this.loseItem(id);
+                        break;
+                    case "Ganlon Berry":
+                        this.applyStatChange(id, {def: 1});
+                        this.loseItem(id);
+                        break;
+                    case "Petaya Berry":
+                        this.applyStatChange(id, {spa: 1});
+                        this.loseItem(id);
+                        break;
+                    case "Apicot Berry":
+                        this.applyStatChange(id, {spd: 1});
+                        this.loseItem(id);
+                        break;
+                    case "Salac Berry":
+                        this.applyStatChange(id, {spe: 1});
+                        this.loseItem(id);
+                        break;
+                }
+            }
         }
-        // Item consumption triggered by damage
+        if (nHits > 0) { // checks that the pokemon was attacked, and that the damage was not due to recoil or chip damage
+            // Item consumption triggered by damage
+            // Focus Sash
+            if (pokemon.item === "Focus Sash" || pokemon.ability === "Sturdy") {
+                if (finalHP <= 0 && originalHP === pokemon.maxHP()) { 
+                    pokemon.originalCurHP = 1;
+                    if (pokemon.ability !== "Sturdy") { this.loseItem(id); } 
+                }
+            }
 
+            // Weakness Policy and Super-Effective reducing Berries
+            // TO DO - abilities that let users use berries more than once
+            if (damage > 0 && isSuperEffective) {
+                switch (pokemon.item) {
+                    case "Weakness Policy":
+                        this.applyStatChange(id, {atk: 2, spa: 2})
+                        this.loseItem(id);
+                        break;
+                    case "Occa Berry":  // the calc alread takes the berry into account, so we can just remove it here
+                        if (moveType === "Fire") { this.loseItem(id); }
+                        break;
+                    case "Passho Berry":
+                        if (moveType === "Water") { this.loseItem(id); }
+                        break;
+                    case "Wacan Berry":
+                        if (moveType === "Electric") { this.loseItem(id); }
+                        break;
+                    case "Rindo Berry":
+                        if (moveType === "Grass") { this.loseItem(id); }
+                        break;
+                    case "Yache Berry":
+                        if (moveType === "Ice") { this.loseItem(id); }
+                        break;
+                    case "Chople Berry":
+                        if (moveType === "Fighting") { this.loseItem(id); }
+                        break;
+                    case "Kebia Berry":
+                        if (moveType === "Poison") { this.loseItem(id); }
+                        break;
+                    case "Shuca Berry":
+                        if (moveType === "Ground") { this.loseItem(id); }
+                        break;
+                    case "Coba Berry":
+                        if (moveType === "Flying") { this.loseItem(id); }
+                        break;
+                    case "Payapa Berry":
+                        if (moveType === "Psychic") { this.loseItem(id); }
+                        break;
+                    case "Tanga Berry":
+                        if (moveType === "Bug") { this.loseItem(id); }
+                        break;
+                    case "Charti Berry":
+                        if (moveType === "Rock") { this.loseItem(id); }
+                        break;
+                    case "Kasib Berry":
+                        if (moveType === "Ghost") { this.loseItem(id); }
+                        break;
+                    case "Haban Berry":
+                        if (moveType === "Dragon") { this.loseItem(id); }
+                        break;
+                    case "Colbur Berry":
+                        if (moveType === "Dark") { this.loseItem(id); }
+                        break;
+                    case "Babiri Berry":
+                        if (moveType === "Steel") { this.loseItem(id); }
+                        break;
+                    case "Roseli Berry":
+                        if (moveType === "Fairy") { this.loseItem(id); }
+                        break;
+                    default: break;
+                }
+            }
+            if (pokemon.item === "Chiban Berry" && moveType === "Normal") {
+                this.loseItem(id);
+            }
+            
+            // abilities triggered by damage
+            // Anger Point
+            if (isCrit && pokemon.ability === "Anger Point") { 
+                const boost = {atk: 12};
+                this.applyStatChange(id, boost);
+            };
+            // Justified
+            if (moveType === "Dark") {
+                if (pokemon.ability === "Justified" && damage>0) { 
+                    const boost = {atk: 1};
+                    this.applyStatChange(id, boost);
+                }
+            }    
+            // Weak Armor
+            if (pokemon.ability === "Weak Armor") {
+                const boost = {def: -1, spe: 2};
+                this.applyStatChange(id, boost);
+            }
+
+            // Electromorphosis
+            if (pokemon.ability ===  "Electromorphosis") {
+                pokemon.field.attackerSide.isCharged = true;
+            }
+        }
     }
 
-    public applyStatChange(id: number, boosts: StatsTable): StatsTable {
+    public applyStatChange(id: number, boosts: Partial<StatsTable>, copyable: boolean = false): StatsTable {
         const pokemon = this.getPokemon(id);
-        const originalStats = {...pokemon.boosts} as StatsTable;
         const diff = pokemon.applyStatChange(boosts);
-        // Mirror Herb
-        const opponentIds = id === 0 ? [1,2,3,4] : [0];
-        for (const opponentId of opponentIds) {
-            const opponent = this.getPokemon(opponentId);
-            if (opponent.item === "Mirror Herb") {
-                this.loseItem(opponentId);
-                this.applyStatChange(opponentId, diff);
+        // Mirror Herb and Opportunist
+        if (copyable) { // Stat changes that are being copied shouldn't be copied in turn
+            const opponentIds = id === 0 ? [1,2,3,4] : [0];
+            for (const opponentId of opponentIds) {
+                const opponent = this.getPokemon(opponentId);
+                if (opponent.item === "Opportunist" || opponent.item === "Mirror Herb")  {
+                    const positiveDiff = {...diff};
+                    let isPositiveBoost = false;
+                    for (const stat in positiveDiff) {
+                        const statId = stat as StatIDExceptHP;
+                        if (positiveDiff[statId] <= 0) {
+                            positiveDiff[statId] = 0;
+                        } else {
+                            isPositiveBoost = true;
+                        }
+                    }
+                    if (isPositiveBoost) {
+                        this.applyStatChange(opponentId, positiveDiff, false);
+                        if (opponent.item === "Mirror Herb") { this.loseItem(opponentId); }
+                    }
+                }
             }
         }
+        // White Herb
+        if (pokemon.item === "White Herb") {
+            let used = false
+            for (const stat in pokemon.boosts) {
+                const statId = stat as StatIDExceptHP;
+                if (pokemon.boosts[statId] < 0) {
+                    pokemon.boosts[statId] = 0;
+                    used = true;
+                }
+            }
+            if (used) { this.loseItem(id); }
+        }
+ 
         return diff;
+    }
+
+    public applyStatus(id: number, status: StatusName) {
+        const pokemon = this.getPokemon(id);
+        if (pokemon.status === "" || pokemon.status === undefined) {
+            pokemon.status = status;
+        }
+        // Status curing berries
+        if (pokemon.item === "Cheri Berry" && pokemon.status === "par") { pokemon.status = ""; this.loseItem(id); }
+        if (pokemon.item === "Chesto Berry" && pokemon.status === "slp") { pokemon.status = ""; this.loseItem(id); }
+        if (pokemon.item === "Pecha Berry" && pokemon.status === "psn") { pokemon.status = ""; this.loseItem(id); }
+        if (pokemon.item === "Rawst Berry" && pokemon.status === "brn") { pokemon.status = ""; this.loseItem(id); }
+        if (pokemon.item === "Aspear Berry" && pokemon.status === "frz") { pokemon.status = ""; this.loseItem(id); }
+        if (pokemon.item === "Lum Berry" && pokemon.status !== "") { 
+            pokemon.status = ""; 
+            pokemon.volatileStatus = pokemon.volatileStatus.filter(status => status !== "confusion"); 
+            this.loseItem(id); 
+        }
     }
 
     public loseItem(id: number) {
         const pokemon = this.getPokemon(id);
         pokemon.loseItem();
-        // Unburden
-        if (pokemon.ability === "Unburden" && 
-            pokemon.item === undefined && 
-            pokemon.item !== undefined) 
-        {
-            pokemon.abilityOn = true;
-        }
         // Symbiosis
-        let lostItemId = -1;
-        for (let i=0; i<5; i++) {
-            if (pokemon.item === undefined && pokemon.item !== undefined) {
-                lostItemId = i;
-                break;
-            }
-        }
-        if (lostItemId >=0) {
-            const lostItemPokemon = this.getPokemon(lostItemId);
+        if (id > 0) {
             const symbiosisIds: number[] = []
-            for (let id=0; id<5; id++) {
-                if (id !== lostItemId && this.getPokemon(id).ability === "Symbiosis" && this.getPokemon(id).item !== undefined) {
-                    symbiosisIds.push(id);
+            for (let sid=1; sid<5; sid++) {
+                if (sid !== id && this.getPokemon(sid).ability === "Symbiosis" && this.getPokemon(sid).item !== undefined) {
+                    symbiosisIds.push(sid);
                 }
             }
             if (symbiosisIds.length > 0) {
                 // speed check for symbiosis
                 let fastestSymbId = symbiosisIds[0];
                 let fastestSymbPoke = this.getPokemon(fastestSymbId);
-                let fastestSymbSpeed = getModifiedStat(fastestSymbPoke.stats.spe, fastestSymbPoke.boosts.spe, gen);
+                let fastestSymbSpeed = fastestSymbPoke.effectiveSpeed;
                 for (let i=1; i<symbiosisIds.length; i++) {
                     const poke = this.getPokemon(symbiosisIds[i]);
                     const speed = getModifiedStat(poke.stats.spe, poke.boosts.spe, gen);
@@ -116,8 +265,77 @@ export class RaidState implements State.RaidState{
                     } 
                 }
                 // symbiosis item transfer
-                lostItemPokemon.item = fastestSymbPoke.item;
-                fastestSymbPoke.item = undefined;
+                this.recieveItem(id, fastestSymbPoke.item!);
+                fastestSymbPoke.item = undefined; // don't call loseItem because it will trigger symbiosis again
+            }
+        }
+    }
+
+    public recieveItem(id: number, item: ItemName | undefined) {
+        const pokemon = this.getPokemon(id);
+        pokemon.item = item;
+        /// Items that activate upon reciept or switch in
+        // Booster Energy
+        if (pokemon.item === "Booster Energy" && (pokemon.ability === "Protosynthesis" || pokemon.ability === "Quark Drive") && !pokemon.abilityOn) {
+            pokemon.abilityOn = true;
+            const statId = getQPBoostedStat(pokemon, gen) as StatIDExceptHP;
+            pokemon.boostedStat = statId;
+            pokemon.usedBoosterEnergy = true;
+            this.loseItem(id)
+        }
+        // Terrain Seeds
+        if (item && item.includes("Seed")) {
+            this.applyTerrain(pokemon.field.terrain, [id]);
+        }
+        // Would berries be consumed immediately upon reciept (via Symbiosis, Trick, etc) if their conditions are met?
+    }
+
+    public applyTerrain(terrain: Terrain | undefined, ids: number[] = [0,1,2,3,4]) {
+        for (let id of ids) {
+            const pokemon = this.getPokemon(id);
+            pokemon.field.terrain = terrain;
+            // Quark Drive
+            if (pokemon.ability === "Quark Drive" && !pokemon.usedBoosterEnergy) {
+                if (pokemon.field.terrain === "Electric" && !pokemon.abilityOn) {
+                    pokemon.abilityOn = true;
+                    const statId = getQPBoostedStat(pokemon, gen) as StatIDExceptHP;
+                    pokemon.boostedStat = statId;
+                } else if (pokemon.field.terrain !== "Electric" && pokemon.abilityOn) {
+                    pokemon.abilityOn = false;
+                    pokemon.boostedStat = undefined;
+                }
+            }
+            // Terrain Seeds
+            if (pokemon.item === "Electric Seed" && pokemon.field.terrain === "Electric") {
+                this.applyStatChange(id, {def: 1});
+                this.loseItem(id);
+            } else if (pokemon.item === "Grassy Seed" && pokemon.field.terrain === "Grassy") {
+                this.applyStatChange(id, {def: 1});
+                this.loseItem(id);
+            } else if (pokemon.item === "Psychic Seed" && pokemon.field.terrain === "Psychic") {
+                this.applyStatChange(id, {spd: 1});
+                this.loseItem(id);
+            } else if (pokemon.item === "Misty Seed" && pokemon.field.terrain === "Misty") {
+                this.applyStatChange(id, {spd: 1});
+                this.loseItem(id);
+            }
+        }
+    }
+
+    public applyWeather(weather: Weather | undefined, ids: number[] = [0,1,2,3,4]) {
+        for (let id of ids) {
+            const pokemon = this.getPokemon(id);
+            pokemon.field.weather = weather;
+            // Protosynthesis
+            if (pokemon.ability === "Protosynthesis" && !pokemon.usedBoosterEnergy) {
+                if ((pokemon.field.weather || "").includes("Sun") && !pokemon.abilityOn) {
+                    pokemon.abilityOn = true;
+                    const statId = getQPBoostedStat(pokemon, gen) as StatIDExceptHP;
+                    pokemon.boostedStat = statId;
+                } else if ((pokemon.field.weather || "").includes("Sun")  && pokemon.abilityOn) {
+                    pokemon.abilityOn = false;
+                    pokemon.boostedStat = undefined;
+                }
             }
         }
     }

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -30,6 +30,7 @@ export class RaidState implements State.RaidState{
 
     public applyDamage(id: number, damage: number, nHits: number = 0, isCrit: boolean = false, isSuperEffective: boolean = false, moveType?: TypeName) {
         const pokemon = this.getPokemon(id);
+        if (pokemon.originalCurHP === 0) { return; } // prevent healing KOd Pokemon, and there's no need to subtract damage from 0HP
         pokemon.applyDamage(damage);
         if (damage <= 0) { return; } // For healing / no damage, we don't need to make the following checks
         const originalHP = pokemon.originalCurHP;

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -1,0 +1,124 @@
+import { Field, Generations, Move, StatsTable } from "../calc";
+import { Raider } from "./Raider";
+import { getModifiedStat } from "../calc/mechanics/util";
+import { safeStatStage } from "./util";
+import * as State from "./interface";
+import { StatIDExceptHP } from "../calc/data/interface";
+
+const gen = Generations.get(9);
+
+export class RaidState implements State.RaidState{
+    raiders: Raider[]; // raiders[0] is the boss, while raiders 1-5 are the players
+
+    constructor(raiders: Raider[]) {
+        this.raiders = raiders;
+    }
+
+    clone(): RaidState {
+        return new RaidState(
+            this.raiders.map(raider => raider.clone()) 
+        )
+    }
+
+    public get fields(): Field[] {
+        return this.raiders.map(raider => raider.field);
+    }
+
+    public getPokemon(id: number): Raider {
+        return this.raiders[id];
+    }
+
+    public applyDamage(id: number, move: Move, damage: number) {
+        if (damage <= 0) { return; }
+        const pokemon = this.getPokemon(id);
+        const originalHP = pokemon.originalCurHP;
+        pokemon.applyDamage(damage);
+        const finalHP = pokemon.originalCurHP;
+        // abilities triggered by damage
+        // Anger Point
+        if (pokemon.ability === "Anger Point") { pokemon.boosts.atk = 6 };
+        // Justified
+        if (move.type === "Dark") {
+            if (pokemon.ability === "Justified" && damage>0) { 
+                const boost = {atk: 1};
+                pokemon.boosts.atk = safeStatStage(pokemon.boosts.atk + move.hits); 
+            }
+        }    
+        // Weak Armor
+        if (pokemon.ability === "Weak Armor") {
+            pokemon.boosts.def = safeStatStage(pokemon.boosts.def - 1);
+            pokemon.boosts.spe = safeStatStage(pokemon.boosts.spe + 2);
+        }
+
+        // Electromorphosis
+        if (pokemon.ability ===  "Electromorphosis") {
+            pokemon.field.attackerSide.isCharged = true;
+        }
+        // Item consumption triggered by damage
+
+    }
+
+    public applyStatChange(id: number, boosts: StatsTable): StatsTable {
+        const pokemon = this.getPokemon(id);
+        const originalStats = {...pokemon.boosts} as StatsTable;
+        const diff = pokemon.applyStatChange(boosts);
+        // Mirror Herb
+        const opponentIds = id === 0 ? [1,2,3,4] : [0];
+        for (const opponentId of opponentIds) {
+            const opponent = this.getPokemon(opponentId);
+            if (opponent.item === "Mirror Herb") {
+                this.loseItem(opponentId);
+                this.applyStatChange(opponentId, diff);
+            }
+        }
+        return diff;
+    }
+
+    public loseItem(id: number) {
+        const pokemon = this.getPokemon(id);
+        pokemon.loseItem();
+        // Unburden
+        if (pokemon.ability === "Unburden" && 
+            pokemon.item === undefined && 
+            pokemon.item !== undefined) 
+        {
+            pokemon.abilityOn = true;
+        }
+        // Symbiosis
+        let lostItemId = -1;
+        for (let i=0; i<5; i++) {
+            if (pokemon.item === undefined && pokemon.item !== undefined) {
+                lostItemId = i;
+                break;
+            }
+        }
+        if (lostItemId >=0) {
+            const lostItemPokemon = this.getPokemon(lostItemId);
+            const symbiosisIds: number[] = []
+            for (let id=0; id<5; id++) {
+                if (id !== lostItemId && this.getPokemon(id).ability === "Symbiosis" && this.getPokemon(id).item !== undefined) {
+                    symbiosisIds.push(id);
+                }
+            }
+            if (symbiosisIds.length > 0) {
+                // speed check for symbiosis
+                let fastestSymbId = symbiosisIds[0];
+                let fastestSymbPoke = this.getPokemon(fastestSymbId);
+                let fastestSymbSpeed = getModifiedStat(fastestSymbPoke.stats.spe, fastestSymbPoke.boosts.spe, gen);
+                for (let i=1; i<symbiosisIds.length; i++) {
+                    const poke = this.getPokemon(symbiosisIds[i]);
+                    const speed = getModifiedStat(poke.stats.spe, poke.boosts.spe, gen);
+                    const field = poke.field;
+                    if ( (!field.isTrickRoom && speed > fastestSymbSpeed) || (field.isTrickRoom && speed < fastestSymbSpeed) ) {
+                        fastestSymbId = symbiosisIds[i];
+                        fastestSymbPoke = poke;
+                        fastestSymbSpeed = speed;
+                    } 
+                }
+                // symbiosis item transfer
+                lostItemPokemon.item = fastestSymbPoke.item;
+                fastestSymbPoke.item = undefined;
+            }
+        }
+    }
+}

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -186,11 +186,17 @@ export class RaidState implements State.RaidState{
             const opponentIds = id === 0 ? [1,2,3,4] : [0];
             for (const opponentId of opponentIds) {
                 const opponent = this.getPokemon(opponentId);
-                if (opponent.item === "Opportunist" || opponent.item === "Mirror Herb")  {
+                const mirrorHerb = opponent.item === "Mirror Herb";
+                const opportunist = opponent.ability === "Opportunist";
+                if (mirrorHerb || opportunist)  {
+                    const both = mirrorHerb && opportunist;
                     const positiveDiff = {...diff};
                     let isPositiveBoost = false;
                     for (const stat in positiveDiff) {
                         const statId = stat as StatIDExceptHP;
+                        if (both) {
+                            positiveDiff[statId] *= 2;
+                        }
                         if (positiveDiff[statId] <= 0) {
                             positiveDiff[statId] = 0;
                         } else {

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -178,7 +178,7 @@ export class RaidState implements State.RaidState{
         }
     }
 
-    public applyStatChange(id: number, boosts: Partial<StatsTable>, copyable: boolean = false): StatsTable {
+    public applyStatChange(id: number, boosts: Partial<StatsTable>, copyable: boolean = true): StatsTable {
         const pokemon = this.getPokemon(id);
         const diff = pokemon.applyStatChange(boosts);
         // Mirror Herb and Opportunist
@@ -197,6 +197,7 @@ export class RaidState implements State.RaidState{
                             isPositiveBoost = true;
                         }
                     }
+                    console.log(positiveDiff, isPositiveBoost)
                     if (isPositiveBoost) {
                         this.applyStatChange(opponentId, positiveDiff, false);
                         if (opponent.item === "Mirror Herb") { this.loseItem(opponentId); }

--- a/src/raidcalc/RaidTurn.ts
+++ b/src/raidcalc/RaidTurn.ts
@@ -1,12 +1,19 @@
-import { Field, Generations, Move, Pokemon } from "../calc";
-import { MoveData, RaidMoveOptions, RaidState, RaidTurnResult, RaidMoveResult, RaidTurnInfo } from "./interface";
+import { Field, Generations, Move } from "../calc";
+import { MoveData, RaidMoveOptions, RaidTurnInfo } from "./interface";
 import { getModifiedStat, getQPBoostedStat } from "../calc/mechanics/util";
+import { RaidState } from "./RaidState";
 import { Raider } from "./interface";
-import { RaidMove } from "./RaidMove";
+import { RaidMove, RaidMoveResult } from "./RaidMove";
 import { AbilityName, ItemName, StatIDExceptHP } from "../calc/data/interface";
 import pranksterMoves from "../data/prankster_moves.json"
 
 const gen = Generations.get(9);
+
+export type RaidTurnResult = {
+    state: RaidState;
+    results: [RaidMoveResult, RaidMoveResult];
+    raiderMovesFirst: boolean;
+}
 
 export class RaidTurn {
     raidState:      RaidState; // We shouldn't mutate this state; it is the result from the previous turn

--- a/src/raidcalc/RaidTurn.ts
+++ b/src/raidcalc/RaidTurn.ts
@@ -1,10 +1,8 @@
-import { Field, Generations, Move } from "../calc";
+import { Generations, Move } from "../calc";
 import { MoveData, RaidMoveOptions, RaidTurnInfo } from "./interface";
-import { getModifiedStat, getQPBoostedStat } from "../calc/mechanics/util";
 import { RaidState } from "./RaidState";
-import { Raider } from "./interface";
+import { Raider } from "./Raider";
 import { RaidMove, RaidMoveResult } from "./RaidMove";
-import { AbilityName, ItemName, StatIDExceptHP } from "../calc/data/interface";
 import pranksterMoves from "../data/prankster_moves.json"
 
 const gen = Generations.get(9);
@@ -68,9 +66,6 @@ export class RaidTurn {
         this._raidState = this.raidState.clone();
         this._flags = [[], [], [], [], []];
 
-        // set Protosynthesis / Quark Drive boosts before getting turn order & processing raid turns
-        this.setQPBoosts();
-
         // determine which move goes first
         this.setTurnOrder();
 
@@ -127,7 +122,6 @@ export class RaidTurn {
                 this._result1.causesFlinch[this.raiderID]);
         }
         this._raidMove2.result();
-        this._raidMove2.applyItemEffects(); // A final check for items triggered by end-of-turn damage
         this._result2 = this._raidMove2.output
         this._raidState = this._result2.state;
         // item effects
@@ -135,10 +129,6 @@ export class RaidTurn {
         // Clear Endure (since side-attacks are not endured)
         this._raidState.raiders[this.raiderID].isEndure = false;
         this._raidState.raiders[0].isEndure = false; // I am unaware of any raid bosses that have endure
-        // Add QP related flags to the first turn
-        for (let i=0; i<5; i++) {
-            this._result1.flags[i] = this._result1.flags[i].concat(this._flags[i]);
-        }
         // remove protect / wide guard / quick guard effects
         this.removeProtection();
 
@@ -178,44 +168,6 @@ export class RaidTurn {
         } 
     }
 
-    private setQPBoosts() {
-        this._raidState.raiders.map((raider, index) => {
-            if (raider.ability === "Protosynthesis" || raider.ability === "Quark Drive") {
-                if (raider.usedBoosterEnergy) { 
-                    return; } // do not change Boost after Booster Energy consumption
-                if ( !raider.abilityOn && ( // we only need to set QP if it is currently inactive
-                        (this._raidState.fields[index].weather?.includes("Sun") && raider.ability === "Protosynthesis") ||
-                        (this._raidState.fields[index].terrain?.includes("Electric") && raider.ability === "Quark Drive")
-                    )
-                ) { // Sun / Electric Terrain has priority over Booster Energy, Booster Energy is not consumed if QP is already active
-                    raider.abilityOn = true;
-                    raider.boostedStat = undefined;
-                    const qpStat = getQPBoostedStat(raider) as StatIDExceptHP;
-                    raider.boostedStat = qpStat;
-                    this._flags[index].push(raider.ability + " activated");
-                } else if ( raider.abilityOn && ( // we only meed to remove QP if it is currently active
-                        (!this._raidState.fields[index].weather?.includes("Sun") && raider.ability === "Protosynthesis") ||
-                        (!this._raidState.fields[index].terrain?.includes("Electric") && raider.ability === "Quark Drive")
-                    )
-                ) { // If a booster energy has not been consumed and the Sun / Electric Terrain is removed, QP will be deactivated 
-                    raider.abilityOn = false;
-                    raider.boostedStat = undefined;
-                    this._flags[index].push(raider.ability + " deactivated");
-                }
-                // If Booster Energy is held and QP is currently inactive, consume it
-                if (!raider.abilityOn && raider.item === "Booster Energy") { // if the raider acquires Booster Energy outside of Turn 0
-                    raider.abilityOn = true;
-                    raider.boostedStat = undefined;
-                    const qpStat = getQPBoostedStat(raider) as StatIDExceptHP;
-                    raider.boostedStat = qpStat;
-                    raider.item = undefined;
-                    raider.usedBoosterEnergy = true;
-                    this._flags[index].push("Booster Energy consumed");
-                }
-            }
-        })
-    }
-
     private setTurnOrder() {
         this._raider = this._raidState.raiders[this.raiderID];
         this._boss = this._raidState.raiders[0];
@@ -232,14 +184,10 @@ export class RaidTurn {
             this._raiderMovesFirst = false;
         } else {
             // if priority is the same, compare speed
-            let raiderSpeed = getModifiedStat(this._raider.stats.spe, this._raider.boosts.spe, gen);
-            let bossSpeed = getModifiedStat(this._boss.stats.spe, this._boss.boosts.spe, gen);
+            const raiderSpeed = this._raider.effectiveSpeed;
+            const bossSpeed = this._boss.effectiveSpeed;
 
-            const raiderField = this._raidState.fields[this.raiderID];
             const bossField = this._raidState.fields[0];
-            raiderSpeed = this.applySpeedModifiers(raiderSpeed, this._raider, raiderField);
-            bossSpeed = this.applySpeedModifiers(bossSpeed, this._boss, bossField);
-
             this._raiderMovesFirst = bossField.isTrickRoom ? (raiderSpeed < bossSpeed) : (raiderSpeed > bossSpeed);
         }
     }
@@ -263,74 +211,6 @@ export class RaidTurn {
             default:
                 break;
         }
-    }
-
-    private applySpeedModifiers(speed: number, raider: Raider, field: Field) {
-        speed = this.modifyPokemonSpeedByStatus(speed, raider.status, raider.ability);
-        speed = this.modifyPokemonSpeedByItem(speed, raider.item);
-        speed = this.modifyPokemonSpeedByAbility(speed, raider.ability, raider.abilityOn, raider.status);
-        speed = this.modifyPokemonSpeedByQP(speed, field, raider.ability, raider.item, raider.boostedStat as StatIDExceptHP);
-        speed = this.modifyPokemonSpeedByField(speed, field);
-        return speed;
-    }
-
-    private modifyPokemonSpeedByStatus(speed: number, status?: string, ability?: AbilityName) {
-        return status === "par" && ability !== "Quick Feet" ? speed * .5 : speed;
-    }
-
-    private modifyPokemonSpeedByItem(speed : number, item?: ItemName) {
-        switch(item) {
-            case "Choice Scarf":
-                return speed * 1.5;
-            case "Iron Ball":
-            case "Macho Brace":
-            case "Power Anklet":
-            case "Power Band":
-            case "Power Belt":
-            case "Power Bracer":
-            case "Power Lens":
-            case "Power Weight":
-                return speed * .5;
-            case "Lagging Tail":
-            case "Full Incense":
-                return 0;
-            // TODO: Quick Powder doubles the speed of untransformed Ditto
-            default:
-                return speed;
-        }
-    }
-
-    private modifyPokemonSpeedByAbility(speed: number, ability?: AbilityName, abilityOn?: boolean, status?: string) {
-        switch(ability) {
-            case "Unburden":
-                return abilityOn ? speed * 2 : speed;
-            case "Slow Start":
-                return abilityOn ? speed * .5 : speed;
-            case "Quick Feet":
-                return status ? speed * 1.5 : speed;
-            default:
-                return speed;
-        }
-    }
-
-    private modifyPokemonSpeedByQP(speed: number, field: Field, ability?: AbilityName, item?: ItemName, qpBoostedStat?: StatIDExceptHP) {
-        return qpBoostedStat === "spe" ? speed * 1.5 : speed;
-    }
-
-    private modifyPokemonSpeedByField(speed: number, field: Field, ability?: AbilityName) {
-        if (
-            ability === "Chlorophyll" && field.weather?.includes("Sun") ||
-            ability === "Sand Rush" && field.weather?.includes("Sand") ||
-            ability === "Slush Rush" && field.weather?.includes("Snow") ||
-            ability === "Swift Swim" && field.weather?.includes("Rain") ||
-            ability === "Surge Surfer" && field.terrain?.includes("Electric")
-        ) {
-            speed *= 2;
-        }
-        if (field.attackerSide.isTailwind) {
-            speed *= 2;
-        }
-        return speed;
     }
 
     private applyEndOfTurnItemEffects() {

--- a/src/raidcalc/Raider.ts
+++ b/src/raidcalc/Raider.ts
@@ -49,6 +49,7 @@ export class Raider extends Pokemon implements State.Raider {
                 ivs: extend(true, {}, this.ivs),
                 evs: extend(true, {}, this.evs),
                 boosts: extend(true, {}, this.boosts),
+                randomBoosts: this.randomBoosts,
                 originalCurHP: this.originalCurHP,
                 status: this.status,
                 teraType: this.teraType,

--- a/src/raidcalc/Raider.ts
+++ b/src/raidcalc/Raider.ts
@@ -1,0 +1,92 @@
+import { Field, Pokemon } from "../calc";
+import { MoveName, StatsTable, StatIDExceptHP } from "../calc/data/interface";
+import { extend } from '../calc/util';
+import { safeStatStage } from "./util";
+import * as State from "./interface";
+
+export class Raider extends Pokemon implements State.Raider {
+    id: number;
+    role: string;
+    field: Field;               // each pokemon gets its own field to deal with things like Helping Hand and Protect
+    extraMoves?: MoveName[];    // for special boss actions
+    isEndure?: boolean;         // store that a Pokemon can't faint until its next move
+    lastMove?: State.MoveData;  // stored for Instruct and Copycat
+    lastTarget?: number;        // stored for Instruct and Copycat
+
+    constructor(id: number, role: string, field: Field, pokemon: Pokemon, extraMoves: MoveName[] = [], isEndure: boolean = false, lastMove: State.MoveData | undefined = undefined, lastTarget: number | undefined = undefined) {
+        super(pokemon.gen, pokemon.name, {...pokemon})
+        this.id = id;
+        this.role = role;
+        this.field = field;
+        this.extraMoves = extraMoves;
+        this.isEndure = isEndure;
+        this.lastMove = lastMove;
+        this.lastTarget = lastTarget;
+    }
+
+    clone(): Raider {
+        return new Raider(
+            this.id, 
+            this.role, 
+            this.field.clone(),
+            new Pokemon(this.gen, this.name, {
+                level: this.level,
+                bossMultiplier: this.bossMultiplier,
+                ability: this.ability,
+                abilityOn: this.abilityOn,
+                isDynamaxed: this.isDynamaxed,
+                dynamaxLevel: this.dynamaxLevel,
+                isSaltCure: this.isSaltCure,
+                alliesFainted: this.alliesFainted,
+                boostedStat: this.boostedStat,
+                usedBoosterEnergy: this.usedBoosterEnergy,
+                item: this.item,
+                gender: this.gender,
+                nature: this.nature,
+                ivs: extend(true, {}, this.ivs),
+                evs: extend(true, {}, this.evs),
+                boosts: extend(true, {}, this.boosts),
+                originalCurHP: this.originalCurHP,
+                status: this.status,
+                teraType: this.teraType,
+                toxicCounter: this.toxicCounter,
+                moves: this.moves.slice(),
+                overrides: this.species,
+            }),
+            this.extraMoves,
+            this.isEndure,
+            this.lastMove,
+            this.lastTarget
+        )
+    }
+
+    public get boostCoefficient(): number {
+        const hasSimple = this.ability === "Simple";
+        const hasContrary = this.ability === "Contrary";
+        return hasSimple ? 2 : hasContrary ? -1 : 1;
+    }
+
+    public applyDamage(damage: number): number { 
+        this.originalCurHP = Math.max(0, this.originalCurHP - damage);
+        return this.originalCurHP;
+    }
+
+    public applyStatChange(boosts: StatsTable): StatsTable {
+        const diff: StatsTable = {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0};
+        for (let stat in boosts) {
+            const statId = stat as StatIDExceptHP;
+            const originalStat = this.boosts[statId];
+            this.boosts[statId] = safeStatStage(this.boosts[statId] + boosts[statId] * this.boostCoefficient)
+            diff[statId] = this.boosts[statId] - originalStat;
+        }
+        return diff;
+    }
+
+    public loseItem(): void {
+         // Unburden
+         if (this.ability === "Unburden" && this.item !== undefined) {
+            this.abilityOn = true;
+        }
+        this.item = undefined;
+    }
+}

--- a/src/raidcalc/inputs.ts
+++ b/src/raidcalc/inputs.ts
@@ -1,0 +1,21 @@
+import { Raider } from "./Raider";
+import { RaidTurnInfo } from "./interface";
+
+// used for passing data to React components
+export type RaidInputProps = {
+    pokemon: Raider[],
+    setPokemon: ((r: Raider) => void)[],
+    turns: RaidTurnInfo[],
+    setTurns: (t: RaidTurnInfo[]) => void,
+    groups: number[][],
+    setGroups: (g: number[][]) => void,
+  }
+
+  export type BuildInfo = {
+    name: string;
+    notes: string;
+    credits: string;
+    pokemon: Raider[],
+    turns: RaidTurnInfo[],
+    groups: number[][],
+}

--- a/src/raidcalc/interface.ts
+++ b/src/raidcalc/interface.ts
@@ -1,6 +1,5 @@
 import { Pokemon, Field, StatID } from "../calc";
 import { MoveName, TypeName } from "../calc/data/interface";
-import { extend } from '../calc/util';
 
 export type MoveSetItem = {
     name: MoveName,
@@ -85,90 +84,18 @@ export type MoveData = {
     maxHits?:       number,
 }
 
-export class Raider extends Pokemon {
+export interface Raider extends Pokemon {
     id: number;
     role: string;
+    field: Field;
     extraMoves?: MoveName[];// for special boss actions
     isEndure?: boolean;     // store that a Pokemon can't faint until its next move
     lastMove?: MoveData;    // stored for Instruct and Copycat
     lastTarget?: number;    // stored for Instruct and Copycat
-
-    constructor(id: number, role: string, pokemon: Pokemon, extraMoves: MoveName[] = [], isEndure: boolean = false, lastMove: MoveData | undefined = undefined, lastTarget: number | undefined = undefined) {
-        super(pokemon.gen, pokemon.name, {...pokemon})
-        this.id = id;
-        this.role = role;
-        this.extraMoves = extraMoves;
-        this.isEndure = isEndure;
-        this.lastMove = lastMove;
-        this.lastTarget = lastTarget;
-    }
-
-    clone() {
-        return new Raider(
-            this.id, 
-            this.role, 
-            new Pokemon(this.gen, this.name, {
-                level: this.level,
-                bossMultiplier: this.bossMultiplier,
-                ability: this.ability,
-                abilityOn: this.abilityOn,
-                isDynamaxed: this.isDynamaxed,
-                dynamaxLevel: this.dynamaxLevel,
-                isSaltCure: this.isSaltCure,
-                alliesFainted: this.alliesFainted,
-                boostedStat: this.boostedStat,
-                usedBoosterEnergy: this.usedBoosterEnergy,
-                item: this.item,
-                gender: this.gender,
-                nature: this.nature,
-                ivs: extend(true, {}, this.ivs),
-                evs: extend(true, {}, this.evs),
-                boosts: extend(true, {}, this.boosts),
-                originalCurHP: this.originalCurHP,
-                status: this.status,
-                teraType: this.teraType,
-                toxicCounter: this.toxicCounter,
-                moves: this.moves.slice(),
-                overrides: this.species,
-            }),
-            this.extraMoves,
-            this.isEndure,
-            this.lastMove,
-            this.lastTarget
-        )
-      }
 }
 
-export class RaidState {
-    raiders: Raider[]; // raiders[0] is the boss, while raiders 1-5 are the players
-    fields: Field[];   // each pokemon gets its own field to deal with things like Friend Guard and Protosynthesis
-
-    constructor(raiders: Raider[], fields: Field[]) {
-        this.raiders = raiders;
-        this.fields = fields;
-    }
-
-    clone() {
-        return new RaidState(
-            this.raiders.map(raider => raider.clone()), 
-            this.fields.map(field => field.clone()));
-    }
-}
-
-export type RaidBattleInfo = {
-    name?: string;
-    notes?: string;
-    credits?: string;
-    startingState: RaidState;
-    turns: RaidTurnInfo[];
-    groups: number[][];
-}
-
-export type RaidBattleResults = {
-    endState: RaidState;
-    turnResults: RaidTurnResult[]; 
-    turnZeroFlags: string[][];
-    turnZeroOrder: number[];
+export interface RaidState {
+    raiders: Raider[]; // raiders[0] is the boss, while raiders 1-4 are the players
 }
 
 export type RaidMoveOptions = {
@@ -191,41 +118,3 @@ export type RaidTurnInfo ={
     moveInfo: RaidMoveInfo;
     bossMoveInfo: RaidMoveInfo;
 }
-
-export type RaidMoveResult= {
-    state: RaidState;
-    userID: number;
-    targetID: number;
-    damage: number[];
-    drain: number[];
-    healing: number[];
-    eot: ({damage: number, texts: string[]} | undefined)[];
-    desc: string[];
-    flags: string[][];
-    causesFlinch: boolean[];
-}
-
-export type RaidTurnResult = {
-    state: RaidState;
-    results: [RaidMoveResult, RaidMoveResult];
-    raiderMovesFirst: boolean;
-}
-
-export type BuildInfo = {
-    name: string;
-    notes: string;
-    credits: string;
-    pokemon: Raider[],
-    turns: RaidTurnInfo[],
-    groups: number[][],
-}
-
-// used for passing data to React components
-export type RaidInputProps = {
-    pokemon: Raider[],
-    setPokemon: ((r: Raider) => void)[],
-    turns: RaidTurnInfo[],
-    setTurns: (t: RaidTurnInfo[]) => void,
-    groups: number[][],
-    setGroups: (g: number[][]) => void,
-  }

--- a/src/raidcalc/util.ts
+++ b/src/raidcalc/util.ts
@@ -1,0 +1,87 @@
+import { Move, Field, Pokemon, Generations } from "../calc";
+import { AilmentName } from "./interface";
+import { Raider } from "./Raider";
+import { StatusName } from "../calc/data/interface";
+import { getMoveEffectiveness, isGrounded } from "../calc/mechanics/util";
+
+const gen = Generations.get(9);
+
+// next time I prepare the move data, I should eliminate the need for translation
+export function ailmentToStatus(ailment: AilmentName): StatusName | "" {
+    if (ailment == "paralysis") { return "par"; }
+    if (ailment == "poison") { return "psn"; }
+    if (ailment == "burn") { return "brn"; }
+    if (ailment == "freeze") { return "frz"; }
+    if (ailment == "sleep") { return "slp"; }
+    if (ailment == "toxic") { return "tox"; }
+    return ""
+}
+
+export function hasNoStatus(pokemon: Pokemon) {
+    return pokemon.status === "" || pokemon.status === undefined;
+}
+
+// See ../calc/mechanics/util.ts for the original
+export function isSuperEffective(move: Move, field: Field, attacker: Pokemon, defender: Pokemon) {
+    const isGhostRevealed =
+    attacker.hasAbility('Scrappy') || field.defenderSide.isForesight;
+    const isRingTarget =
+      defender.hasItem('Ring Target') && !defender.hasAbility('Klutz');
+    const type1Effectiveness = getMoveEffectiveness(
+      gen,
+      move,
+      defender.types[0],
+      isGhostRevealed,
+      field.isGravity,
+      isRingTarget
+    );
+    const type2Effectiveness = defender.types[1]
+      ? getMoveEffectiveness(
+        gen,
+        move,
+        defender.types[1],
+        isGhostRevealed,
+        field.isGravity,
+        isRingTarget
+      )
+      : 1;
+    let typeEffectiveness = type1Effectiveness * type2Effectiveness;
+  
+    if (defender.teraType) {
+      typeEffectiveness = getMoveEffectiveness(
+        gen,
+        move,
+        defender.teraType,
+        isGhostRevealed,
+        field.isGravity,
+        isRingTarget
+      );
+    }
+  
+    if (typeEffectiveness === 0 && move.hasType('Ground') &&
+      defender.hasItem('Iron Ball') && !defender.hasAbility('Klutz')) {
+      typeEffectiveness = 1;
+    }
+  
+    if (typeEffectiveness === 0 && move.named('Thousand Arrows')) {
+      typeEffectiveness = 1;
+    }
+    return typeEffectiveness >= 2;
+}
+
+export function pokemonIsGrounded(pokemon: Raider, field: Field) {
+    let grounded = isGrounded(pokemon, field);
+    if (pokemon.lastMove) { grounded = grounded || pokemon.lastMove.name === "Roost"; }
+    // TO DO: Ingrain, Smack Down
+    return grounded;
+}
+
+export function getBoostCoefficient(pokemon: Pokemon) {
+    const hasSimple = pokemon.ability === "Simple";
+    const hasContrary = pokemon.ability === "Contrary";
+    return hasSimple ? 2 : hasContrary ? -1 : 1;
+}
+
+export function safeStatStage(value: number) {
+    return Math.max(-6, Math.min(6, value));
+}

--- a/src/raidcalc/util.ts
+++ b/src/raidcalc/util.ts
@@ -1,7 +1,7 @@
 import { Move, Field, Pokemon, Generations } from "../calc";
 import { AilmentName } from "./interface";
 import { Raider } from "./Raider";
-import { StatusName } from "../calc/data/interface";
+import { StatusName, AbilityName, ItemName, StatIDExceptHP } from "../calc/data/interface";
 import { getMoveEffectiveness, isGrounded } from "../calc/mechanics/util";
 
 const gen = Generations.get(9);
@@ -84,4 +84,65 @@ export function getBoostCoefficient(pokemon: Pokemon) {
 
 export function safeStatStage(value: number) {
     return Math.max(-6, Math.min(6, value));
+}
+
+// Speed modifiers
+
+export function modifyPokemonSpeedByStatus(speed: number, status?: string, ability?: AbilityName) {
+    return status === "par" && ability !== "Quick Feet" ? speed * .5 : speed;
+}
+
+export function modifyPokemonSpeedByItem(speed : number, item?: ItemName) {
+    switch(item) {
+        case "Choice Scarf":
+            return speed * 1.5;
+        case "Iron Ball":
+        case "Macho Brace":
+        case "Power Anklet":
+        case "Power Band":
+        case "Power Belt":
+        case "Power Bracer":
+        case "Power Lens":
+        case "Power Weight":
+            return speed * .5;
+        case "Lagging Tail":
+        case "Full Incense":
+            return 0;
+        // TODO: Quick Powder doubles the speed of untransformed Ditto
+        default:
+            return speed;
+    }
+}
+
+export function modifyPokemonSpeedByAbility(speed: number, ability?: AbilityName, abilityOn?: boolean, status?: string) {
+    switch(ability) {
+        case "Unburden":
+            return abilityOn ? speed * 2 : speed;
+        case "Slow Start":
+            return abilityOn ? speed * .5 : speed;
+        case "Quick Feet":
+            return status ? speed * 1.5 : speed;
+        default:
+            return speed;
+    }
+}
+
+export function modifyPokemonSpeedByQP(speed: number, field: Field, ability?: AbilityName, item?: ItemName, qpBoostedStat?: StatIDExceptHP) {
+    return qpBoostedStat === "spe" ? speed * 1.5 : speed;
+}
+
+export function modifyPokemonSpeedByField(speed: number, field: Field, ability?: AbilityName) {
+    if (
+        ability === "Chlorophyll" && field.weather?.includes("Sun") ||
+        ability === "Sand Rush" && field.weather?.includes("Sand") ||
+        ability === "Slush Rush" && field.weather?.includes("Snow") ||
+        ability === "Swift Swim" && field.weather?.includes("Rain") ||
+        ability === "Surge Surfer" && field.terrain?.includes("Electric")
+    ) {
+        speed *= 2;
+    }
+    if (field.attackerSide.isTailwind) {
+        speed *= 2;
+    }
+    return speed;
 }

--- a/src/raidcalc/util.ts
+++ b/src/raidcalc/util.ts
@@ -23,6 +23,7 @@ export function hasNoStatus(pokemon: Pokemon) {
 
 // See ../calc/mechanics/util.ts for the original
 export function isSuperEffective(move: Move, field: Field, attacker: Pokemon, defender: Pokemon) {
+    if (!move.type) {return false; }
     const isGhostRevealed =
     attacker.hasAbility('Scrappy') || field.defenderSide.isForesight;
     const isRingTarget =

--- a/src/services/getdata.ts
+++ b/src/services/getdata.ts
@@ -17,7 +17,10 @@ export type PokemonData = {
 
 export namespace PokedexService {
 
-    export async function getMoveByName(name: string) {
+    export async function getMoveByName(name: string): Promise<MoveData | undefined> {
+        if (["(No Move)", "Attack Cheer", "Defense Cheer", "Heal Cheer"].includes(name)) {
+            return {name: name as MoveName}
+        }
         try {
             const preppedName = prepareFileName(name);
             let response = await fetch(assetsProlog + "moves/" + preppedName + ".json");

--- a/src/uicomponents/BossSummary.tsx
+++ b/src/uicomponents/BossSummary.tsx
@@ -3,8 +3,8 @@ import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Paper from '@mui/material/Paper';
 
-import { Generations, Pokemon } from '../calc';
-import { AbilityName, Generation } from "../calc/data/interface";
+import { Generations } from '../calc';
+import { AbilityName } from "../calc/data/interface";
 import { toID } from '../calc/util';
 
 import BuildControls, { BossBuildControlsMemo } from "./BuildControls";
@@ -13,7 +13,8 @@ import { RoleField } from "./PokemonSummary";
 import PokedexService, { PokemonData } from '../services/getdata';
 import { getItemSpriteURL, getPokemonArtURL, getTypeIconURL, getTeraTypeIconURL, arraysEqual } from "../utils";
 import StatRadarPlot from "./StatRadarPlot";
-import { MoveSetItem, Raider } from "../raidcalc/interface";
+import { MoveSetItem } from "../raidcalc/interface";
+import { Raider } from "../raidcalc/Raider";
 
 const gen = Generations.get(9); // we only use gen 9
 

--- a/src/uicomponents/BuildControls.tsx
+++ b/src/uicomponents/BuildControls.tsx
@@ -25,7 +25,8 @@ import { toID } from '../calc/util';
 import StatsControls from "./StatsControls";
 import ImportExportArea from "./ImportExportArea";
 
-import { MoveData, MoveSetItem, Raider } from "../raidcalc/interface";
+import { MoveData, MoveSetItem } from "../raidcalc/interface";
+import { Raider } from "../raidcalc/Raider";
 import PokedexService from "../services/getdata";
 import { getItemSpriteURL, getMoveMethodIconURL, getPokemonSpriteURL, getTeraTypeIconURL, getTypeIconURL, getAilmentReadableName, getLearnMethodReadableName, arraysEqual } from "../utils";
 
@@ -623,6 +624,7 @@ function BuildControls({pokemon, abilities, moveSet, setPokemon, prettyMode}:
             setPokemon(new Raider(
                 newPokemon.id, 
                 newPokemon.role, 
+                newPokemon.field,
                 new Pokemon(gen, newPokemon.name, {
                     level: newPokemon.level,
                     ability: newPokemon.ability,
@@ -640,7 +642,7 @@ function BuildControls({pokemon, abilities, moveSet, setPokemon, prettyMode}:
     }
 
     const handleChangeSpecies = (val: string) => {
-        setPokemon(new Raider(pokemon.id, pokemon.role, new Pokemon(gen, val, {nature: "Hardy", ability: "(No Ability)"})))
+        setPokemon(new Raider(pokemon.id, pokemon.role, pokemon.field, new Pokemon(gen, val, {nature: "Hardy", ability: "(No Ability)"})))
     }
 
     return (
@@ -778,7 +780,7 @@ function BossBuildControls({moveSet, pokemon, setPokemon, prettyMode}:
         if (val < 1) val = 1;
         const newPokemon = {...pokemon};
         newPokemon.bossMultiplier = val;
-        setPokemon(new Raider(pokemon.id, pokemon.role,
+        setPokemon(new Raider(pokemon.id, pokemon.role, pokemon.field,
             new Pokemon(gen, newPokemon.name, {
                 level: newPokemon.level,
                 ability: newPokemon.ability,

--- a/src/uicomponents/ImportExportArea.tsx
+++ b/src/uicomponents/ImportExportArea.tsx
@@ -7,8 +7,8 @@ import OutputIcon from '@mui/icons-material/Output';
 import TextField from '@mui/material/TextField';
 
 import { Pokemon, Stats, SPECIES, ABILITIES, TYPE_CHART, StatsTable, ITEMS } from "../calc";
-import { AbilityName, ItemName, MoveName, NatureName, SpeciesName, TypeName, Generation } from "../calc/data/interface";
-import { Raider } from "../raidcalc/interface";
+import { AbilityName, ItemName, MoveName, NatureName, SpeciesName, TypeName } from "../calc/data/interface";
+import { Raider } from "../raidcalc/Raider";
 
 function serialize(array: string[], separator: String) {
 	var text = "";
@@ -331,7 +331,7 @@ function ImportExportArea({pokemon, setPokemon}: { pokemon: Raider, setPokemon: 
 						onClick={() => {
 							const newPoke = addSet(textValue)
 							if (newPoke) {
-								const newRaider = new Raider(pokemon.id, pokemon.role, newPoke)
+								const newRaider = new Raider(pokemon.id, pokemon.role, pokemon.field, newPoke)
 								setPokemon(newRaider)
 							}
 						}}

--- a/src/uicomponents/LinkButton.tsx
+++ b/src/uicomponents/LinkButton.tsx
@@ -6,8 +6,12 @@ import Button from "@mui/material/Button";
 
 import { Pokemon, Generations, Field } from "../calc";
 import { MoveName, TypeName } from "../calc/data/interface";
-import { RaidBattleInfo, Raider, RaidState, BuildInfo, RaidTurnInfo, RaidInputProps } from "../raidcalc/interface";
+import { RaidInputProps, BuildInfo } from "../raidcalc/inputs";
 import { LightBuildInfo, LightPokemon, LightTurnInfo } from "../raidcalc/hashData";
+import { Raider } from "../raidcalc/Raider";
+import { RaidState } from "../raidcalc/RaidState";
+import { RaidBattleInfo } from "../raidcalc/RaidBattle";
+
 
 const gen = Generations.get(9);
 
@@ -22,7 +26,7 @@ function deserializeInfo(hash: string): BuildInfo | null {
 
 function lightToFullBuildInfo(obj: LightBuildInfo): BuildInfo | null {
     try {
-        const pokemon = (obj.pokemon as LightPokemon[]).map((r) => new Raider(r.id, r.role, 
+        const pokemon = (obj.pokemon as LightPokemon[]).map((r) => new Raider(r.id, r.role, new Field(), 
             new Pokemon(gen, r.name, {
                 ability: r.ability || undefined,
                 item: r.item || undefined,
@@ -146,7 +150,7 @@ function LinkButton({title, notes, credits, raidInputProps, setTitle, setNotes, 
             }
             if (res) {
                 const {name, notes, credits, pokemon, turns, groups} = res;
-                const startingState = new RaidState(pokemon, pokemon.map((r) => new Field()));
+                const startingState = new RaidState(pokemon);
                 // setInfo({
                 //     name: name,
                 //     notes: notes,
@@ -187,7 +191,7 @@ function LinkButton({title, notes, credits, raidInputProps, setTitle, setNotes, 
                     name: title,
                     notes: notes,
                     credits: credits,
-                    startingState: new RaidState(raidInputProps.pokemon, [new Field(), new Field(), new Field(), new Field(), new Field()]),
+                    startingState: new RaidState(raidInputProps.pokemon),
                     turns: raidInputProps.turns,
                     groups: raidInputProps.groups,
                 });

--- a/src/uicomponents/MoveDisplay.tsx
+++ b/src/uicomponents/MoveDisplay.tsx
@@ -3,13 +3,13 @@ import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import Paper from "@mui/material/Paper";
-import { RaidBattleInfo, RaidTurnInfo, Raider } from "../raidcalc/interface";
+import { RaidTurnInfo, Raider } from "../raidcalc/interface";
 import { getPokemonSpriteURL } from "../utils";
 
 function MoveText({raiders, turn}: {raiders: Raider[], turn: RaidTurnInfo}) {
 
-    const name = raiders[turn.moveInfo.userID].name;
-    const user = raiders[turn.moveInfo.userID].role;
+    let name = raiders[turn.moveInfo.userID].name;
+    let user = raiders[turn.moveInfo.userID].role;
 
     let target = raiders[turn.moveInfo.targetID].role;
     if (target === user) { 
@@ -18,13 +18,30 @@ function MoveText({raiders, turn}: {raiders: Raider[], turn: RaidTurnInfo}) {
     if ([undefined, "user", "user-and-allies", "all-allies"].includes(turn.moveInfo.moveData.target)) {
         target = "";
     }
-    const targetName = raiders[turn.moveInfo.targetID].name;
+    let targetName = raiders[turn.moveInfo.targetID].name;
 
     let move: string = turn.moveInfo.moveData.name;
     if (move == "(No Move)") {
         move = "";
     }
 
+    if (move === "") {
+        name = raiders[0].name;
+        user = raiders[0].role;
+        target = raiders[turn.bossMoveInfo.targetID].role;
+        if (target === user) { 
+            target = ""
+        }
+        if ([undefined, "user", "user-and-allies", "all-allies"].includes(turn.moveInfo.moveData.target)) {
+            target = "";
+        }
+        targetName = raiders[turn.bossMoveInfo.targetID].name;
+        move = turn.bossMoveInfo.moveData.name;
+        if (move == "(No Move)") {
+            move = "";
+        }
+    }
+    console.log(user, move, target)
     return (
         <>
         {move !== "" &&

--- a/src/uicomponents/MoveDisplay.tsx
+++ b/src/uicomponents/MoveDisplay.tsx
@@ -41,7 +41,6 @@ function MoveText({raiders, turn}: {raiders: Raider[], turn: RaidTurnInfo}) {
             move = "";
         }
     }
-    console.log(user, move, target)
     return (
         <>
         {move !== "" &&

--- a/src/uicomponents/MoveSelection.tsx
+++ b/src/uicomponents/MoveSelection.tsx
@@ -22,7 +22,8 @@ import Collapse from '@mui/material/Collapse';
 import { DragDropContext, DropResult, Droppable, Draggable } from "react-beautiful-dnd";
 
 import { MoveName } from "../calc/data/interface";
-import { MoveData, RaidMoveInfo, RaidMoveOptions, RaidInputProps, RaidTurnInfo, Raider } from "../raidcalc/interface";
+import { MoveData, RaidMoveInfo, RaidMoveOptions, RaidTurnInfo, Raider } from "../raidcalc/interface";
+import { RaidInputProps } from "../raidcalc/inputs";
 import PokedexService from "../services/getdata";
 import { getPokemonSpriteURL, arraysEqual } from "../utils";
 

--- a/src/uicomponents/MoveSelection.tsx
+++ b/src/uicomponents/MoveSelection.tsx
@@ -507,6 +507,7 @@ const MoveSelectionCardMemo = React.memo(MoveSelectionCard, (prevProps, nextProp
     prevProps.turns[prevProps.index].bossMoveInfo.options?.secondaryEffects === nextProps.turns[nextProps.index].bossMoveInfo.options?.secondaryEffects &&
     prevProps.turns[prevProps.index].bossMoveInfo.options?.roll === nextProps.turns[nextProps.index].bossMoveInfo.options?.roll &&
     arraysEqual(prevProps.raiders.map((r) => r.name), nextProps.raiders.map((r) => r.name)) &&
+    arraysEqual(prevProps.raiders.map((r) => r.role), nextProps.raiders.map((r) => r.role)) &&
     arraysEqual(prevProps.raiders[prevProps.turns[prevProps.index].moveInfo.userID].moves, nextProps.raiders[nextProps.turns[nextProps.index].moveInfo.userID].moves) &&
     arraysEqual(prevProps.raiders[0].moves, nextProps.raiders[0].moves) &&  
     arraysEqual(prevProps.raiders[0].extraMoves!, nextProps.raiders[0].extraMoves!) &&

--- a/src/uicomponents/PokemonSummary.tsx
+++ b/src/uicomponents/PokemonSummary.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Paper from '@mui/material/Paper';
@@ -20,17 +20,22 @@ const gen = Generations.get(9); // we will only use gen 9
 
 export function RoleField({pokemon, setPokemon}: {pokemon: Raider, setPokemon: (r: Raider) => void}) {
     const [str, setStr] = useState(pokemon.role);
+    const roleRef = useRef(pokemon.role);
+    const nameRef = useRef(pokemon.name);
 
     useEffect(() => {
-        if (pokemon.role !== str) {
-            setStr(pokemon.role);
+        if (roleRef.current !== pokemon.role) {
+            roleRef.current = pokemon.role;
+            if (pokemon.role !== str) {
+                setStr(pokemon.role);
+            }
+        } else if (nameRef.current !== pokemon.name) {
+            nameRef.current = pokemon.name;
+            const name = pokemon.name.split("-")[0]; // some regional forms have long names
+            setRole(name);
+            setStr(name);
         }
-    }, [pokemon.role])
-
-    useEffect(() => {
-        const name = pokemon.name.split("-")[0]; // some regional forms have long names
-        setRole(name);
-    }, [pokemon.name])
+    }, [pokemon.role, pokemon.name])
 
     const setRole = (r: string) => {
         const newPoke = pokemon.clone();

--- a/src/uicomponents/PokemonSummary.tsx
+++ b/src/uicomponents/PokemonSummary.tsx
@@ -4,7 +4,7 @@ import Stack from '@mui/material/Stack';
 import Paper from '@mui/material/Paper';
 import TextField from '@mui/material/TextField';
 
-import { Generations, Pokemon } from '../calc';
+import { Generations } from '../calc';
 import { toID } from '../calc/util';
 
 import StatRadarPlot from "./StatRadarPlot";
@@ -12,7 +12,8 @@ import BuildControls from "./BuildControls";
 
 import PokedexService, { PokemonData } from '../services/getdata';
 import { getItemSpriteURL, getPokemonArtURL, getTypeIconURL, getTeraTypeIconURL } from "../utils";
-import { MoveSetItem, Raider } from "../raidcalc/interface";
+import { MoveSetItem } from "../raidcalc/interface";
+import { Raider } from "../raidcalc/Raider";
 import { AbilityName } from "../calc/data/interface";
 
 const gen = Generations.get(9); // we will only use gen 9

--- a/src/uicomponents/RaidControls.tsx
+++ b/src/uicomponents/RaidControls.tsx
@@ -7,7 +7,8 @@ import Tab from '@mui/material/Tab';
 import MoveSelection from "./MoveSelection";
 import RaidResults from "./RaidResults";
 import MoveDisplay from './MoveDisplay';
-import { RaidBattleInfo, RaidBattleResults, RaidInputProps } from "../raidcalc/interface";
+import { RaidInputProps } from "../raidcalc/inputs";
+import { RaidBattleResults } from "../raidcalc/RaidBattle";
 
 
 const raidcalcWorker = new Worker(new URL("../workers/raidcalc.worker.ts", import.meta.url));

--- a/src/uicomponents/RaidResults.tsx
+++ b/src/uicomponents/RaidResults.tsx
@@ -2,9 +2,12 @@ import React from "react"
 import Box from "@mui/material/Box"
 import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography"
-
-import { RaidState, RaidBattleResults, RaidTurnResult, RaidMoveResult } from "../raidcalc/interface"
 import ButtonBase from "@mui/material/ButtonBase"
+
+import { RaidState } from "../raidcalc/interface"
+import { RaidBattleResults } from "../raidcalc/RaidBattle"
+import { RaidTurnResult } from "../raidcalc/RaidTurn"
+import { RaidMoveResult } from "../raidcalc/RaidMove"
 
 function CopyTextButton({text}: {text: string}) {
     return (

--- a/src/uicomponents/StatsControls.tsx
+++ b/src/uicomponents/StatsControls.tsx
@@ -13,8 +13,7 @@ import MuiInput from '@mui/material/Input';
 import { styled } from '@mui/material/styles';
 
 import { Generations, Pokemon } from "../calc";
-import { Raider } from "../raidcalc/interface";
-import { Generation } from "../calc/data/interface";
+import { Raider } from "../raidcalc/Raider";
 
 const gen = Generations.get(9); // we will only use gen 9
 
@@ -131,7 +130,7 @@ function StatsControls({ pokemon, setPokemon}: { pokemon: Raider, setPokemon: (r
             const newEVs = {...pokemon.evs};
             //@ts-ignore
             newEVs[evName] = safeValue;
-            setPokemon(new Raider(pokemon.id, pokemon.role, 
+            setPokemon(new Raider(pokemon.id, pokemon.role, pokemon.field,
                 new Pokemon(gen, pokemon.name, {
                     level: pokemon.level,
                     ability: pokemon.ability,
@@ -156,7 +155,7 @@ function StatsControls({ pokemon, setPokemon}: { pokemon: Raider, setPokemon: (r
             const newIVs = {...pokemon.ivs};
             //@ts-ignore
             newIVs[ivName] = safeValue;
-            setPokemon(new Raider(pokemon.id, pokemon.role, 
+            setPokemon(new Raider(pokemon.id, pokemon.role, pokemon.field,
                 new Pokemon(gen, pokemon.name, {
                     level: pokemon.level,
                     ability: pokemon.ability,

--- a/src/workers/raidcalc.worker.ts
+++ b/src/workers/raidcalc.worker.ts
@@ -1,6 +1,7 @@
-import { RaidBattle } from "../raidcalc/RaidBattle";
-import { RaidBattleInfo, RaidTurnInfo, Raider } from "../raidcalc/interface";
-import { RaidState } from "../raidcalc/interface";
+import { RaidBattle, RaidBattleInfo } from "../raidcalc/RaidBattle";
+import { RaidTurnInfo } from "../raidcalc/interface";
+import { RaidState } from "../raidcalc/RaidState";
+import { Raider } from "../raidcalc/Raider";
 import { Field, Pokemon, Generations } from "../calc";
 
 declare var self: DedicatedWorkerGlobalScope;
@@ -10,7 +11,7 @@ const gen = Generations.get(9);
 
 self.onmessage = (event: MessageEvent<{raiders: Raider[], turns: RaidTurnInfo[]}>) => {
     const raidersMessage = event.data.raiders;
-    const raiders = raidersMessage.map((r) => new Raider(r.id, r.role, new Pokemon(gen, r.name, {
+    const raiders = raidersMessage.map((r) => new Raider(r.id, r.role, new Field(), new Pokemon(gen, r.name, {
         level: r.level,
         bossMultiplier: r.bossMultiplier,
         ability: r.ability,
@@ -22,9 +23,7 @@ self.onmessage = (event: MessageEvent<{raiders: Raider[], turns: RaidTurnInfo[]}
         moves: r.moves,
     }), r.extraMoves))
 
-    const fields = raiders.map((r) => new Field());
-
-    const state = new RaidState(raiders, fields);
+    const state = new RaidState(raiders);
     const info: RaidBattleInfo = {
         startingState: state,
         turns: event.data.turns,


### PR DESCRIPTION
I've moved a lot of the checks for item/ability activation to the `RaidState` class and tried to set things up so that things will be activated when trigger conditions are met (e.g. taking damage, terrain change, applying a stat boost) regardless of when it happens during a move/turn.

I've tested a few of our more recent tricky test cases, as well as previous ERS strats, and things seem to be working.

I've also added Opportunist, Acupressure (sort of), and some more abilities that are activated by taking a hit from an opponent

Other things that I've included here:
- fixed issues with role names being loaded from the URL hash
- make sure MoveData is loaded before running the calc for strats from the URL hash
- better display in Pretty Mode for boss-only moves