### PR TITLE
add Mew boost for Mewtwo event

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -243,6 +243,11 @@ describe('Specific Test Cases', () => {
     // T6: OHKO
     expect(result.turnResults[5].state.raiders[0].originalCurHP).toEqual(0);
   })
+  test('mew_mewtwo_boost', async() => {
+    const hash = "#H4sIAAAAAAAAA71UbWvbMBD+K0Iw6MDr7KRpS79ly7aUtU0gHYOFfFDsc6xFlowkJ/FK//tOsp26JR86WErC+STf3fPcmx9oSq9o/NsoSQNq6dV8HgZUshzoInAqTxol1tyiiYFYyYTp6kuaQmwNXmklhDOKAloa0NcjF4npFVivqsJyJY2z6AV0pVVZ4G2uNnAtU4XqUhlz2x7rOFJZcKFjDQn3IIVaQ16TLLV0Nz6SadhlLiaza5QJpI5nwbxMvIQGHakCbfJD+yUX3FaocQu5v8fg7g1sHAL3UsAGhMMFze6rAhrypmVeCssLwUE7v53V7Na/XSwCuqFXDxRreh7QW9iS0XSGNhMpKpIqTfrhjoynxGmDHdlym5EPs2JE0NRu1al7EiyiIYz0wndkqZSxxCrChCDGMmsCYhThlphMlSIhiSIgVbnKSMJytgJnuyqZZtICHjIgk/H3ySlSKD/iaWisVt+UzWgw9ywvg9DzRHDaUX5ICXqDactSCLxXCRicBO9ygS773+KxvexHL/74KgrDOsKcTk2F2HztSjnLWKK25BMmhadhqRmZFRn4LqBdnPEYe9cP0Xu+aBEug8gTpK2cVTLOtJL8j/P7CWwtwRgyVYLHrr8HSfcGvVq+mvgdM7YiU6HcJoxhh8yiF8RwyCZY8VWpS/pMnVX5kivD3dzc8BSboZcuCtNJtSdWU/rXel5LLGcZ2wN0+gi8LqVl0q1GRz25U2RYz/97PP5SKic34Bdrxow5RMlrryZ1r3bYOlcmUXC5ImMmkwMEz3DA8qUGv9pP2gt6N5Ba3Cr9/+h9ZWsg98C06ZBaNJsw8AG9ivy6XY/a+36QMmGgkTTnkqL/497p5NZt68gtImaPOYTo23his6AWNGc779d6DoJeB/lZ7bCX0ZGx+x3sToGwScfOOuogD61l8Zp8zsB9U3uIflzs89YOgzRT2z96whcd0Lct9aCDvP9yvEGZz+rVe5rt3THXCVd57lYJlwbVC2zyYIEb/vgX7e0lCfEIAAA=";
+    const strategy = deserialize(hash) as LightBuildInfo;
+    await testOHKO(strategy);
+  })
 })
 
 // Test cases for OHKO strats

