### PR TITLE
Graphic Header Tweaks

### DIFF
--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -119,7 +119,7 @@ const BossTera = styled("img")({
     position: "absolute",
     bottom: "0px",
     alignSelf: "center",
-    transform: "translate(0px, -100px)"
+    transform: "translate(0px, -50px)"
 });
 
 const Title = styled(Typography)({

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -493,7 +493,7 @@ function generateGraphic(theme: any, raidInputProps: RaidInputProps, learnMethod
                             <Boss src={getPokemonArtURL(raidInputProps.pokemon[0].species.name, raidInputProps.pokemon[0].shiny)} />
                         </BossWrapper>
                         <Title>{title ? title : "Untitled"}</Title>
-                        <Subtitle>{subtitle ? subtitle : (credits ? `By: ${credits}` : `A Strategy For A ${raidInputProps.pokemon[0].species.name} Tera Raid Battle`)}</Subtitle>
+                        <Subtitle>{subtitle ? subtitle : `A Strategy For A ${raidInputProps.pokemon[0].species.name} Tera Raid Battle`}</Subtitle>
                     </Header>
                     <BuildsSection>
                         <Separator>

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -4,7 +4,7 @@ import Box from '@mui/material/Box';
 
 import { Move } from "../calc";
 import { TypeName } from "../calc/data/interface";
-import { getItemSpriteURL, getPokemonArtURL, getTypeIconURL, getTeraTypeIconURL, getMoveMethodIconURL, getEVDescription, getIVDescription, getPokemonSpriteURL, getMiscImageURL } from "../utils";
+import { getItemSpriteURL, getPokemonArtURL, getTypeIconURL, getTeraTypeIconURL, getMoveMethodIconURL, getEVDescription, getIVDescription, getPokemonSpriteURL, getMiscImageURL, getTeraTypeBannerURL } from "../utils";
 import { RaidMoveInfo } from "../raidcalc/interface";
 import { RaidInputProps } from "../raidcalc/inputs";
 import { PokedexService, PokemonData } from "../services/getdata"
@@ -112,16 +112,14 @@ const Boss = styled("img")({
     height: "100%",
     position: "absolute",
     right: "0px",
-    zIndex: 10002,
 });
 
 const BossTera = styled("img")({
-    width: "70%",
+    width: "100%",
     position: "absolute",
     bottom: "0px",
     alignSelf: "center",
-    zIndex: 10001,
-    transform: "translate(-250px, 0px)"
+    transform: "translate(0px, -100px)"
 });
 
 const Title = styled(Typography)({
@@ -132,14 +130,12 @@ const Title = styled(Typography)({
     fontWeight: "inherit",
     fontSize: "16em",
     margin: "0px",
-    zIndex: 10003,
 });
 
 const Subtitle = styled(Typography)({
     color: "rgba(255, 255, 255, 0.65)",
     fontSize: "8em",
     margin: "0px",
-    zIndex: 10004,
 });
 
 const BuildsSection = styled(Box)({
@@ -489,8 +485,8 @@ function generateGraphic(theme: any, raidInputProps: RaidInputProps, learnMethod
                 >
                     <Header>
                         <BossWrapper>
-                            <BossTera src={getTeraTypeIconURL(raidInputProps.pokemon[0].teraType || "inactive")}></BossTera>
                             <Boss src={getPokemonArtURL(raidInputProps.pokemon[0].species.name, raidInputProps.pokemon[0].shiny)} />
+                            <BossTera src={getTeraTypeBannerURL(raidInputProps.pokemon[0].teraType || "blank")}></BossTera>
                         </BossWrapper>
                         <Title>{title ? title : "Untitled"}</Title>
                         <Subtitle>{subtitle ? subtitle : `A Strategy For A ${raidInputProps.pokemon[0].species.name} Tera Raid Battle`}</Subtitle>

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -99,8 +99,8 @@ const Header = styled(Box)({
 });
 
 const BossWrapper = styled(Box)({
-    height: "450px",
-    width: "450px",
+    height: "550px",
+    width: "550px",
     position: "absolute",
     right: "100px",
     top: "50px",
@@ -111,29 +111,35 @@ const BossWrapper = styled(Box)({
 const Boss = styled("img")({
     height: "100%",
     position: "absolute",
-    right: "0px"
+    right: "0px",
+    zIndex: 10002,
 });
 
 const BossTera = styled("img")({
-    width: "60%",
+    width: "70%",
     position: "absolute",
     bottom: "0px",
-    alignSelf: "center"
+    alignSelf: "center",
+    zIndex: 10001,
+    transform: "translate(-250px, 0px)"
 });
 
 const Title = styled(Typography)({
-    height: "250px",
-    lineHeight: "250px",
+    // height: "250px",
+    // lineHeight: "250px",
+    maxWidth: "2800px",
     color: "white",
     fontWeight: "inherit",
     fontSize: "16em",
     margin: "0px",
+    zIndex: 10003,
 });
 
 const Subtitle = styled(Typography)({
     color: "rgba(255, 255, 255, 0.65)",
     fontSize: "8em",
     margin: "0px",
+    zIndex: 10004,
 });
 
 const BuildsSection = styled(Box)({
@@ -483,9 +489,8 @@ function generateGraphic(theme: any, raidInputProps: RaidInputProps, learnMethod
                 >
                     <Header>
                         <BossWrapper>
-                            {/* <BossTera src={getTeraTypeIconURL(raidInputProps.pokemon[0].teraType || "inactive")}></BossTera> */}
+                            <BossTera src={getTeraTypeIconURL(raidInputProps.pokemon[0].teraType || "inactive")}></BossTera>
                             <Boss src={getPokemonArtURL(raidInputProps.pokemon[0].species.name)} />
-                            {/* Need to figure out how to show the tera type nicely */}
                         </BossWrapper>
                         <Title>{title ? title : "Untitled"}</Title>
                         <Subtitle>{subtitle ? subtitle : (credits ? `By: ${credits}` : `A Strategy For A ${raidInputProps.pokemon[0].species.name} Tera Raid Battle`)}</Subtitle>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,6 +55,7 @@ const pokemonSpriteProlog = "https://raw.githubusercontent.com/theastrogoth/tera
 const itemSpriteProlog = "https://raw.githubusercontent.com/theastrogoth/tera-raid-builder/assets/images/items/";
 const typeIconProlog = "https://raw.githubusercontent.com/theastrogoth/tera-raid-builder/assets/images/type_icons/";
 const teraTypeIconProlog = "https://raw.githubusercontent.com/theastrogoth/tera-raid-builder/assets/images/tera_type_icons/";
+const teraTypeBannerProlog = "https://raw.githubusercontent.com/theastrogoth/tera-raid-builder/assets/images/tera_banners/";
 const methodIconProlog = "https://raw.githubusercontent.com/theastrogoth/tera-raid-builder/assets/images/move_methods/";
 
 // use the Serebii item dex for item sprites
@@ -77,6 +78,10 @@ export function getTypeIconURL(name: string) {
 
 export function getTeraTypeIconURL(name: string) {
     return teraTypeIconProlog + prepareImageAssetName(name) + ".png";
+}
+
+export function getTeraTypeBannerURL(name: string) {
+    return teraTypeBannerProlog + prepareImageAssetName(name) + "_banner_sticker.png";
 }
 
 export function getMoveMethodIconURL(name: string) {


### PR DESCRIPTION
Allow long titles to overflow to the next line.

Add boss tera icon partially overlapped by boss art