### PR TITLE
Allow field effects to wear off

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -163,7 +163,7 @@ describe('Specific Test Cases', () => {
     expect(result.turnResults[4].state.raiders[0].boosts.def).toEqual(-2); // Screech lowers defense
     // T8 Trick Room lets Iron Hands outspeed
     expect(result.turnResults[7].results[0].userID).toEqual(1); // Iron Hands moves first
-    expect(result.turnResults[7].state.raiders[0].field.isTrickRoom).toEqual(true); // Trick Room is up
+    expect(!!result.turnResults[7].state.raiders[0].field.isTrickRoom).toEqual(true); // Trick Room is up
   })
   test('sturdy_oran', async() => {
     const hash = "#H4sIAAAAAAAAA72TS2/bMAzHv4rB0wbokEezFbk16B7dlm5oupPhg2zTiRY9DD3SBkW++yjZTtftNKAwYhAUJfL/E8U8QQNLqH45o4GBh2WeTxhorhAKFl1R905lhacjDiuja26PH5oGK+8oZI2U8dCUQXBob65jJW636JNrWi+MdvHEjMHWmtBSVJkD3ujGkFsa59bDsqujjcdYurJYiyTSmj2qDjJYHSOpkuvpdrEm93uyNTaRs+XJ1slir06oCP396HwppPBH8oRHleJUPO7gISqIZCUeUEZdtPz+2GIP7wbyIL1opUAb8x695eu0WxQMDrB8AurpOwbQf3kKXDJivuOizlZUgjbuhJS8NCZSfLLcuWO2CdRCYDpIyeAL9ZhAU/J7Sj7/itMQnE//+mhrOiGdW2MVpxvkcG2DylbIvdBbErqqrClpUUWClalJU/JI8M08ZF9FtaeuzRdUIicm8+B36ZhRZbAuzsIqyH32s6Wr9hCXjN5uzbcaFXUUXvob6m0dm/3dck0U1sbFZ56C/32xri85bGhEsNoRabxr/gfKrFPaBhvghbs5qlIYJ9xrsZBwR/MvxJzBR2noIaPYszcmwgWDH2LPq128+7P35tZkV90f4O0wZa+oXvSTvmD9XloRy/Bg9ISTLjhnDZcOewtKaKD80znjPI2UMB1SvA3YGVD8MSUMKYthOsaUnI0vOR9f8mI8ySKN0ek3xSUqPqEGAAA=";

--- a/src/calc/field.ts
+++ b/src/calc/field.ts
@@ -63,7 +63,9 @@ export class Field implements State.Field {
     return new Field({
       gameType: this.gameType,
       weather: this.weather,
+      weatherTurnsRemaining: this.weatherTurnsRemaining,
       terrain: this.terrain,
+      terrainTurnsRemaining: this.terrainTurnsRemaining,
       isMagicRoom: this.isMagicRoom,
       isWonderRoom: this.isWonderRoom,
       isGravity: this.isGravity,

--- a/src/calc/field.ts
+++ b/src/calc/field.ts
@@ -4,10 +4,12 @@ import {GameType, Weather, Terrain} from './data/interface';
 export class Field implements State.Field {
   gameType: GameType;
   weather?: Weather;
+  weatherTurnsRemaining?: number;
   terrain?: Terrain;
-  isMagicRoom: boolean;
-  isWonderRoom: boolean;
-  isGravity: boolean;
+  terrainTurnsRemaining?: number;
+  isMagicRoom: number;
+  isWonderRoom: number;
+  isGravity: number;
   isAuraBreak?: boolean;
   isFairyAura?: boolean;
   isDarkAura?: boolean;
@@ -15,7 +17,7 @@ export class Field implements State.Field {
   isSwordOfRuin?: boolean;
   isTabletsOfRuin?: boolean;
   isVesselOfRuin?: boolean;
-  isTrickRoom?: boolean;
+  isTrickRoom: number;
   isCloudNine?: boolean;
   attackerSide: Side;
   defenderSide: Side;
@@ -23,10 +25,12 @@ export class Field implements State.Field {
   constructor(field: Partial<State.Field> = {}) {
     this.gameType = field.gameType || 'Singles';
     this.terrain = field.terrain;
+    this.terrainTurnsRemaining = field.terrainTurnsRemaining;
     this.weather = field.weather;
-    this.isMagicRoom = !!field.isMagicRoom;
-    this.isWonderRoom = !!field.isWonderRoom;
-    this.isGravity = !!field.isGravity;
+    this.weatherTurnsRemaining = field.weatherTurnsRemaining;
+    this.isMagicRoom = field.isMagicRoom || 0;
+    this.isWonderRoom = field.isWonderRoom || 0;
+    this.isGravity = field.isGravity || 0;
     this.isAuraBreak = field.isAuraBreak || false;
     this.isFairyAura = field.isFairyAura || false;
     this.isDarkAura = field.isDarkAura || false;
@@ -34,7 +38,7 @@ export class Field implements State.Field {
     this.isSwordOfRuin = field.isSwordOfRuin || false;
     this.isTabletsOfRuin = field.isTabletsOfRuin || false;
     this.isVesselOfRuin = field.isVesselOfRuin || false;
-    this.isTrickRoom = field.isTrickRoom || false;
+    this.isTrickRoom = field.isTrickRoom || 0;
     this.isCloudNine = field.isCloudNine || false;
 
     this.attackerSide = new Side(field.attackerSide || {});
@@ -86,29 +90,29 @@ export class Side implements State.Side {
   cannonade: boolean;
   volcalith: boolean;
   isSR: boolean;
-  isReflect: boolean;
-  isLightScreen: boolean;
-  isDefCheered: boolean
+  isReflect: number;
+  isLightScreen: number;
+  isDefCheered: number
   isProtected: boolean;
   isWideGuard: boolean;
   isQuickGuard: boolean;
   isSeeded: boolean;
   isForesight: boolean;
-  isTailwind: boolean;
+  isTailwind: number;
   isHelpingHand: boolean;
-  isAtkCheered: boolean;
+  isAtkCheered: number;
   isFlowerGift: boolean;
   isFriendGuard: boolean;
   friendGuards: number;
-  isAuroraVeil: boolean;
+  isAuroraVeil: number;
   isBattery: boolean;
   isPowerSpot: boolean;
   powerSpots: number;
   steelySpirits: number;
   isSwitching?: 'out' | 'in';
   isCharged: boolean;
-  isMist: boolean;
-  isSafeguard: boolean;
+  isMist: number;
+  isSafeguard: number;
   isAromaVeil: boolean;
 
   constructor(side: State.Side = {}) {
@@ -119,29 +123,29 @@ export class Side implements State.Side {
     this.cannonade = !!side.cannonade;
     this.volcalith = !!side.volcalith;
     this.isSR = !!side.isSR;
-    this.isReflect = !!side.isReflect;
-    this.isLightScreen = !!side.isLightScreen;
-    this.isDefCheered = !!side.isDefCheered;
+    this.isReflect = side.isReflect || 0;
+    this.isLightScreen = side.isLightScreen || 0;
+    this.isDefCheered = side.isDefCheered || 0;
     this.isProtected = !!side.isProtected;
     this.isWideGuard = !!side.isWideGuard;
     this.isQuickGuard = !!side.isQuickGuard;
     this.isSeeded = !!side.isSeeded;
     this.isForesight = !!side.isForesight;
-    this.isTailwind = !!side.isTailwind;
+    this.isTailwind = side.isTailwind || 0;
     this.isHelpingHand = !!side.isHelpingHand;
-    this.isAtkCheered = !!side.isAtkCheered;
+    this.isAtkCheered = side.isAtkCheered || 0;
     this.isFlowerGift = !!side.isFlowerGift;
     this.isFriendGuard = !!side.isFriendGuard;
     this.friendGuards = side.friendGuards || 0;
-    this.isAuroraVeil = !!side.isAuroraVeil;
+    this.isAuroraVeil = side.isAuroraVeil || 0;
     this.isBattery = !!side.isBattery;
     this.isPowerSpot = !!side.isPowerSpot;
     this.powerSpots = side.powerSpots || 0;
     this.steelySpirits = side.steelySpirits || 0;
     this.isSwitching = side.isSwitching;
     this.isCharged = !!side.isCharged;
-    this.isMist = !!side.isMist;
-    this.isSafeguard = !!side.isSafeguard;
+    this.isMist = side.isMist || 0;
+    this.isSafeguard = side.isSafeguard || 0;
     this.isAromaVeil = !!side.isAromaVeil;
   }
 

--- a/src/calc/state.ts
+++ b/src/calc/state.ts
@@ -61,10 +61,12 @@ export namespace State {
   export interface Field {
     gameType: I.GameType;
     weather?: I.Weather;
+    weatherTurnsRemaining?: number;
     terrain?: I.Terrain;
-    isMagicRoom?: boolean;
-    isWonderRoom?: boolean;
-    isGravity?: boolean;
+    terrainTurnsRemaining?: number;
+    isMagicRoom?: number;       // # turns remaining
+    isWonderRoom?: number;      // # turns remaining
+    isGravity?: number;         // # turns remaining
     isAuraBreak?: boolean;
     isFairyAura?: boolean;
     isDarkAura?: boolean;
@@ -72,7 +74,7 @@ export namespace State {
     isSwordOfRuin?: boolean;
     isTabletsOfRuin?: boolean;
     isVesselOfRuin?: boolean;
-    isTrickRoom?: boolean;
+    isTrickRoom?: number;       // # turns remaining
     isCloudNine?: boolean;
     attackerSide: Side;
     defenderSide: Side;
@@ -86,29 +88,29 @@ export namespace State {
     cannonade?: boolean;
     volcalith?: boolean;
     isSR?: boolean;
-    isReflect?: boolean;
-    isLightScreen?: boolean;
-    isDefCheered?: boolean;
+    isReflect?: number;         // # turns remaining
+    isLightScreen?: number;     // # turns remaining
+    isDefCheered?: number;      // # turns remaining
     isProtected?: boolean;
     isWideGuard?: boolean;
     isQuickGuard?: boolean;
     isSeeded?: boolean;
     isForesight?: boolean;
-    isTailwind?: boolean;
+    isTailwind?: number;        // # turns remaining
     isHelpingHand?: boolean;
-    isAtkCheered?: boolean;
+    isAtkCheered?: number;      // # turns remaining
     isFlowerGift?: boolean;
     isFriendGuard?: boolean;
     friendGuards?: number;
-    isAuroraVeil?: boolean;
+    isAuroraVeil?: number;      // # turns remaining
     isBattery?: boolean;
     isPowerSpot?: boolean;
     powerSpots?: number;
     steelySpirits?: number;
     isSwitching?: 'out' | 'in';
     isCharged?: boolean;
-    isMist?: boolean;
-    isSafeguard?: boolean;
+    isMist?: number;            // # turns remaining
+    isSafeguard?: number;       // # turns remaining
     isAromaVeil?: boolean;
   }
 }

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -596,15 +596,15 @@ export class RaidMove {
     private applyFieldChanges() {
         /// Whole-Field Effects
         // Weather
-        if (this.move.name === "Rain Dance") { this._raidState.applyWeather("Rain"); }
-        if (this.move.name === "Sunny Day") { this._raidState.applyWeather("Sun"); }
-        if (this.move.name === "Sandstorm") { this._raidState.applyWeather("Sand"); }
-        if (this.move.name === "Snowscape") { this._raidState.applyWeather("Snow"); }
+        if (this.move.name === "Rain Dance") { this._raidState.applyWeather("Rain", this._user.item === "Damp Rock" ? 32 : 20); }
+        if (this.move.name === "Sunny Day") { this._raidState.applyWeather("Sun", this._user.item === "Heat Rock" ? 32 : 20); }
+        if (this.move.name === "Sandstorm") { this._raidState.applyWeather("Sand", this._user.item === "Smooth Rock" ? 32 : 20); }
+        if (this.move.name === "Snowscape") { this._raidState.applyWeather("Snow", this._user.item === "Icy Rock" ? 32 : 20); }
         // Terrain
-        if (this.move.name === "Electric Terrain") { this._raidState.applyTerrain("Electric"); }
-        if (this.move.name === "Grassy Terrain") { this._raidState.applyTerrain("Grassy"); }
-        if (this.move.name === "Misty Terrain") { this._raidState.applyTerrain("Misty"); }
-        if (this.move.name === "Psychic Terrain") { this._raidState.applyTerrain("Psychic"); }
+        if (this.move.name === "Electric Terrain") { this._raidState.applyTerrain("Electric", this._user.item === "Terrain Extender" ? 32 : 20); }
+        if (this.move.name === "Grassy Terrain") { this._raidState.applyTerrain("Grassy", this._user.item === "Terrain Extender" ? 32 : 20); }
+        if (this.move.name === "Misty Terrain") { this._raidState.applyTerrain("Misty", this._user.item === "Terrain Extender" ? 32 : 20); }
+        if (this.move.name === "Psychic Terrain") { this._raidState.applyTerrain("Psychic", this._user.item === "Terrain Extender" ? 32 : 20); }
         // Gravity
         const gravity = this.move.name === "Gravity";
         // Trick Room
@@ -615,10 +615,10 @@ export class RaidMove {
         const wonderroom = this.move.name === "Wonder Room";
         // apply effects
         for (let field of this._fields) {
-            field.isGravity = gravity || field.isGravity;
-            field.isTrickRoom = (trickroom ? !field.isTrickRoom : field.isTrickRoom);
-            field.isMagicRoom = (magicroom ? !field.isMagicRoom : field.isMagicRoom);
-            field.isWonderRoom = (wonderroom ? !field.isWonderRoom : field.isWonderRoom);
+            field.isGravity = (gravity && !field.isGravity) ? 20 : field.isGravity;
+            field.isTrickRoom = trickroom ? (field.isTrickRoom ? 0 : 20) : field.isTrickRoom;
+            field.isMagicRoom = magicroom ? (field.isMagicRoom ? 0 : 20) : field.isMagicRoom;
+            field.isWonderRoom = wonderroom ? (field.isWonderRoom ? 0 : 20) : field.isWonderRoom;
         }
         /// Side Effects
         // Reflect
@@ -641,14 +641,14 @@ export class RaidMove {
         const sideFieldIDs = this.userID === 0 ? [0] : [1,2,3,4];
         for (let id of sideFieldIDs) {
             const field = this._fields[id];
-            field.attackerSide.isReflect = reflect || field.attackerSide.isReflect;
-            field.attackerSide.isLightScreen = lightscreen || field.attackerSide.isLightScreen;
-            field.attackerSide.isAuroraVeil = auroraveil || field.attackerSide.isAuroraVeil;
-            field.attackerSide.isMist = mist || field.attackerSide.isMist;
-            field.attackerSide.isSafeguard = safeguard || field.attackerSide.isSafeguard;
-            field.attackerSide.isTailwind = tailwind || field.attackerSide.isTailwind;
-            field.attackerSide.isAtkCheered = attackcheer || field.attackerSide.isAtkCheered;
-            field.attackerSide.isDefCheered = defensecheer || field.attackerSide.isDefCheered;
+            field.attackerSide.isReflect = (reflect && !field.attackerSide.isReflect) ? (this._user.item === "Light Clay" ? 32 : 20) : field.attackerSide.isReflect;
+            field.attackerSide.isLightScreen = (lightscreen && !field.attackerSide.isLightScreen) ? (this._user.item === "Light Clay" ? 32 : 20) : field.attackerSide.isLightScreen;
+            field.attackerSide.isAuroraVeil = (auroraveil && !field.attackerSide.isAromaVeil) ? (this._user.item === "Light Clay" ? 32 : 20) : field.attackerSide.isAuroraVeil;
+            field.attackerSide.isMist = (mist && !field.attackerSide.isMist) ? 20 : field.attackerSide.isMist;
+            field.attackerSide.isSafeguard = (safeguard && !field.attackerSide.isSafeguard) ? 20 : field.attackerSide.isSafeguard;
+            field.attackerSide.isTailwind = (tailwind && !field.attackerSide.isTailwind) ? 20 : field.attackerSide.isTailwind;
+            field.attackerSide.isAtkCheered = attackcheer ? 12 : field.attackerSide.isAtkCheered;
+            field.attackerSide.isDefCheered = defensecheer ? 12 : field.attackerSide.isDefCheered;
         }
 
         // Helping Hand
@@ -853,14 +853,14 @@ export class RaidMove {
             case "Defog":
                 const targetFields = this.userID === 0 ? this._fields.slice(1) : [this._fields[0]];
                 for (let field of this._fields) {
-                    field.attackerSide.isReflect = false;
-                    field.attackerSide.isLightScreen = false;
-                    field.attackerSide.isSafeguard = false;
-                    field.attackerSide.isMist = false;
+                    field.attackerSide.isReflect = 0;
+                    field.attackerSide.isLightScreen = 0;
+                    field.attackerSide.isSafeguard = 0;
+                    field.attackerSide.isMist = 0;
                     field.terrain = undefined;
                 }
                 for (let field of targetFields) {
-                    field.attackerSide.isAuroraVeil = false;
+                    field.attackerSide.isAuroraVeil = 0;
                 }
                 break;
             case "Clear Smog":

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -677,8 +677,11 @@ export class RaidMove {
                 this._desc[this.targetID] = "The Raid Boss nullified all stat boosts and abilities!"
                 for (let i=1; i<5; i++) {
                     const pokemon = this.getPokemon(i);
-                    pokemon.ability = undefined;
-                    pokemon.abilityNullified = 3;
+                    pokemon.ability = "(None)" as AbilityName;
+                    pokemon.abilityOn = false;
+                    pokemon.abilityNullified = 2;
+                    pokemon.field.attackerSide.isAtkCheered = 0; // clear active cheers
+                    pokemon.field.attackerSide.isDefCheered = 0;
                     for (let stat in pokemon.boosts) {
                         pokemon.boosts[stat as StatIDExceptHP] = Math.min(0, (pokemon.boosts[stat as StatIDExceptHP] || 0));
                     }
@@ -996,7 +999,7 @@ export class RaidMove {
         const finalAbilities = this._raiders.map(p => p.ability);
         for (let i=0; i<5; i++) {
             if (initialAbilities[i] !== finalAbilities[i])  {
-                if (finalAbilities[i] === undefined) {
+                if (finalAbilities[i] === "(None)" || finalAbilities[i] === undefined) {
                     this._flags[i].push(initialAbilities[i] + " nullified")
                 } else {
                     this._flags[i].push("ability changed to " + finalAbilities[i])

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -44,7 +44,7 @@ export class RaidMove {
     _affectedIDs!: number[];
     _fields!: Field[];
 
-    _doesNotEffect!: boolean[];
+    _doesNotAffect!: (string | undefined)[];
     _causesFlinch!: boolean[];
     _blockedBy!: string[];
 
@@ -81,7 +81,7 @@ export class RaidMove {
         this._raidState.raiders[0].checkShield(); // check for shield activation
         this.setAffectedPokemon();
         if (this.flinch) {
-            this._desc[this.userID] = this._user.role + " flinched!";
+            this._desc[this.userID] = this._user.name + " flinched!";
         } else {
             this.setDoesNotEffect();
             this.checkProtection();
@@ -138,7 +138,7 @@ export class RaidMove {
         this._user = this._raiders[this.userID];
 
         // initialize arrays
-        this._doesNotEffect = [false, false, false, false, false];
+        this._doesNotAffect = [undefined, undefined, undefined, undefined, undefined];
         this._causesFlinch = [false, false, false, false, false];
         this._damage = [0,0,0,0,0];
         this._drain = [0,0,0,0,0];
@@ -169,63 +169,62 @@ export class RaidMove {
             const field = pokemon.field;
             // Terrain-based failure
             if (field.hasTerrain("Psychic") && pokemonIsGrounded(pokemon, field) && this.move.priority > 0) {
-                this._doesNotEffect[id] = true;
+                this._doesNotAffect[id] = "blocked by Psychic Terrain";
                 continue;
             }
             // Ability-based immunities
             if (this._user.ability !== "Mold Breaker") {
                 if (pokemon.ability === "Good As Gold" && category === "Status" && targetType !== "user") { 
-                    this._doesNotEffect[id] = true; 
+                    this._doesNotAffect[id] = "does not affect " + pokemon.name + " due to " + pokemon.ability;
                     continue; 
                 }
                 if (["Dry Skin", "Water Absorb"].includes(pokemon.ability || "") && moveType === "Water") { 
-                    this._doesNotEffect[id] = true; 
+                    this._doesNotAffect[id] = "heals " + pokemon.name + " due to " + pokemon.ability; 
                     this._healing[id] = Math.floor(pokemon.maxHP() * 0.25);
                     continue;
                 }
                 if (pokemon.ability === "Volt Absorb" && moveType === "Electric") { 
-                    this._doesNotEffect[id] = true; 
+                    this._doesNotAffect[id] = "heals " + pokemon.name + " due to " + pokemon.ability; 
                     this._healing[id] = Math.floor(pokemon.maxHP() * 0.25);
                     continue;
                 }
                 if (pokemon.ability === "Earth Eater" && moveType === "Ground") {
-                    this._doesNotEffect[id] = true;
+                    this._doesNotAffect[id] = "heals " + pokemon.name + " due to " + pokemon.ability; 
                     this._healing[id] = Math.floor(pokemon.maxHP() * 0.25);
                     continue;
                 }
                 if (pokemon.ability === "Flash Fire" && moveType === "Fire") { 
-                    this._doesNotEffect[id] = true; 
+                    this._doesNotAffect[id] = "boosts " + pokemon.name + " due to " + pokemon.ability; 
                     const boost = {spa: 1};
                     this._raidState.applyStatChange(id, boost);
                     continue;
                 }
                 if (pokemon.ability === "Well-Baked Body") {
-                    this._doesNotEffect[id] = true;
+                    this._doesNotAffect[id] = "boosts " + pokemon.name + " due to " + pokemon.ability; 
                     const boost = {def: 2};
                     this._raidState.applyStatChange(id, boost);
                     continue;
                 }
                 if (pokemon.ability === "Sap Sipper" && moveType === "Grass") {
-                    this._doesNotEffect[id] = true; 
+                    this._doesNotAffect[id] = "boosts " + pokemon.name + " due to " + pokemon.ability; 
                     const boost = {atk: 1};
                     this._raidState.applyStatChange(id, boost);
                     continue;
                 }
                 if (pokemon.ability === "Motor Drive" && moveType === "Electric") {
-                    this._doesNotEffect[id] = true;
+                    this._doesNotAffect[id] = "boosts " + pokemon.name + " due to " + pokemon.ability; 
                     const boost = {spe: 1};
                     this._raidState.applyStatChange(id, boost);
-                    pokemon.boosts.spe = safeStatStage(pokemon.boosts.spe + 1);
                     continue;
                 }
                 if (pokemon.ability === "Storm Drain" && moveType === "Water") {
-                    this._doesNotEffect[id] = true;
+                    this._doesNotAffect[id] = "boosts " + pokemon.name + " due to " + pokemon.ability; 
                     const boost = {spa: 1};
                     this._raidState.applyStatChange(id, boost);
                     continue;
                 }
                 if (pokemon.ability === "Lightning Rod" && moveType === "Electric") {
-                    this._doesNotEffect[id] = true;
+                    this._doesNotAffect[id] = "boosts " + pokemon.name + " due to " + pokemon.ability; 
                     const boost = {spa: 1};
                     this._raidState.applyStatChange(id, boost);
                     continue;
@@ -258,51 +257,51 @@ export class RaidMove {
                         "Zap Cannon"
                     ].includes(moveName)) 
                 {
-                    this._doesNotEffect[id] = true;
+                    this._doesNotAffect[id] = "blocked by Bulletproof";
                     continue;
                 }
                 if (pokemon.ability === "Levitate" && !pokemonIsGrounded(pokemon, field) && moveType === "Ground") { 
-                    this._doesNotEffect[id] = true; 
+                    this._doesNotAffect[id] = "does not affect " + pokemon.name + " due to " + pokemon.ability;
                     continue;
                 }
             }
             // Type-based immunities
             if (category !== "Status" && pokemon.item !== "Ring Target") {
                 if (moveType === "Ground" && !pokemonIsGrounded(pokemon, field)) { 
-                    this._doesNotEffect[id] = true; 
+                    this._doesNotAffect[id] = "does not affect " + pokemon.name;
                     continue;
                 }
                 if (moveType === "Electric" && pokemon.types.includes("Ground")) { 
-                    this._doesNotEffect[id] = true; 
+                    this._doesNotAffect[id] = "does not affect " + pokemon.name; 
                     continue;
                 }
                 if (["Normal", "Fighting"].includes(moveType || "") && pokemon.types.includes("Ghost")) {
-                    this._doesNotEffect[id] = true;
+                    this._doesNotAffect[id] = "does not affect " + pokemon.name;
                     continue;
                 }
                 if (moveType === "Ghost" && pokemon.types.includes("Normal")) {
-                    this._doesNotEffect[id] = true;
+                    this._doesNotAffect[id] = "does not affect " + pokemon.name;
                     continue;
                 }
                 if (moveType === "Dragon" && pokemon.types.includes("Fairy")) {
-                    this._doesNotEffect[id] = true;
+                    this._doesNotAffect[id] = "does not affect " + pokemon.name;
                     continue;
                 }
                 if (moveType === "Psychic" && pokemon.types.includes("Dark")) {
-                    this._doesNotEffect[id] = true;
+                    this._doesNotAffect[id] = "does not affect " + pokemon.name;
                     continue;
                 }
             }
             if (moveName === "Thunder Wave" && pokemon.types.includes("Ground") && pokemon.item !== "Ring Target") {
-                this._doesNotEffect[id] = true;
+                this._doesNotAffect[id] = "does not affect " + pokemon.name;
                 continue;
             }
             if ((moveName.includes("Powder") || moveName.includes("Spore") && moveName !== "Powder Snow") && (pokemon.types.includes("Grass") || pokemon.item === "Safety Goggles")) {
-                this._doesNotEffect[id] = true;
+                this._doesNotAffect[id] = "does not affect " + pokemon.name;
                 continue;
             }
             if (id !== this.userID && this._user.ability === "Prankster" && category === "Status" && pokemon.types.includes("Dark")) {
-                this._doesNotEffect[id] = true;
+                this._doesNotAffect[id] = "does not affect " + pokemon.name;
                 continue;
             }
         }
@@ -311,7 +310,7 @@ export class RaidMove {
     private checkProtection() {
         if (!bypassProtectMoves.includes(this.moveData.name)){
             for (let id of this._affectedIDs) {
-                if (!this._doesNotEffect[id]) {
+                if (!this._doesNotAffect[id]) {
                     const pokemon = this.getPokemon(id);
                     const field = pokemon.field;
                     if (field.attackerSide.isProtected) {
@@ -370,10 +369,10 @@ export class RaidMove {
         }
         let hasCausedDamage = false;
         for (let id of this._affectedIDs) {
-            if (this._doesNotEffect[id]) {
-                this._desc[id] = this.move.name + " does not affect " + this.getPokemon(id).role + "."; // a more specific reason might be helpful
+            if (this._doesNotAffect[id]) {
+                this._desc[id] = this.move.name + " " + this._doesNotAffect[id] + "!";
             } else if (this._blockedBy[id] !== "")  {
-                this._desc[id] = this.move.name + " was blocked by " + this._blockedBy[id] + ".";
+                this._desc[id] = this.move.name + " was blocked by " + this._blockedBy[id] + "!";
             } else {
                 try {
                     const target = this.getPokemon(id);
@@ -463,7 +462,7 @@ export class RaidMove {
     private applyHealing() {
         const healingPercent = this.moveData.healing;
         for (let id of this._affectedIDs) {
-            if (this._doesNotEffect[id] || this._blockedBy[id] !== "") { continue; }
+            if (this._doesNotAffect[id] || this._blockedBy[id] !== "") { continue; }
             const target = this.getPokemon(id);
             const maxHP = target.maxHP();
             if (this.move.name === "Heal Cheer") {
@@ -488,7 +487,7 @@ export class RaidMove {
         if (flinchChance && (this.options.secondaryEffects || flinchChance === 100)) {
             for (let id of this._affectedIDs) {
                 if (id === 0) { continue; }
-                if (this._doesNotEffect[id] || this._blockedBy[id] !== "") { continue; }
+                if (this._doesNotAffect[id] || this._blockedBy[id] !== "") { continue; }
                 const target = this.getPokemon(id);
                 if (target.item === "Covert Cloak" || target.ability === "Shield Dust") { continue; }
                 if (target.ability === "Inner Focus" && this._user.ability !== "Mold Breaker") { continue; }
@@ -506,7 +505,7 @@ export class RaidMove {
         const chance = this.moveData.statChance || 100;
         if (chance && (this.options.secondaryEffects || chance === 100 )) {
             for (let id of affectedIDs) {
-                if (this._doesNotEffect[id] || this._blockedBy[id] !== "") { continue; }
+                if (this._doesNotAffect[id] || this._blockedBy[id] !== "") { continue; }
                 const pokemon = this.getPokemon(id);
                 const field = pokemon.field;
                 if (id !== this.userID && this.moveData.category?.includes("damage") && (pokemon.item === "Covert Cloak" || pokemon.ability === "Shield Dust")) { continue; }
@@ -536,7 +535,7 @@ export class RaidMove {
         const chance = this.moveData.ailmentChance || 100;
         if (ailment && (chance === 100 || this.options.secondaryEffects)) {
             for (let id of this._affectedIDs) {
-                if (this._doesNotEffect[id] || this._blockedBy[id] !== "") { continue; }
+                if (this._doesNotAffect[id] || this._blockedBy[id] !== "") { continue; }
                 const pokemon = this.getPokemon(id);
                 const field = pokemon.field;
                 const status = ailmentToStatus(ailment);
@@ -654,8 +653,8 @@ export class RaidMove {
         // Helping Hand
         const helpinghand = this.move.name === "Helping Hand";
         if (helpinghand) {
-            if (this._doesNotEffect[this.targetID]) {
-                this._desc[this.targetID] = this.move.name + " does not affect " + this.getPokemon(this.targetID).role + "."; // a more specific reason might be helpful
+            if (this._doesNotAffect[this.targetID]) {
+                this._desc[this.targetID] = this.move.name + " " + this._doesNotAffect[this.targetID] + "!";
             } else {
                 this._fields[this.targetID].attackerSide.isHelpingHand = true;
             }
@@ -679,7 +678,7 @@ export class RaidMove {
                     const pokemon = this.getPokemon(i);
                     pokemon.ability = "(None)" as AbilityName;
                     pokemon.abilityOn = false;
-                    pokemon.abilityNullified = 2;
+                    pokemon.abilityNullified = i === this.targetID ? 2 : 1;
                     pokemon.field.attackerSide.isAtkCheered = 0; // clear active cheers
                     pokemon.field.attackerSide.isDefCheered = 0;
                     for (let stat in pokemon.boosts) {
@@ -1042,12 +1041,12 @@ export class RaidMove {
                 const newStat = pokemon.boosts[stat] === undefined ? origStat : pokemon.boosts[stat];
                 const diff = newStat - origStat;
                 if (diff !== 0) {
-                    boostStr.push(stat + " " + (origStat > 0 ? "+" : "") + origStat + " -> " + (newStat > 0 ? "+" : "") + newStat);
+                    boostStr.push(stat + " " + (origStat > 0 ? "+" : "") + origStat + " → " + (newStat > 0 ? "+" : "") + newStat);
                 }
             }
             // acupressure check
             if (pokemon.randomBoosts !== origPokemon.randomBoosts) {
-                boostStr.push("random stat " + (origPokemon.randomBoosts > 0 ? "+" : "") + origPokemon.randomBoosts + " -> " + (pokemon.randomBoosts > 0 ? "+" : "") + pokemon.randomBoosts);
+                boostStr.push("random stat " + (origPokemon.randomBoosts > 0 ? "+" : "") + origPokemon.randomBoosts + " → " + (pokemon.randomBoosts > 0 ? "+" : "") + pokemon.randomBoosts);
             }
             if (boostStr.length > 0) {
                 const displayStr = "Stat changes: (" + boostStr.join(", ") + ")";
@@ -1061,7 +1060,7 @@ export class RaidMove {
             if (initialHP !== finalHP) {
                 const initialPercent = Math.floor(initialHP / this.raidState.raiders[i].maxHP() * 1000)/10;;
                 const finalPercent = Math.floor(finalHP / this._raiders[i].maxHP() * 1000)/10;
-                const hpStr = "HP: " + initialPercent + "% -> " + finalPercent + "%";
+                const hpStr = "HP: " + initialPercent + "% → " + finalPercent + "%";
                 this._flags[i].push(hpStr);
             }
         }

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -715,7 +715,7 @@ export class RaidState implements State.RaidState{
 
             );
             this.raiders[id].originalCurHP = this.raiders[id].maxHP();
-            flags[id].push(pokemon.role + " is going to go all out against this formidable opponent!")
+            flags[id].push(pokemon.name + " is going to go all out against this formidable opponent!")
         }
         return flags;
     }

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -341,16 +341,17 @@ export class RaidState implements State.RaidState{
         }
         // Terrain Seeds
         if (item && item.includes("Seed")) {
-            this.applyTerrain(pokemon.field.terrain, [id]);
+            this.applyTerrain(pokemon.field.terrain, pokemon.field.terrainTurnsRemaining, [id]);
         }
         // Berries consumed immediately upon reciept (via Symbiosis, Trick, etc) if their conditions are met
         this.applyDamage(id, 0, 0);
     }
 
-    public applyTerrain(terrain: Terrain | undefined, ids: number[] = [0,1,2,3,4]) {
+    public applyTerrain(terrain: Terrain | undefined, turns: number = 20, ids: number[] = [0,1,2,3,4]) {
         for (let id of ids) {
             const pokemon = this.getPokemon(id);
             pokemon.field.terrain = terrain;
+            pokemon.field.terrainTurnsRemaining = turns;
             // Quark Drive
             if (pokemon.ability === "Quark Drive" && !pokemon.usedBoosterEnergy) {
                 if (pokemon.field.terrain === "Electric" && !pokemon.abilityOn) {
@@ -380,10 +381,11 @@ export class RaidState implements State.RaidState{
         }
     }
 
-    public applyWeather(weather: Weather | undefined, ids: number[] = [0,1,2,3,4]) {
+    public applyWeather(weather: Weather | undefined, turns = 20, ids: number[] = [0,1,2,3,4]) {
         for (let id of ids) {
             const pokemon = this.getPokemon(id);
             pokemon.field.weather = weather;
+            pokemon.field.weatherTurnsRemaining = turns;
             // Protosynthesis
             if (pokemon.ability === "Protosynthesis" && !pokemon.usedBoosterEnergy) {
                 if ((pokemon.field.weather || "").includes("Sun") && !pokemon.abilityOn) {
@@ -546,19 +548,19 @@ export class RaidState implements State.RaidState{
         //// Abilites That Take Effect upon switch-in
         /// Weather Abilities
         if (ability === "Drought") {
-            this.applyWeather("Sun");
+            this.applyWeather("Sun", pokemon.item === "Heat Rock" ? 32 : 20);
             flags[id].push("Drought summons the Sun");
         } else if (ability === "Drizzle") {
-            this.applyWeather("Rain");
+            this.applyWeather("Rain", pokemon.item === "Damp Rock" ? 32 : 20);
             flags[id].push("Drizzle summons the Rain");
         } else if (ability === "Sand Stream") {
-            this.applyWeather("Sand");
+            this.applyWeather("Sand", pokemon.item === "Smooth Rock" ? 32 : 20);
             flags[id].push("Sand Stream summons a Sandstorm");
         } else if (ability === "Snow Warning") {
-            this.applyWeather("Snow");
+            this.applyWeather("Snow", pokemon.item === "Icy Rock" ? 32 : 20);
             flags[id].push("Snow Warning summons a Snowstorm");
         } else if (ability === "Orichalcum Pulse") {
-            this.applyWeather("Sun");
+            this.applyWeather("Sun", pokemon.item === "Heat Rock" ? 32 : 20);
             flags[id].push("Orichalcum Pulse summons the Sun");
         } else if (ability === "Cloud Nine" || ability === "Air Lock") {
             for (let field of this.fields) {
@@ -567,19 +569,19 @@ export class RaidState implements State.RaidState{
             flags[id].push("Cloud Nine negates the weather");
         /// Terrain Abilities
         } else if (ability === "Grassy Surge") {
-            this.applyTerrain("Grassy");
+            this.applyTerrain("Grassy", pokemon.item === "Terrain Extender" ? 32 : 20);
             flags[id].push("Grassy Surge summons Grassy Terrain");
         } else if (ability === "Electric Surge") {
-            this.applyTerrain("Electric");
+            this.applyTerrain("Electric", pokemon.item === "Terrain Extender" ? 32 : 20);
             flags[id].push("Electric Surge summons Electric Terrain");
         } else if (ability === "Misty Surge") {
-            this.applyTerrain("Misty");
+            this.applyTerrain("Misty", pokemon.item === "Terrain Extender" ? 32 : 20);
             flags[id].push("Misty Surge summons Misty Terrain");
         } else if (ability === "Psychic Surge") {
-            this.applyTerrain("Psychic");
+            this.applyTerrain("Psychic", pokemon.item === "Terrain Extender" ? 32 : 20);
             flags[id].push("Psychic Surge summons Psychic Terrain");
         } else if (ability === "Hadron Engine") {
-            this.applyTerrain("Electric");
+            this.applyTerrain("Electric", pokemon.item === "Terrain Extender" ? 32 : 20);
             flags[id].push("Hadron Engine summons Electric Terrain");
         /// Ruin Abilities
         } else if (ability === "Sword of Ruin") {

--- a/src/raidcalc/Raider.ts
+++ b/src/raidcalc/Raider.ts
@@ -45,7 +45,7 @@ export class Raider extends Pokemon implements State.Raider {
         shieldActivateHP: number | undefined = undefined, 
         shieldBroken: boolean | undefined = undefined, 
         abilityNullified: number | undefined = 0, 
-        originalAbility: AbilityName | "(None)" = "(None)"
+        originalAbility: AbilityName | "(None)" | undefined = undefined,
     ) {
         super(pokemon.gen, pokemon.name, {...pokemon})
         this.id = id;
@@ -63,7 +63,7 @@ export class Raider extends Pokemon implements State.Raider {
         this.shieldActivateHP = shieldActivateHP;
         this.shieldBroken = shieldBroken;
         this.abilityNullified = abilityNullified;
-        this.originalAbility = originalAbility;
+        this.originalAbility = originalAbility || pokemon.ability || "(None)";
     }
 
     clone(): Raider {

--- a/src/uicomponents/RaidResults.tsx
+++ b/src/uicomponents/RaidResults.tsx
@@ -63,6 +63,20 @@ function TurnFlagDisplay({turnResult}: {turnResult: RaidTurnResult}) {
     )
 }
 
+function EndTurnFlagDisplay({turnResult}: {turnResult: RaidTurnResult}) {
+    const flags = turnResult.endFlags || [];
+    const texts = flags.map((flag) => "\t"+flag)
+    return (
+        <Stack direction="column" spacing={0}>
+            {
+                texts.map((text, idx) => (
+                    <Typography key={idx} variant="body2" style={{ whiteSpace: "pre-wrap" }}>{text}</Typography>  
+                ))
+            }
+        </Stack>
+    )
+}
+
 function TurnResultDisplay({state, turnResult, index}: {state: RaidState, turnResult: RaidTurnResult, index: number}) { 
     return (
         <Stack direction="column" spacing={0} key={index}>
@@ -70,6 +84,7 @@ function TurnResultDisplay({state, turnResult, index}: {state: RaidState, turnRe
             <TurnFlagDisplay turnResult={turnResult} />
             { moveResultDisplay(state, turnResult.results[0]) }
             { moveResultDisplay(state, turnResult.results[1]) }
+            <EndTurnFlagDisplay turnResult={turnResult} />
         </Stack>
     )
 }


### PR DESCRIPTION
Pending testing, effects are assumed to have a shared duration counter between all raiders, and the duration of an effect is 4x its usual duration in normal play. 

Ex: Reflect lasts 20 moves without Light Clay and 32 moves with Light Clay. 

Cheers are set to last 3 "turns" (12 moves). In reality, there might be a random element to their duration. 

closes #126 