--- a/src/calc/pokemon.ts
+++ b/src/calc/pokemon.ts
@@ -17,6 +17,7 @@ export class Pokemon implements State.Pokemon {
 
   level: number;
   bossMultiplier: number;
+  statMultipliers: I.StatsTable;
   gender?: I.GenderName;
   ability?: I.AbilityName;
   abilityOn?: boolean;
@@ -55,6 +56,7 @@ export class Pokemon implements State.Pokemon {
       ivs?: Partial<I.StatsTable> & {spc?: number};
       evs?: Partial<I.StatsTable> & {spc?: number};
       boosts?: Partial<I.StatsTable> & {spc?: number};
+      statMultipliers?: Partial<I.StatsTable> & {spc?: number};
     } = {}
   ) {
     this.species = extend(true, {}, gen.species.get(toID(name)), options.overrides);
@@ -66,6 +68,8 @@ export class Pokemon implements State.Pokemon {
 
     this.level = options.level || 100;
     this.bossMultiplier = options.bossMultiplier || 100;
+    this.statMultipliers = Pokemon.withDefault(gen, options.statMultipliers, 1);
+
     this.gender = options.gender || this.species.gender || 'M';
     this.ability = options.ability || this.species.abilities?.[0] || undefined;
     this.abilityOn = !!options.abilityOn;
@@ -173,6 +177,7 @@ export class Pokemon implements State.Pokemon {
     return new Pokemon(this.gen, this.name, {
       level: this.level,
       bossMultiplier: this.bossMultiplier,
+      statMultipliers: this.statMultipliers,
       ability: this.ability,
       abilityOn: this.abilityOn,
       isDynamaxed: this.isDynamaxed,
@@ -201,7 +206,7 @@ export class Pokemon implements State.Pokemon {
   }
 
   private calcStat(gen: I.Generation, stat: I.StatID) {
-    return Stats.calcStat(
+    return Math.floor(this.statMultipliers[stat] * Stats.calcStat(
       gen,
       stat,
       this.species.baseStats[stat],
@@ -209,7 +214,7 @@ export class Pokemon implements State.Pokemon {
       this.evs[stat]!,
       this.level,
       this.nature
-    );
+    ));
   }
 
   static getForme(

--- a/src/calc/state.ts
+++ b/src/calc/state.ts
@@ -5,6 +5,7 @@ export namespace State {
     name: I.SpeciesName;
     level?: number;
     bossMultiplier?: number;
+    statMultipliers?: I.StatsTable;
     ability?: I.AbilityName;
     abilityOn?: boolean;
     isDynamaxed?: boolean;

--- a/src/raidcalc/RaidBattle.ts
+++ b/src/raidcalc/RaidBattle.ts
@@ -1,10 +1,11 @@
-import { Move, Generations } from "../calc";
-import { MoveName, ItemName } from "../calc/data/interface";
+import { Move, Generations, Pokemon } from "../calc";
+import { MoveName, ItemName, SpeciesName } from "../calc/data/interface";
 import { RaidTurnInfo } from "./interface";
 import { RaidState } from "./RaidState";
 import { RaidMove } from "./RaidMove";
 import { getBoostCoefficient, safeStatStage } from "./util";
 import { RaidTurn, RaidTurnResult } from "./RaidTurn";
+import { Raider } from "./Raider";
 
 const gen = Generations.get(9);
 
@@ -220,6 +221,38 @@ export class RaidBattle {
                 this._turnZeroFlags[0].push("Def: " + origDef + "->" + pokemon.boosts.def + " (Dauntless Shield)");
             } else {
                 // 
+            }
+            /// special interactions
+            // Mew stat boosts for Mewtwo event.
+            if (id !== 0 && pokemon.name === "Mew" && this._state.raiders[0].name === "Mewtwo") {
+                console.log(pokemon.stats)
+                this._state.raiders[id] = new Raider(
+                    id,
+                    pokemon.role,
+                    pokemon.field.clone(),
+                    new Pokemon(
+                        gen,
+                        pokemon.name as SpeciesName,
+                        {
+                            ...pokemon,
+                            statMultipliers: {
+                                hp: 1.5,
+                                atk: 1.2,
+                                def: 1.2,
+                                spa: 1.2,
+                                spd: 1.2,
+                                spe: 1.2,
+                            }
+                        }
+                    ),
+                    [...pokemon.moveData],
+                    [...(pokemon.extraMoves || [])],
+                    [...(pokemon.extraMoveData || [])],
+
+                );
+                this._state.raiders[id].originalCurHP = this._state.raiders[id].maxHP();
+                this._turnZeroFlags[id].push(pokemon.role + " is going to go all out against this formidable opponent!")
+                console.log(id, this._state.raiders[id].stats);
             }
         }
         // check for item/ability activation by executing dummy moves

--- a/src/raidcalc/Raider.ts
+++ b/src/raidcalc/Raider.ts
@@ -40,6 +40,7 @@ export class Raider extends Pokemon implements State.Raider {
             new Pokemon(this.gen, this.name, {
                 level: this.level,
                 bossMultiplier: this.bossMultiplier,
+                statMultipliers: this.statMultipliers,
                 ability: this.ability,
                 abilityOn: this.abilityOn,
                 isDynamaxed: this.isDynamaxed,


### PR DESCRIPTION
Boosts Mew's stats when the raid boss is Mewtwo:
- 50% HP boost
- 20% boost for all other stats