### PR TITLE
Multi hit hotfix

### DIFF
--- a/src/calc/move.ts
+++ b/src/calc/move.ts
@@ -55,7 +55,7 @@ export class Move implements State.Move {
     this.originalName = name;
     let data: I.Move = extend(true, {name}, gen.moves.get(toID(name)), options.overrides);
 
-    this.hits = 1;
+    this.hits = options.hits || 1;
     // If isZMove but there isn't a corresponding z-move, use the original move
     if (options.useMax && data.maxMove) {
       const maxMoveName: string = getMaxMoveName(
@@ -91,7 +91,7 @@ export class Move implements State.Move {
         category: data.category,
       });
     } else {
-      if (data.multihit) {
+      if (options.hits === undefined && data.multihit) {
         if (typeof data.multihit === 'number') {
           this.hits = data.multihit;
         } else if (options.hits) {

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -420,6 +420,11 @@ export class RaidMove {
                         this._raidState.applyDamage(id, hitDamage, 1, this.move.isCrit, superEffective, this.move.type);
                         totalDamage += hitDamage;
                     }
+                    if (this.move.name === "Surging Strikes") {
+                        console.log(results)
+                        console.log(this.move)
+                        console.log(this.move.clone())
+                    }
                     // prepare desc from results
                     const result = results[0];
                     result.damage = damageResult as number | number[];

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -420,11 +420,6 @@ export class RaidMove {
                         this._raidState.applyDamage(id, hitDamage, 1, this.move.isCrit, superEffective, this.move.type);
                         totalDamage += hitDamage;
                     }
-                    if (this.move.name === "Surging Strikes") {
-                        console.log(results)
-                        console.log(this.move)
-                        console.log(this.move.clone())
-                    }
                     // prepare desc from results
                     const result = results[0];
                     result.damage = damageResult as number | number[];


### PR DESCRIPTION
For moves with a guaranteed number of multiple hits (like Surging Strikes), cloning a move now persists the 'hits'  property for the move instead of setting it to this number.

