### PR TITLE
fetch movedata when hash is loaded

### DIFF
--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -197,7 +197,6 @@ export class RaidState implements State.RaidState{
                             isPositiveBoost = true;
                         }
                     }
-                    console.log(positiveDiff, isPositiveBoost)
                     if (isPositiveBoost) {
                         this.applyStatChange(opponentId, positiveDiff, false);
                         if (opponent.item === "Mirror Herb") { this.loseItem(opponentId); }

--- a/src/services/getdata.ts
+++ b/src/services/getdata.ts
@@ -17,7 +17,10 @@ export type PokemonData = {
 
 export namespace PokedexService {
 
-    export async function getMoveByName(name: string) {
+    export async function getMoveByName(name: string): Promise<MoveData | undefined> {
+        if (["(No Move)", "Attack Cheer", "Defense Cheer", "Heal Cheer"].includes(name)) {
+            return {name: name as MoveName}
+        }
         try {
             const preppedName = prepareFileName(name);
             let response = await fetch(assetsProlog + "moves/" + preppedName + ".json");


### PR DESCRIPTION
Ensure that a move's MoveData has been fetched when a strategy is loaded from the URL hash. This will prevent the need to toggle Pretty/Edit mode to see correct calcs