### PR TITLE
Add substitute builds for strategies

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -219,7 +219,7 @@ function App() {
     }), 
     [
       {name: "Triple Arrows" as MoveName, category: "damage+lower", target: "selected-pokemon", statChanges: [{stat: "def", change: -1}], statChance: 50, flinchChance: 30},
-      {name: "Brave Bird" as MoveName, category: "damage", target: "selected-pokemon", drain: -0.5},
+      {name: "Brave Bird" as MoveName, category: "damage", target: "selected-pokemon", drain: -50},
       {name: "Leaf Blade" as MoveName, category: "damage", target: "selected-pokemon"},
       {name: "Rock Tomb" as MoveName, category: "damage+lower", target: "selected-pokemon", statChanges: [{stat: "spe", change: -1}], statChance: 100},
     ], 
@@ -239,7 +239,7 @@ function App() {
       evs: {atk: 252, spe: 252},
     }), 
     [
-      {name: "Flare Blitz" as MoveName, category: "damage", target: "selected-pokemon", drain: -0.5},
+      {name: "Flare Blitz" as MoveName, category: "damage", target: "selected-pokemon", drain: -50},
     ])
   );
   const [raider2, setRaider2] = useState(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ import StratFooter from './uicomponents/StratFooter.tsx';
 
 import { Generations, Pokemon, Field } from './calc/index.ts';
 import { MoveName } from './calc/data/interface.ts';
-import { TurnGroupInfo } from './raidcalc/interface.ts';
+import { SubstituteBuildInfo, TurnGroupInfo } from './raidcalc/interface.ts';
 import { Raider } from './raidcalc/Raider.ts';
 import { RaidInputProps } from './raidcalc/inputs.ts';
 import { RaidBattleResults } from './raidcalc/RaidBattle.ts';
@@ -292,12 +292,18 @@ function App() {
       ]
     }
   ]);
+  const [substitutes1, setSubstitutes1] = useState<SubstituteBuildInfo[]>([]);
+  const [substitutes2, setSubstitutes2] = useState<SubstituteBuildInfo[]>([]);
+  const [substitutes3, setSubstitutes3] = useState<SubstituteBuildInfo[]>([]);
+  const [substitutes4, setSubstitutes4] = useState<SubstituteBuildInfo[]>([]);
 
   const raidInputProps: RaidInputProps = {
     pokemon: [raidBoss, raider1, raider2, raider3, raider4],
     setPokemon: [setRaidBoss, setRaider1, setRaider2, setRaider3, setRaider4],
     groups: groups,
     setGroups: setGroups,
+    // substitutes: [substitutes1, substitutes2, substitutes3, substitutes4],
+    // setSubstitutes: [setSubstitutes1, setSubstitutes2, setSubstitutes3, setSubstitutes4],
   }
 
   const [results, setResults] = useState<RaidBattleResults>(
@@ -325,14 +331,14 @@ function App() {
         <Grid container component='main' justifyContent="center" sx={{ my: 1 }}>
           <Grid item>
             <Stack direction="row">
-              <PokemonSummary pokemon={raider1} setPokemon={setRaider1} prettyMode={prettyMode} />
-              <PokemonSummary pokemon={raider2} setPokemon={setRaider2} prettyMode={prettyMode}/>
+              <PokemonSummary pokemon={raider1} setPokemon={setRaider1} groups={groups} setGroups={setGroups} substitutes={substitutes1} setSubstitutes={setSubstitutes1} prettyMode={prettyMode} />
+              <PokemonSummary pokemon={raider2} setPokemon={setRaider2} groups={groups} setGroups={setGroups} substitutes={substitutes2} setSubstitutes={setSubstitutes2} prettyMode={prettyMode}/>
             </Stack>
           </Grid>
           <Grid item>
             <Stack direction="row">
-              <PokemonSummary pokemon={raider3} setPokemon={setRaider3} prettyMode={prettyMode} />
-              <PokemonSummary pokemon={raider4} setPokemon={setRaider4} prettyMode={prettyMode} />
+              <PokemonSummary pokemon={raider3} setPokemon={setRaider3} groups={groups} setGroups={setGroups} substitutes={substitutes3} setSubstitutes={setSubstitutes3} prettyMode={prettyMode} />
+              <PokemonSummary pokemon={raider4} setPokemon={setRaider4} groups={groups} setGroups={setGroups} substitutes={substitutes4} setSubstitutes={setSubstitutes4} prettyMode={prettyMode} />
             </Stack>
           </Grid>
           <Grid item>
@@ -352,6 +358,8 @@ function App() {
                     title={title} notes={notes} credits={credits}
                     raidInputProps={raidInputProps}
                     setTitle={setTitle} setNotes={setNotes} setCredits={setCredits}
+                    substitutes={[substitutes1, substitutes2, substitutes3, substitutes4]}
+                    setSubstitutes={[setSubstitutes1, setSubstitutes2, setSubstitutes3, setSubstitutes4]}
                     setPrettyMode={setPrettyMode}
                   />
                   <Box width="15px"/>

--- a/src/data/strats/chesnaught/main.json
+++ b/src/data/strats/chesnaught/main.json
@@ -1,391 +1,619 @@
 {
-  "name": "Flower Power: OHKO Chesnaught Strategy",
-  "notes": "",
-  "credits": "r/PokePortal Event Raid Support Team",
-  "pokemon": [
+    "name": "Flower Power: OHKO Chesnaught Strategy",
+    "notes": "",
+    "credits": "r/PokePortal Event Raid Support Team",
+    "pokemon": [
       {
-          "id": 0,
-          "role": "7⭐event",
-          "name": "Chesnaught",
-          "ability": "Bulletproof",
-          "nature": "Impish",
-          "evs": {
-              "hp": 0,
-              "atk": 0,
-              "def": 0,
-              "spa": 0,
-              "spd": 0,
-              "spe": 0
-          },
-          "ivs": {
-              "hp": 31,
-              "atk": 31,
-              "def": 31,
-              "spa": 31,
-              "spd": 31,
-              "spe": 31
-          },
-          "level": 100,
-          "teraType": "Rock",
-          "moves": [
-              "Earthquake",
-              "Hammer Arm",
-              "Stone Edge",
-              "Wood Hammer"
-          ],
-          "bossMultiplier": 3500,
-          "extraMoves": [
-              "Iron Defense",
-              "Bulk Up",
-              "Curse"
-          ]
+        "id": 0,
+        "role": "Chesnaught",
+        "name": "Chesnaught",
+        "shiny": false,
+        "ability": "Bulletproof",
+        "nature": "Impish",
+        "evs": {
+          "hp": 0,
+          "atk": 0,
+          "def": 0,
+          "spa": 0,
+          "spd": 0,
+          "spe": 0
+        },
+        "ivs": {
+          "hp": 31,
+          "atk": 31,
+          "def": 31,
+          "spa": 31,
+          "spd": 31,
+          "spe": 31
+        },
+        "level": 100,
+        "teraType": "Rock",
+        "moves": [
+          "Earthquake",
+          "Hammer Arm",
+          "Stone Edge",
+          "Wood Hammer"
+        ],
+        "bossMultiplier": 3500,
+        "extraMoves": [
+          "Iron Defense",
+          "Bulk Up",
+          "Curse"
+        ],
+        "shieldData": {
+          "hpTrigger": 0,
+          "timeTrigger": 0,
+          "shieldCancelDamage": 0,
+          "shieldDamageRate": 0,
+          "shieldDamageRateTera": 0,
+          "shieldDamageRateTeraChange": 0
+        }
       },
       {
-          "id": 1,
-          "role": "Lilligant",
-          "name": "Lilligant",
-          "ability": "(No Ability)",
-          "item": "Life Orb",
-          "nature": "Modest",
-          "evs": {
-              "hp": 252,
-              "atk": 0,
-              "def": 0,
-              "spa": 252,
-              "spd": 0,
-              "spe": 0
-          },
-          "ivs": {
-              "hp": 31,
-              "atk": 31,
-              "def": 31,
-              "spa": 31,
-              "spd": 31,
-              "spe": 31
-          },
-          "level": 100,
-          "moves": [
-              "Growth",
-              "Solar Beam"
-          ],
-          "bossMultiplier": 100,
-          "extraMoves": []
+        "id": 1,
+        "role": "Lilligant",
+        "name": "Lilligant",
+        "shiny": false,
+        "ability": "(No Ability)",
+        "item": "Life Orb",
+        "nature": "Modest",
+        "evs": {
+          "hp": 252,
+          "atk": 0,
+          "def": 0,
+          "spa": 252,
+          "spd": 0,
+          "spe": 0
+        },
+        "ivs": {
+          "hp": 31,
+          "atk": 31,
+          "def": 31,
+          "spa": 31,
+          "spd": 31,
+          "spe": 31
+        },
+        "level": 100,
+        "moves": [
+          "Growth",
+          "Solar Beam"
+        ],
+        "bossMultiplier": 100,
+        "extraMoves": [],
+        "shieldData": {
+          "hpTrigger": 0,
+          "timeTrigger": 0,
+          "shieldCancelDamage": 0,
+          "shieldDamageRate": 0,
+          "shieldDamageRateTera": 0,
+          "shieldDamageRateTeraChange": 0
+        }
       },
       {
-          "id": 2,
-          "role": "Sun Support",
-          "name": "Koraidon",
-          "ability": "Orichalcum Pulse",
-          "nature": "Hardy",
-          "evs": {
-              "hp": 252,
-              "atk": 0,
-              "def": 0,
-              "spa": 0,
-              "spd": 0,
-              "spe": 0
-          },
-          "ivs": {
-              "hp": 31,
-              "atk": 31,
-              "def": 31,
-              "spa": 31,
-              "spd": 31,
-              "spe": 31
-          },
-          "level": 100,
-          "moves": [
-              "Helping Hand"
-          ],
-          "bossMultiplier": 100,
-          "extraMoves": []
+        "id": 2,
+        "role": "Sun Support",
+        "name": "Koraidon",
+        "shiny": false,
+        "ability": "Orichalcum Pulse",
+        "nature": "Hardy",
+        "evs": {
+          "hp": 252,
+          "atk": 0,
+          "def": 0,
+          "spa": 0,
+          "spd": 0,
+          "spe": 0
+        },
+        "ivs": {
+          "hp": 31,
+          "atk": 31,
+          "def": 31,
+          "spa": 31,
+          "spd": 31,
+          "spe": 31
+        },
+        "level": 100,
+        "moves": [
+          "Helping Hand"
+        ],
+        "bossMultiplier": 100,
+        "extraMoves": [],
+        "shieldData": {
+          "hpTrigger": 0,
+          "timeTrigger": 0,
+          "shieldCancelDamage": 0,
+          "shieldDamageRate": 0,
+          "shieldDamageRateTera": 0,
+          "shieldDamageRateTeraChange": 0
+        }
       },
       {
-          "id": 3,
-          "role": "Fake Tears",
-          "name": "Corviknight",
-          "ability": "(No Ability)",
-          "nature": "Hardy",
-          "evs": {
-              "hp": 252,
-              "atk": 0,
-              "def": 0,
-              "spa": 0,
-              "spd": 0,
-              "spe": 0
-          },
-          "ivs": {
-              "hp": 31,
-              "atk": 31,
-              "def": 31,
-              "spa": 31,
-              "spd": 31,
-              "spe": 31
-          },
-          "level": 100,
-          "moves": [
-              "Fake Tears"
-          ],
-          "bossMultiplier": 100,
-          "extraMoves": []
+        "id": 3,
+        "role": "Fake Tears",
+        "name": "Corviknight",
+        "shiny": false,
+        "ability": "(No Ability)",
+        "nature": "Hardy",
+        "evs": {
+          "hp": 252,
+          "atk": 0,
+          "def": 0,
+          "spa": 0,
+          "spd": 0,
+          "spe": 0
+        },
+        "ivs": {
+          "hp": 31,
+          "atk": 31,
+          "def": 31,
+          "spa": 31,
+          "spd": 31,
+          "spe": 31
+        },
+        "level": 100,
+        "moves": [
+          "Fake Tears"
+        ],
+        "bossMultiplier": 100,
+        "extraMoves": [],
+        "shieldData": {
+          "hpTrigger": 0,
+          "timeTrigger": 0,
+          "shieldCancelDamage": 0,
+          "shieldDamageRate": 0,
+          "shieldDamageRateTera": 0,
+          "shieldDamageRateTeraChange": 0
+        }
       },
       {
-          "id": 4,
-          "role": "Fake Tears",
-          "name": "Corviknight",
-          "ability": "(No Ability)",
-          "nature": "Hardy",
-          "evs": {
-              "hp": 252,
-              "atk": 0,
-              "def": 0,
-              "spa": 0,
-              "spd": 0,
-              "spe": 0
-          },
-          "ivs": {
-              "hp": 31,
-              "atk": 31,
-              "def": 31,
-              "spa": 31,
-              "spd": 31,
-              "spe": 31
-          },
-          "level": 100,
-          "moves": [
-              "Fake Tears"
-          ],
-          "bossMultiplier": 100,
-          "extraMoves": []
+        "id": 4,
+        "role": "Fake Tears",
+        "name": "Corviknight",
+        "shiny": false,
+        "ability": "(No Ability)",
+        "nature": "Hardy",
+        "evs": {
+          "hp": 252,
+          "atk": 0,
+          "def": 0,
+          "spa": 0,
+          "spd": 0,
+          "spe": 0
+        },
+        "ivs": {
+          "hp": 31,
+          "atk": 31,
+          "def": 31,
+          "spa": 31,
+          "spd": 31,
+          "spe": 31
+        },
+        "level": 100,
+        "moves": [
+          "Fake Tears"
+        ],
+        "bossMultiplier": 100,
+        "extraMoves": [],
+        "shieldData": {
+          "hpTrigger": 0,
+          "timeTrigger": 0,
+          "shieldCancelDamage": 0,
+          "shieldDamageRate": 0,
+          "shieldDamageRateTera": 0,
+          "shieldDamageRateTeraChange": 0
+        }
       }
-  ],
-  "turns": [
+    ],
+    "turns": [
       {
-          "id": 10,
-          "moveInfo": {
-              "name": "(No Move)",
-              "userID": 1,
-              "targetID": 0,
-              "options": {
-                  "crit": false,
-                  "secondaryEffects": false,
-                  "roll": "min"
-              }
-          },
-          "bossMoveInfo": {
-              "name": "Iron Defense",
-              "userID": 0,
-              "targetID": 1,
-              "options": {
-                  "crit": true,
-                  "secondaryEffects": true,
-                  "roll": "max"
-              }
+        "id": 10,
+        "group": 2,
+        "moveInfo": {
+          "name": "(No Move)",
+          "userID": 2,
+          "targetID": 0,
+          "options": {
+            "crit": false,
+            "secondaryEffects": false,
+            "roll": "min"
           }
+        },
+        "bossMoveInfo": {
+          "name": "Iron Defense",
+          "userID": 0,
+          "targetID": 1,
+          "options": {
+            "crit": true,
+            "secondaryEffects": true,
+            "roll": "max"
+          }
+        }
       },
       {
-          "id": 3,
-          "group": 0,
-          "moveInfo": {
-              "name": "Growth",
-              "userID": 1,
-              "targetID": 0,
-              "options": {
-                  "crit": false,
-                  "secondaryEffects": false,
-                  "roll": "min"
-              }
-          },
-          "bossMoveInfo": {
-              "name": "Hammer Arm",
-              "userID": 0,
-              "targetID": 1,
-              "options": {
-                  "crit": true,
-                  "secondaryEffects": true,
-                  "roll": "max"
-              }
+        "id": 3,
+        "group": 0,
+        "moveInfo": {
+          "name": "Growth",
+          "userID": 1,
+          "targetID": 0,
+          "options": {
+            "crit": false,
+            "secondaryEffects": false,
+            "roll": "min"
           }
+        },
+        "bossMoveInfo": {
+          "name": "(Most Damaging)",
+          "userID": 0,
+          "targetID": 1,
+          "options": {
+            "crit": true,
+            "secondaryEffects": true,
+            "roll": "max"
+          }
+        }
       },
       {
-          "id": 0,
-          "group": 0,
-          "moveInfo": {
-              "name": "Attack Cheer",
-              "userID": 2,
-              "targetID": 0,
-              "options": {
-                  "crit": false,
-                  "secondaryEffects": false,
-                  "roll": "min"
-              }
-          },
-          "bossMoveInfo": {
-              "name": "Wood Hammer",
-              "userID": 0,
-              "targetID": 1,
-              "options": {
-                  "crit": true,
-                  "secondaryEffects": true,
-                  "roll": "max"
-              }
+        "id": 0,
+        "group": 0,
+        "moveInfo": {
+          "name": "Attack Cheer",
+          "userID": 2,
+          "targetID": 0,
+          "options": {
+            "crit": false,
+            "secondaryEffects": false,
+            "roll": "min"
           }
+        },
+        "bossMoveInfo": {
+          "name": "(Most Damaging)",
+          "userID": 0,
+          "targetID": 1,
+          "options": {
+            "crit": true,
+            "secondaryEffects": true,
+            "roll": "max"
+          }
+        }
       },
       {
-          "id": 5,
-          "group": 0,
-          "moveInfo": {
-              "name": "Fake Tears",
-              "userID": 4,
-              "targetID": 0,
-              "options": {
-                  "crit": false,
-                  "secondaryEffects": false,
-                  "roll": "min"
-              }
-          },
-          "bossMoveInfo": {
-              "name": "Wood Hammer",
-              "userID": 0,
-              "targetID": 1,
-              "options": {
-                  "crit": true,
-                  "secondaryEffects": true,
-                  "roll": "max"
-              }
+        "id": 5,
+        "group": 0,
+        "moveInfo": {
+          "name": "Fake Tears",
+          "userID": 3,
+          "targetID": 1,
+          "options": {
+            "crit": false,
+            "secondaryEffects": false,
+            "roll": "min"
           }
+        },
+        "bossMoveInfo": {
+          "name": "(Most Damaging)",
+          "userID": 0,
+          "targetID": 1,
+          "options": {
+            "crit": true,
+            "secondaryEffects": true,
+            "roll": "max"
+          }
+        }
       },
       {
-          "id": 2,
-          "group": 0,
-          "moveInfo": {
-              "name": "Fake Tears",
-              "userID": 3,
-              "targetID": 1,
-              "options": {
-                  "crit": false,
-                  "secondaryEffects": false,
-                  "roll": "min"
-              }
-          },
-          "bossMoveInfo": {
-              "name": "Wood Hammer",
-              "userID": 0,
-              "targetID": 1,
-              "options": {
-                  "crit": true,
-                  "secondaryEffects": true,
-                  "roll": "max"
-              }
+        "id": 2,
+        "group": 0,
+        "moveInfo": {
+          "name": "Fake Tears",
+          "userID": 4,
+          "targetID": 0,
+          "options": {
+            "crit": false,
+            "secondaryEffects": false,
+            "roll": "min"
           }
+        },
+        "bossMoveInfo": {
+          "name": "(Most Damaging)",
+          "userID": 0,
+          "targetID": 1,
+          "options": {
+            "crit": true,
+            "secondaryEffects": true,
+            "roll": "max"
+          }
+        }
       },
       {
-          "id": 6,
-          "group": 1,
-          "moveInfo": {
-              "name": "Helping Hand",
-              "userID": 2,
-              "targetID": 1,
-              "options": {
-                  "crit": false,
-                  "secondaryEffects": false,
-                  "roll": "min"
-              }
-          },
-          "bossMoveInfo": {
-              "name": "Wood Hammer",
-              "userID": 0,
-              "targetID": 1,
-              "options": {
-                  "crit": true,
-                  "secondaryEffects": true,
-                  "roll": "max"
-              }
+        "id": 6,
+        "group": 1,
+        "moveInfo": {
+          "name": "Helping Hand",
+          "userID": 2,
+          "targetID": 1,
+          "options": {
+            "crit": false,
+            "secondaryEffects": false,
+            "roll": "min"
           }
+        },
+        "bossMoveInfo": {
+          "name": "(Most Damaging)",
+          "userID": 0,
+          "targetID": 1,
+          "options": {
+            "crit": true,
+            "secondaryEffects": true,
+            "roll": "max"
+          }
+        }
       },
       {
-          "id": 8,
-          "group": 1,
-          "moveInfo": {
-              "name": "Fake Tears",
-              "userID": 4,
-              "targetID": 0,
-              "options": {
-                  "crit": false,
-                  "secondaryEffects": false,
-                  "roll": "min"
-              }
-          },
-          "bossMoveInfo": {
-              "name": "Wood Hammer",
-              "userID": 0,
-              "targetID": 1,
-              "options": {
-                  "crit": true,
-                  "secondaryEffects": true,
-                  "roll": "max"
-              }
+        "id": 8,
+        "group": 1,
+        "moveInfo": {
+          "name": "Fake Tears",
+          "userID": 4,
+          "targetID": 0,
+          "options": {
+            "crit": false,
+            "secondaryEffects": false,
+            "roll": "min"
           }
+        },
+        "bossMoveInfo": {
+          "name": "(Most Damaging)",
+          "userID": 0,
+          "targetID": 1,
+          "options": {
+            "crit": true,
+            "secondaryEffects": true,
+            "roll": "max"
+          }
+        }
       },
       {
-          "id": 7,
-          "group": 1,
-          "moveInfo": {
-              "name": "Fake Tears",
-              "userID": 3,
-              "targetID": 0,
-              "options": {
-                  "crit": false,
-                  "secondaryEffects": false,
-                  "roll": "min"
-              }
-          },
-          "bossMoveInfo": {
-              "name": "Wood Hammer",
-              "userID": 0,
-              "targetID": 1,
-              "options": {
-                  "crit": true,
-                  "secondaryEffects": true,
-                  "roll": "max"
-              }
+        "id": 7,
+        "group": 1,
+        "moveInfo": {
+          "name": "Fake Tears",
+          "userID": 3,
+          "targetID": 0,
+          "options": {
+            "crit": false,
+            "secondaryEffects": false,
+            "roll": "min"
           }
+        },
+        "bossMoveInfo": {
+          "name": "(Most Damaging)",
+          "userID": 0,
+          "targetID": 1,
+          "options": {
+            "crit": true,
+            "secondaryEffects": true,
+            "roll": "max"
+          }
+        }
       },
       {
-          "id": 9,
-          "moveInfo": {
-              "name": "Solar Beam",
-              "userID": 1,
-              "targetID": 0,
-              "options": {
-                  "crit": false,
-                  "secondaryEffects": false,
-                  "roll": "min"
-              }
-          },
-          "bossMoveInfo": {
-              "name": "(No Move)",
-              "userID": 0,
-              "targetID": 1,
-              "options": {
-                  "crit": true,
-                  "secondaryEffects": true,
-                  "roll": "max"
-              }
+        "id": 9,
+        "group": 3,
+        "moveInfo": {
+          "name": "Solar Beam",
+          "userID": 1,
+          "targetID": 0,
+          "options": {
+            "crit": false,
+            "secondaryEffects": false,
+            "roll": "min"
           }
+        },
+        "bossMoveInfo": {
+          "name": "(Most Damaging)",
+          "userID": 0,
+          "targetID": 1,
+          "options": {
+            "crit": true,
+            "secondaryEffects": true,
+            "roll": "max"
+          }
+        }
       }
-  ],
-  "groups": [
+    ],
+    "groups": [
       [
-          5,
-          3,
-          2,
-          0
+        10
       ],
       [
-          7,
-          8,
-          6
+        3,
+        0,
+        5,
+        2
+      ],
+      [
+        6,
+        8,
+        7
+      ],
+      [
+        9
       ]
-  ]
-}
+    ],
+    "repeats": [
+      1,
+      1,
+      1,
+      1
+    ],
+    "substitutes": [
+      [
+        {
+          "raider": {
+            "id": 1,
+            "role": "Sunflora",
+            "name": "Sunflora",
+            "shiny": true,
+            "ability": "Solar Power",
+            "item": "Life Orb",
+            "nature": "Timid",
+            "evs": {
+              "hp": 0,
+              "atk": 0,
+              "def": 252,
+              "spa": 0,
+              "spd": 0,
+              "spe": 252
+            },
+            "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+            },
+            "level": 100,
+            "moves": [
+              "Growth",
+              "Solar Beam"
+            ]
+          },
+          "substituteMoves": [
+            "Growth",
+            "Solar Beam"
+          ],
+          "substituteTargets": [
+            0,
+            0
+          ]
+        }
+      ],
+      [
+        {
+          "raider": {
+            "id": 2,
+            "role": "Sun Support",
+            "name": "Torkoal",
+            "shiny": true,
+            "ability": "Drought",
+            "item": "Charti Berry",
+            "nature": "Bold",
+            "evs": {
+              "hp": 252,
+              "atk": 0,
+              "def": 252,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+            },
+            "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+            },
+            "level": 100,
+            "moves": [
+              "Helping Hand"
+            ]
+          },
+          "substituteMoves": [
+            "(No Move)",
+            "Attack Cheer",
+            "Helping Hand"
+          ],
+          "substituteTargets": [
+            0,
+            0,
+            1
+          ]
+        }
+      ],
+      [
+        {
+          "raider": {
+            "id": 3,
+            "role": "Fake Tears",
+            "name": "Jigglypuff",
+            "shiny": true,
+            "ability": "Friend Guard",
+            "item": "Eviolite",
+            "nature": "Bold",
+            "evs": {
+              "hp": 252,
+              "atk": 0,
+              "def": 252,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+            },
+            "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+            },
+            "level": 100,
+            "moves": [
+              "Fake Tears"
+            ]
+          },
+          "substituteMoves": [
+            "Fake Tears",
+            "Fake Tears"
+          ],
+          "substituteTargets": [
+            0,
+            0
+          ]
+        }
+      ],
+      [
+        {
+          "raider": {
+            "id": 4,
+            "role": "Fake Tears",
+            "name": "Jigglypuff",
+            "shiny": true,
+            "ability": "Friend Guard",
+            "item": "Eviolite",
+            "nature": "Bold",
+            "evs": {
+              "hp": 252,
+              "atk": 0,
+              "def": 252,
+              "spa": 0,
+              "spd": 0,
+              "spe": 0
+            },
+            "ivs": {
+              "hp": 31,
+              "atk": 31,
+              "def": 31,
+              "spa": 31,
+              "spd": 31,
+              "spe": 31
+            },
+            "level": 100,
+            "moves": [
+              "Fake Tears"
+            ]
+          },
+          "substituteMoves": [
+            "Fake Tears",
+            "Fake Tears"
+          ],
+          "substituteTargets": [
+            0,
+            0
+          ]
+        }
+      ]
+    ]
+  }

--- a/src/data/strats/delphox/main.json
+++ b/src/data/strats/delphox/main.json
@@ -5,8 +5,9 @@
     "pokemon": [
         {
             "id": 0,
-            "role": "Event Delphox",
+            "role": "Delphox",
             "name": "Delphox",
+            "shiny": false,
             "ability": "Magician",
             "nature": "Timid",
             "evs": {
@@ -37,12 +38,21 @@
             "extraMoves": [
                 "Dazzling Gleam",
                 "Magic Room"
-            ]
+            ],
+            "shieldData": {
+                "hpTrigger": 0,
+                "timeTrigger": 0,
+                "shieldCancelDamage": 0,
+                "shieldDamageRate": 0,
+                "shieldDamageRateTera": 0,
+                "shieldDamageRateTeraChange": 0
+            }
         },
         {
             "id": 1,
-            "role": "Tink",
+            "role": "Tinkaton",
             "name": "Tinkaton",
+            "shiny": false,
             "ability": "(No Ability)",
             "item": "Life Orb",
             "nature": "Adamant",
@@ -68,12 +78,21 @@
                 "Gigaton Hammer"
             ],
             "bossMultiplier": 100,
-            "extraMoves": []
+            "extraMoves": [],
+            "shieldData": {
+                "hpTrigger": 0,
+                "timeTrigger": 0,
+                "shieldCancelDamage": 0,
+                "shieldDamageRate": 0,
+                "shieldDamageRateTera": 0,
+                "shieldDamageRateTeraChange": 0
+            }
         },
         {
             "id": 2,
-            "role": "Peli",
+            "role": "Pelipper",
             "name": "Pelipper",
+            "shiny": false,
             "ability": "Drizzle",
             "nature": "Calm",
             "evs": {
@@ -97,12 +116,21 @@
                 "Helping Hand"
             ],
             "bossMultiplier": 100,
-            "extraMoves": []
+            "extraMoves": [],
+            "shieldData": {
+                "hpTrigger": 0,
+                "timeTrigger": 0,
+                "shieldCancelDamage": 0,
+                "shieldDamageRate": 0,
+                "shieldDamageRateTera": 0,
+                "shieldDamageRateTeraChange": 0
+            }
         },
         {
             "id": 3,
-            "role": "Corv 1",
+            "role": "Screecher",
             "name": "Corviknight",
+            "shiny": false,
             "ability": "(No Ability)",
             "item": "Zoom Lens",
             "nature": "Sassy",
@@ -127,12 +155,21 @@
                 "Screech"
             ],
             "bossMultiplier": 100,
-            "extraMoves": []
+            "extraMoves": [],
+            "shieldData": {
+                "hpTrigger": 0,
+                "timeTrigger": 0,
+                "shieldCancelDamage": 0,
+                "shieldDamageRate": 0,
+                "shieldDamageRateTera": 0,
+                "shieldDamageRateTeraChange": 0
+            }
         },
         {
             "id": 4,
-            "role": "Corv 2",
+            "role": "Screecher",
             "name": "Corviknight",
+            "shiny": false,
             "ability": "(No Ability)",
             "item": "Zoom Lens",
             "nature": "Sassy",
@@ -157,12 +194,21 @@
                 "Screech"
             ],
             "bossMultiplier": 100,
-            "extraMoves": []
+            "extraMoves": [],
+            "shieldData": {
+                "hpTrigger": 0,
+                "timeTrigger": 0,
+                "shieldCancelDamage": 0,
+                "shieldDamageRate": 0,
+                "shieldDamageRateTera": 0,
+                "shieldDamageRateTeraChange": 0
+            }
         }
     ],
     "turns": [
         {
             "id": 8,
+            "group": 2,
             "moveInfo": {
                 "name": "(No Move)",
                 "userID": 1,
@@ -181,6 +227,84 @@
                     "crit": true,
                     "secondaryEffects": true,
                     "roll": "max"
+                }
+            }
+        },
+        {
+            "id": 9,
+            "group": 2,
+            "moveInfo": {
+                "name": "(No Move)",
+                "userID": 2,
+                "targetID": 0,
+                "options": {
+                    "crit": false,
+                    "secondaryEffects": false,
+                    "roll": "min",
+                    "hits": 1
+                }
+            },
+            "bossMoveInfo": {
+                "name": "Dazzling Gleam",
+                "userID": 0,
+                "targetID": 1,
+                "options": {
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "roll": "max",
+                    "hits": 10
+                }
+            }
+        },
+        {
+            "id": 10,
+            "group": 2,
+            "moveInfo": {
+                "name": "(No Move)",
+                "userID": 3,
+                "targetID": 0,
+                "options": {
+                    "crit": false,
+                    "secondaryEffects": false,
+                    "roll": "min",
+                    "hits": 1
+                }
+            },
+            "bossMoveInfo": {
+                "name": "Dazzling Gleam",
+                "userID": 0,
+                "targetID": 1,
+                "options": {
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "roll": "max",
+                    "hits": 10
+                }
+            }
+        },
+        {
+            "id": 11,
+            "group": 2,
+            "moveInfo": {
+                "name": "(No Move)",
+                "userID": 4,
+                "targetID": 0,
+                "options": {
+                    "crit": false,
+                    "secondaryEffects": false,
+                    "roll": "min",
+                    "hits": 1
+                }
+            },
+            "bossMoveInfo": {
+                "name": "Dazzling Gleam",
+                "userID": 0,
+                "targetID": 1,
+                "options": {
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "roll": "max",
+                    "hits": 10
                 }
             }
         },
@@ -308,6 +432,7 @@
         },
         {
             "id": 6,
+            "group": 3,
             "moveInfo": {
                 "name": "Attack Cheer",
                 "userID": 2,
@@ -328,6 +453,7 @@
         },
         {
             "id": 7,
+            "group": 4,
             "moveInfo": {
                 "name": "Gigaton Hammer",
                 "userID": 1,
@@ -345,6 +471,12 @@
     ],
     "groups": [
         [
+            8,
+            9,
+            10,
+            11
+        ],
+        [
             0,
             1,
             2,
@@ -353,6 +485,152 @@
         [
             4,
             5
+        ],
+        [
+            6
+        ],
+        [
+            7
+        ]
+    ],
+    "repeats": [
+        1,
+        1,
+        1,
+        1,
+        1
+    ],
+    "substitutes": [
+        [
+            {
+                "raider": {
+                    "id": 1,
+                    "role": "Zacian",
+                    "name": "Zacian-Crowned",
+                    "shiny": true,
+                    "ability": "Intrepid Sword",
+                    "item": "Rusted Sword",
+                    "nature": "Adamant",
+                    "evs": {
+                        "hp": 252,
+                        "atk": 252,
+                        "def": 0,
+                        "spa": 0,
+                        "spd": 0,
+                        "spe": 0
+                    },
+                    "ivs": {
+                        "hp": 31,
+                        "atk": 31,
+                        "def": 31,
+                        "spa": 31,
+                        "spd": 31,
+                        "spe": 31
+                    },
+                    "level": 100,
+                    "moves": [
+                        "Swords Dance",
+                        "Behemoth Blade"
+                    ]
+                },
+                "substituteMoves": [
+                    "(No Move)",
+                    "Swords Dance",
+                    "Behemoth Blade"
+                ],
+                "substituteTargets": [
+                    0,
+                    0,
+                    0
+                ]
+            }
+        ],
+        [],
+        [
+            {
+                "raider": {
+                    "id": 3,
+                    "role": "Screecher",
+                    "name": "Muk-Alola",
+                    "shiny": true,
+                    "ability": "(No Ability)",
+                    "item": "Zoom Lens",
+                    "nature": "Sassy",
+                    "evs": {
+                        "hp": 252,
+                        "atk": 0,
+                        "def": 0,
+                        "spa": 0,
+                        "spd": 252,
+                        "spe": 0
+                    },
+                    "ivs": {
+                        "hp": 31,
+                        "atk": 31,
+                        "def": 31,
+                        "spa": 31,
+                        "spd": 31,
+                        "spe": 31
+                    },
+                    "level": 100,
+                    "moves": [
+                        "Screech"
+                    ]
+                },
+                "substituteMoves": [
+                    "(No Move)",
+                    "Screech",
+                    "Heal Cheer"
+                ],
+                "substituteTargets": [
+                    0,
+                    0,
+                    3
+                ]
+            }
+        ],
+        [
+            {
+                "raider": {
+                    "id": 4,
+                    "role": "Screecher",
+                    "name": "Muk-Alola",
+                    "shiny": true,
+                    "ability": "(No Ability)",
+                    "item": "Zoom Lens",
+                    "nature": "Sassy",
+                    "evs": {
+                        "hp": 252,
+                        "atk": 0,
+                        "def": 0,
+                        "spa": 0,
+                        "spd": 252,
+                        "spe": 0
+                    },
+                    "ivs": {
+                        "hp": 31,
+                        "atk": 31,
+                        "def": 31,
+                        "spa": 31,
+                        "spd": 31,
+                        "spe": 31
+                    },
+                    "level": 100,
+                    "moves": [
+                        "Screech"
+                    ]
+                },
+                "substituteMoves": [
+                    "(No Move)",
+                    "Screech",
+                    "Heal Cheer"
+                ],
+                "substituteTargets": [
+                    0,
+                    0,
+                    4
+                ]
+            }
         ]
     ]
 }

--- a/src/data/strats/delphox/main.json
+++ b/src/data/strats/delphox/main.json
@@ -320,7 +320,7 @@
                 }
             },
             "bossMoveInfo": {
-                "name": "Will-O-Wisp",
+                "name": "(Most Damaging)",
                 "userID": 0,
                 "targetID": 1,
                 "options": {
@@ -340,7 +340,7 @@
                 }
             },
             "bossMoveInfo": {
-                "name": "Will-O-Wisp",
+                "name": "(Most Damaging)",
                 "userID": 0,
                 "targetID": 2,
                 "options": {
@@ -360,7 +360,7 @@
                 }
             },
             "bossMoveInfo": {
-                "name": "Will-O-Wisp",
+                "name": "(Most Damaging)",
                 "userID": 0,
                 "targetID": 3,
                 "options": {
@@ -380,7 +380,7 @@
                 }
             },
             "bossMoveInfo": {
-                "name": "Will-O-Wisp",
+                "name": "(Most Damaging)",
                 "userID": 0,
                 "targetID": 4,
                 "options": {
@@ -400,7 +400,7 @@
                 }
             },
             "bossMoveInfo": {
-                "name": "Psychic",
+                "name": "(Most Damaging)",
                 "userID": 0,
                 "targetID": 3,
                 "options": {
@@ -421,7 +421,7 @@
                 }
             },
             "bossMoveInfo": {
-                "name": "Psychic",
+                "name": "(Most Damaging)",
                 "userID": 0,
                 "targetID": 4,
                 "options": {
@@ -442,7 +442,7 @@
                 }
             },
             "bossMoveInfo": {
-                "name": "Psychic",
+                "name": "(Most Damaging)",
                 "userID": 0,
                 "targetID": 2,
                 "options": {
@@ -463,7 +463,7 @@
                 }
             },
             "bossMoveInfo": {
-                "name": "(No Move)",
+                "name": "(Most Damaging)",
                 "userID": 0,
                 "targetID": 0
             }
@@ -585,7 +585,7 @@
                 "substituteTargets": [
                     0,
                     0,
-                    3
+                    0
                 ]
             }
         ],
@@ -628,7 +628,7 @@
                 "substituteTargets": [
                     0,
                     0,
-                    4
+                    0
                 ]
             }
         ]

--- a/src/data/strats/inteleon/main.json
+++ b/src/data/strats/inteleon/main.json
@@ -1,311 +1,578 @@
 {
-  "name": "Official OHKO Inteleon Strategy",
-  "notes": "",
-  "credits": "r/PokemonScarletViolet Event Raid Support Team",
-  "pokemon": [
-      {
-          "id": 0,
-          "role": "Inteleon",
-          "name": "Inteleon",
-          "ability": "Sniper",
-          "nature": "Quiet",
-          "evs": {
-              "hp": 0,
-              "atk": 0,
-              "def": 0,
-              "spa": 0,
-              "spd": 0,
-              "spe": 0
-          },
-          "ivs": {
-              "hp": 31,
-              "atk": 31,
-              "def": 31,
-              "spa": 31,
-              "spd": 31,
-              "spe": 31
-          },
-          "level": 100,
-          "teraType": "Ice",
-          "moves": [
-              "Blizzard",
-              "Snipe Shot",
-              "Dark Pulse",
-              "Tearful Look"
-          ],
-          "bossMultiplier": 3000,
-          "extraMoves": [
-              "Mist",
-              "Snowscape"
-          ]
-      },
-      {
-          "id": 1,
-          "role": "Tauros-Blaze",
-          "name": "Tauros-Paldea-Blaze",
-          "ability": "Anger Point",
-          "item": "Choice Band",
-          "nature": "Jolly",
-          "evs": {
-              "hp": 0,
-              "atk": 252,
-              "def": 0,
-              "spa": 0,
-              "spd": 0,
-              "spe": 0
-          },
-          "ivs": {
-              "hp": 31,
-              "atk": 31,
-              "def": 31,
-              "spa": 31,
-              "spd": 31,
-              "spe": 31
-          },
-          "level": 100,
-          "moves": [
-              "Flare Blitz",
-              "(No Move)",
-              "(No Move)"
-          ],
-          "bossMultiplier": 100,
-          "extraMoves": []
-      },
-      {
-          "id": 2,
-          "role": "Sunny Day",
-          "name": "Klefki",
-          "ability": "Prankster",
-          "item": "Focus Sash",
-          "nature": "Hardy",
-          "evs": {
-              "hp": 0,
-              "atk": 0,
-              "def": 0,
-              "spa": 0,
-              "spd": 0,
-              "spe": 0
-          },
-          "ivs": {
-              "hp": 31,
-              "atk": 31,
-              "def": 31,
-              "spa": 31,
-              "spd": 31,
-              "spe": 31
-          },
-          "level": 1,
-          "moves": [
-              "Sunny Day"
-          ],
-          "bossMultiplier": 100,
-          "extraMoves": []
-      },
-      {
-          "id": 3,
-          "role": "Critter",
-          "name": "Meowscarada",
-          "ability": "(No Ability)",
-          "item": "Focus Sash",
-          "nature": "Hardy",
-          "evs": {
-              "hp": 0,
-              "atk": 0,
-              "def": 0,
-              "spa": 0,
-              "spd": 0,
-              "spe": 0
-          },
-          "ivs": {
-              "hp": 31,
-              "atk": 31,
-              "def": 31,
-              "spa": 31,
-              "spd": 31,
-              "spe": 31
-          },
-          "level": 36,
-          "moves": [
-              "Flower Trick"
-          ],
-          "bossMultiplier": 100,
-          "extraMoves": []
-      },
-      {
-          "id": 4,
-          "role": "Power Spot",
-          "name": "Stonjourner",
-          "ability": "Power Spot",
-          "item": "Focus Sash",
-          "nature": "Hardy",
-          "evs": {
-              "hp": 0,
-              "atk": 0,
-              "def": 0,
-              "spa": 0,
-              "spd": 0,
-              "spe": 0
-          },
-          "ivs": {
-              "hp": 31,
-              "atk": 31,
-              "def": 31,
-              "spa": 31,
-              "spd": 31,
-              "spe": 31
-          },
-          "level": 1,
-          "moves": [],
-          "bossMultiplier": 100,
-          "extraMoves": []
-      }
-  ],
-  "turns": [
-      {
-          "id": 7,
-          "group": 0,
-          "moveInfo": {
-              "name": "(No Move)",
-              "userID": 1,
-              "targetID": 0,
-              "options": {
-                  "crit": false,
-                  "secondaryEffects": false,
-                  "roll": "min"
-              }
-          },
-          "bossMoveInfo": {
-              "name": "Mist",
-              "userID": 0,
-              "targetID": 1,
-              "options": {
-                  "crit": true,
-                  "secondaryEffects": true,
-                  "roll": "max"
-              }
-          }
-      },
-      {
-          "id": 6,
-          "group": 0,
-          "moveInfo": {
-              "name": "(No Move)",
-              "userID": 1,
-              "targetID": 0,
-              "options": {
-                  "crit": false,
-                  "secondaryEffects": false,
-                  "roll": "min"
-              }
-          },
-          "bossMoveInfo": {
-              "name": "Snowscape",
-              "userID": 0,
-              "targetID": 1,
-              "options": {
-                  "crit": true,
-                  "secondaryEffects": true,
-                  "roll": "max"
-              }
-          }
-      },
-      {
-          "id": 0,
-          "moveInfo": {
-              "name": "Sunny Day",
-              "userID": 2,
-              "targetID": 0,
-              "options": {
-                  "crit": false,
-                  "secondaryEffects": false,
-                  "roll": "min"
-              }
-          },
-          "bossMoveInfo": {
-              "name": "Blizzard",
-              "userID": 0,
-              "targetID": 1,
-              "options": {
-                  "crit": true,
-                  "secondaryEffects": true,
-                  "roll": "max"
-              }
-          }
-      },
-      {
-          "id": 2,
-          "moveInfo": {
-              "name": "Flower Trick",
-              "userID": 3,
-              "targetID": 1,
-              "options": {
-                  "crit": false,
-                  "secondaryEffects": false,
-                  "roll": "min"
-              }
-          },
-          "bossMoveInfo": {
-              "name": "Snipe Shot",
-              "userID": 0,
-              "targetID": 1,
-              "options": {
-                  "crit": true,
-                  "secondaryEffects": true,
-                  "roll": "max"
-              }
-          }
-      },
-      {
-          "id": 5,
-          "moveInfo": {
-              "name": "Attack Cheer",
-              "userID": 4,
-              "targetID": 0,
-              "options": {
-                  "crit": false,
-                  "secondaryEffects": false,
-                  "roll": "min"
-              }
-          },
-          "bossMoveInfo": {
-              "name": "Snipe Shot",
-              "userID": 0,
-              "targetID": 1,
-              "options": {
-                  "crit": true,
-                  "secondaryEffects": true,
-                  "roll": "max"
-              }
-          }
-      },
-      {
-          "id": 3,
-          "moveInfo": {
-              "name": "Flare Blitz",
-              "userID": 1,
-              "targetID": 0,
-              "options": {
-                  "crit": false,
-                  "secondaryEffects": false,
-                  "roll": "min"
-              }
-          },
-          "bossMoveInfo": {
-              "name": "(No Move)",
-              "userID": 0,
-              "targetID": 1,
-              "options": {
-                  "crit": true,
-                  "secondaryEffects": true,
-                  "roll": "max"
-              }
-          }
-      }
-  ],
-  "groups": [
-      [
-          7,
-          6
-      ]
-  ]
+    "name": "Official OHKO Inteleon Strategy",
+    "notes": "",
+    "credits": "r/PokemonScarletViolet Event Raid Support Team",
+    "pokemon": [
+        {
+            "id": 0,
+            "role": "Inteleon",
+            "name": "Inteleon",
+            "shiny": false,
+            "ability": "Sniper",
+            "nature": "Quiet",
+            "evs": {
+                "hp": 0,
+                "atk": 0,
+                "def": 0,
+                "spa": 0,
+                "spd": 0,
+                "spe": 0
+            },
+            "ivs": {
+                "hp": 31,
+                "atk": 31,
+                "def": 31,
+                "spa": 31,
+                "spd": 31,
+                "spe": 31
+            },
+            "level": 100,
+            "teraType": "Ice",
+            "moves": [
+                "Blizzard",
+                "Snipe Shot",
+                "Dark Pulse",
+                "Tearful Look"
+            ],
+            "bossMultiplier": 3000,
+            "extraMoves": [
+                "Mist",
+                "Snowscape"
+            ],
+            "shieldData": {
+                "hpTrigger": 0,
+                "timeTrigger": 0,
+                "shieldCancelDamage": 0,
+                "shieldDamageRate": 0,
+                "shieldDamageRateTera": 0,
+                "shieldDamageRateTeraChange": 0
+            }
+        },
+        {
+            "id": 1,
+            "role": "DPS",
+            "name": "Tauros-Paldea-Blaze",
+            "shiny": false,
+            "ability": "Anger Point",
+            "item": "Choice Band",
+            "nature": "Jolly",
+            "evs": {
+                "hp": 0,
+                "atk": 252,
+                "def": 0,
+                "spa": 0,
+                "spd": 0,
+                "spe": 0
+            },
+            "ivs": {
+                "hp": 31,
+                "atk": 31,
+                "def": 31,
+                "spa": 31,
+                "spd": 31,
+                "spe": 31
+            },
+            "level": 100,
+            "moves": [
+                "Flare Blitz",
+                "(No Move)",
+                "(No Move)"
+            ],
+            "bossMultiplier": 100,
+            "extraMoves": [],
+            "shieldData": {
+                "hpTrigger": 0,
+                "timeTrigger": 0,
+                "shieldCancelDamage": 0,
+                "shieldDamageRate": 0,
+                "shieldDamageRateTera": 0,
+                "shieldDamageRateTeraChange": 0
+            }
+        },
+        {
+            "id": 2,
+            "role": "Weather",
+            "name": "Klefki",
+            "shiny": false,
+            "ability": "Prankster",
+            "item": "Focus Sash",
+            "nature": "Hardy",
+            "evs": {
+                "hp": 0,
+                "atk": 0,
+                "def": 0,
+                "spa": 0,
+                "spd": 0,
+                "spe": 0
+            },
+            "ivs": {
+                "hp": 31,
+                "atk": 31,
+                "def": 31,
+                "spa": 31,
+                "spd": 31,
+                "spe": 31
+            },
+            "level": 1,
+            "moves": [
+                "Sunny Day"
+            ],
+            "bossMultiplier": 100,
+            "extraMoves": [],
+            "shieldData": {
+                "hpTrigger": 0,
+                "timeTrigger": 0,
+                "shieldCancelDamage": 0,
+                "shieldDamageRate": 0,
+                "shieldDamageRateTera": 0,
+                "shieldDamageRateTeraChange": 0
+            }
+        },
+        {
+            "id": 3,
+            "role": "Critter",
+            "name": "Meowscarada",
+            "shiny": false,
+            "ability": "(No Ability)",
+            "item": "Focus Sash",
+            "nature": "Hardy",
+            "evs": {
+                "hp": 0,
+                "atk": 0,
+                "def": 0,
+                "spa": 0,
+                "spd": 0,
+                "spe": 0
+            },
+            "ivs": {
+                "hp": 31,
+                "atk": 31,
+                "def": 31,
+                "spa": 31,
+                "spd": 31,
+                "spe": 31
+            },
+            "level": 36,
+            "moves": [
+                "Flower Trick"
+            ],
+            "bossMultiplier": 100,
+            "extraMoves": [],
+            "shieldData": {
+                "hpTrigger": 0,
+                "timeTrigger": 0,
+                "shieldCancelDamage": 0,
+                "shieldDamageRate": 0,
+                "shieldDamageRateTera": 0,
+                "shieldDamageRateTeraChange": 0
+            }
+        },
+        {
+            "id": 4,
+            "role": "Power Support",
+            "name": "Stonjourner",
+            "shiny": false,
+            "ability": "Power Spot",
+            "item": "Focus Sash",
+            "nature": "Hardy",
+            "evs": {
+                "hp": 0,
+                "atk": 0,
+                "def": 0,
+                "spa": 0,
+                "spd": 0,
+                "spe": 0
+            },
+            "ivs": {
+                "hp": 31,
+                "atk": 31,
+                "def": 31,
+                "spa": 31,
+                "spd": 31,
+                "spe": 31
+            },
+            "level": 1,
+            "moves": [],
+            "bossMultiplier": 100,
+            "extraMoves": [],
+            "shieldData": {
+                "hpTrigger": 0,
+                "timeTrigger": 0,
+                "shieldCancelDamage": 0,
+                "shieldDamageRate": 0,
+                "shieldDamageRateTera": 0,
+                "shieldDamageRateTeraChange": 0
+            }
+        }
+    ],
+    "turns": [
+        {
+            "id": 7,
+            "group": 0,
+            "moveInfo": {
+                "name": "(No Move)",
+                "userID": 1,
+                "targetID": 0,
+                "options": {
+                    "crit": false,
+                    "secondaryEffects": false,
+                    "roll": "min"
+                }
+            },
+            "bossMoveInfo": {
+                "name": "Mist",
+                "userID": 0,
+                "targetID": 1,
+                "options": {
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "roll": "max"
+                }
+            }
+        },
+        {
+            "id": 6,
+            "group": 0,
+            "moveInfo": {
+                "name": "(No Move)",
+                "userID": 1,
+                "targetID": 0,
+                "options": {
+                    "crit": false,
+                    "secondaryEffects": false,
+                    "roll": "min"
+                }
+            },
+            "bossMoveInfo": {
+                "name": "Snowscape",
+                "userID": 0,
+                "targetID": 1,
+                "options": {
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "roll": "max"
+                }
+            }
+        },
+        {
+            "id": 0,
+            "group": 1,
+            "moveInfo": {
+                "name": "Sunny Day",
+                "userID": 2,
+                "targetID": 0,
+                "options": {
+                    "crit": false,
+                    "secondaryEffects": false,
+                    "roll": "min"
+                }
+            },
+            "bossMoveInfo": {
+                "name": "Blizzard",
+                "userID": 0,
+                "targetID": 1,
+                "options": {
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "roll": "max"
+                }
+            }
+        },
+        {
+            "id": 2,
+            "group": 2,
+            "moveInfo": {
+                "name": "Flower Trick",
+                "userID": 3,
+                "targetID": 1,
+                "options": {
+                    "crit": false,
+                    "secondaryEffects": false,
+                    "roll": "min"
+                }
+            },
+            "bossMoveInfo": {
+                "name": "Snipe Shot",
+                "userID": 0,
+                "targetID": 1,
+                "options": {
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "roll": "max"
+                }
+            }
+        },
+        {
+            "id": 5,
+            "group": 3,
+            "moveInfo": {
+                "name": "Attack Cheer",
+                "userID": 4,
+                "targetID": 0,
+                "options": {
+                    "crit": false,
+                    "secondaryEffects": false,
+                    "roll": "min"
+                }
+            },
+            "bossMoveInfo": {
+                "name": "Snipe Shot",
+                "userID": 0,
+                "targetID": 1,
+                "options": {
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "roll": "max"
+                }
+            }
+        },
+        {
+            "id": 3,
+            "group": 4,
+            "moveInfo": {
+                "name": "Flare Blitz",
+                "userID": 1,
+                "targetID": 0,
+                "options": {
+                    "crit": false,
+                    "secondaryEffects": false,
+                    "roll": "min"
+                }
+            },
+            "bossMoveInfo": {
+                "name": "(No Move)",
+                "userID": 0,
+                "targetID": 1,
+                "options": {
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "roll": "max"
+                }
+            }
+        }
+    ],
+    "groups": [
+        [
+            7,
+            6
+        ],
+        [
+            0
+        ],
+        [
+            2
+        ],
+        [
+            5
+        ],
+        [
+            3
+        ]
+    ],
+    "repeats": [
+        1,
+        1,
+        1,
+        1,
+        1
+    ],
+    "substitutes": [
+        [
+            {
+                "raider": {
+                    "id": 1,
+                    "role": "DPS",
+                    "name": "Crabominable",
+                    "shiny": true,
+                    "ability": "Anger Point",
+                    "item": "Choice Band",
+                    "nature": "Jolly",
+                    "evs": {
+                        "hp": 0,
+                        "atk": 252,
+                        "def": 0,
+                        "spa": 0,
+                        "spd": 0,
+                        "spe": 252
+                    },
+                    "ivs": {
+                        "hp": 31,
+                        "atk": 31,
+                        "def": 31,
+                        "spa": 31,
+                        "spd": 31,
+                        "spe": 31
+                    },
+                    "level": 100,
+                    "moves": [
+                        "Close Combat"
+                    ]
+                },
+                "substituteMoves": [
+                    "(No Move)",
+                    "(No Move)",
+                    "Close Combat"
+                ],
+                "substituteTargets": [
+                    0,
+                    0,
+                    0
+                ]
+            }
+        ],
+        [
+            {
+                "raider": {
+                    "id": 2,
+                    "role": "Weather",
+                    "name": "Forretress",
+                    "shiny": true,
+                    "ability": "Sturdy",
+                    "item": "Covert Cloak",
+                    "nature": "Relaxed",
+                    "evs": {
+                        "hp": 252,
+                        "atk": 0,
+                        "def": 252,
+                        "spa": 0,
+                        "spd": 0,
+                        "spe": 0
+                    },
+                    "ivs": {
+                        "hp": 31,
+                        "atk": 31,
+                        "def": 31,
+                        "spa": 31,
+                        "spd": 31,
+                        "spe": 31
+                    },
+                    "level": 100,
+                    "moves": [
+                        "Sunny Day"
+                    ]
+                },
+                "substituteMoves": [
+                    "Sunny Day"
+                ],
+                "substituteTargets": [
+                    1
+                ]
+            },
+            {
+                "raider": {
+                    "id": 2,
+                    "role": "Weather",
+                    "name": "Psyduck",
+                    "shiny": true,
+                    "ability": "Cloud Nine",
+                    "item": "Focus Sash",
+                    "nature": "Hardy",
+                    "evs": {
+                        "hp": 0,
+                        "atk": 0,
+                        "def": 0,
+                        "spa": 0,
+                        "spd": 0,
+                        "spe": 0
+                    },
+                    "ivs": {
+                        "hp": 31,
+                        "atk": 31,
+                        "def": 31,
+                        "spa": 31,
+                        "spd": 31,
+                        "spe": 31
+                    },
+                    "level": 1,
+                    "moves": [
+                        "Helping Hand"
+                    ]
+                },
+                "substituteMoves": [
+                    "Helping Hand"
+                ],
+                "substituteTargets": [
+                    1
+                ]
+            }
+        ],
+        [
+            {
+                "raider": {
+                    "id": 3,
+                    "role": "Critter",
+                    "name": "Snorunt",
+                    "shiny": false,
+                    "ability": "Inner Focus",
+                    "item": "Wide Lens",
+                    "nature": "Careful",
+                    "evs": {
+                        "hp": 252,
+                        "atk": 0,
+                        "def": 0,
+                        "spa": 0,
+                        "spd": 252,
+                        "spe": 0
+                    },
+                    "ivs": {
+                        "hp": 31,
+                        "atk": 31,
+                        "def": 31,
+                        "spa": 31,
+                        "spd": 31,
+                        "spe": 31
+                    },
+                    "level": 100,
+                    "moves": [
+                        "Frost Breath"
+                    ]
+                },
+                "substituteMoves": [
+                    "Frost Breath"
+                ],
+                "substituteTargets": [
+                    1
+                ]
+            }
+        ],
+        [
+            {
+                "raider": {
+                    "id": 4,
+                    "role": "Power Support",
+                    "name": "Medicham",
+                    "shiny": false,
+                    "ability": "Pure Power",
+                    "item": "Focus Sash",
+                    "nature": "Hardy",
+                    "evs": {
+                        "hp": 0,
+                        "atk": 0,
+                        "def": 0,
+                        "spa": 0,
+                        "spd": 0,
+                        "spe": 0
+                    },
+                    "ivs": {
+                        "hp": 31,
+                        "atk": 31,
+                        "def": 31,
+                        "spa": 31,
+                        "spd": 31,
+                        "spe": 31
+                    },
+                    "level": 1,
+                    "moves": [
+                        "Skill Swap"
+                    ]
+                },
+                "substituteMoves": [
+                    "Skill Swap"
+                ],
+                "substituteTargets": [
+                    1
+                ]
+            }
+        ]
+    ]
 }

--- a/src/data/strats/rillaboom/main.json
+++ b/src/data/strats/rillaboom/main.json
@@ -7,6 +7,7 @@
             "id": 0,
             "role": "Rilla Kong",
             "name": "Rillaboom",
+            "shiny": false,
             "ability": "Grassy Surge",
             "nature": "Jolly",
             "evs": {
@@ -38,12 +39,21 @@
                 "Growth",
                 "Boomburst",
                 "Bulk Up"
-            ]
+            ],
+            "shieldData": {
+                "hpTrigger": 0,
+                "timeTrigger": 0,
+                "shieldCancelDamage": 0,
+                "shieldDamageRate": 0,
+                "shieldDamageRateTera": 0,
+                "shieldDamageRateTeraChange": 0
+            }
         },
         {
             "id": 1,
             "role": "Korzilla",
             "name": "Koraidon",
+            "shiny": false,
             "ability": "Orichalcum Pulse",
             "item": "Life Orb",
             "nature": "Adamant",
@@ -69,12 +79,21 @@
                 "Collision Course"
             ],
             "bossMultiplier": 100,
-            "extraMoves": []
+            "extraMoves": [],
+            "shieldData": {
+                "hpTrigger": 0,
+                "timeTrigger": 0,
+                "shieldCancelDamage": 0,
+                "shieldDamageRate": 0,
+                "shieldDamageRateTera": 0,
+                "shieldDamageRateTeraChange": 0
+            }
         },
         {
             "id": 2,
-            "role": "Arcanine",
+            "role": "Atk Debuff",
             "name": "Arcanine",
+            "shiny": false,
             "ability": "Intimidate",
             "item": "Covert Cloak",
             "nature": "Jolly",
@@ -100,12 +119,21 @@
                 "Helping Hand"
             ],
             "bossMultiplier": 100,
-            "extraMoves": []
+            "extraMoves": [],
+            "shieldData": {
+                "hpTrigger": 0,
+                "timeTrigger": 0,
+                "shieldCancelDamage": 0,
+                "shieldDamageRate": 0,
+                "shieldDamageRateTera": 0,
+                "shieldDamageRateTeraChange": 0
+            }
         },
         {
             "id": 3,
-            "role": "Corviknight",
+            "role": "Screecher",
             "name": "Corviknight",
+            "shiny": false,
             "ability": "(No Ability)",
             "item": "Zoom Lens",
             "nature": "Relaxed",
@@ -130,12 +158,21 @@
                 "Screech"
             ],
             "bossMultiplier": 100,
-            "extraMoves": []
+            "extraMoves": [],
+            "shieldData": {
+                "hpTrigger": 0,
+                "timeTrigger": 0,
+                "shieldCancelDamage": 0,
+                "shieldDamageRate": 0,
+                "shieldDamageRateTera": 0,
+                "shieldDamageRateTeraChange": 0
+            }
         },
         {
             "id": 4,
-            "role": "Umbreon",
+            "role": "Screecher",
             "name": "Umbreon",
+            "shiny": false,
             "ability": "(No Ability)",
             "item": "Zoom Lens",
             "nature": "Relaxed",
@@ -160,12 +197,21 @@
                 "Screech"
             ],
             "bossMultiplier": 100,
-            "extraMoves": []
+            "extraMoves": [],
+            "shieldData": {
+                "hpTrigger": 0,
+                "timeTrigger": 0,
+                "shieldCancelDamage": 0,
+                "shieldDamageRate": 0,
+                "shieldDamageRateTera": 0,
+                "shieldDamageRateTeraChange": 0
+            }
         }
     ],
     "turns": [
         {
             "id": 8,
+            "group": 2,
             "moveInfo": {
                 "name": "(No Move)",
                 "userID": 1,
@@ -189,6 +235,7 @@
         },
         {
             "id": 0,
+            "group": 3,
             "moveInfo": {
                 "name": "Charm",
                 "userID": 2,
@@ -198,7 +245,7 @@
                 }
             },
             "bossMoveInfo": {
-                "name": "Body Slam",
+                "name": "(Most Damaging)",
                 "userID": 0,
                 "targetID": 1,
                 "options": {
@@ -219,7 +266,7 @@
                 }
             },
             "bossMoveInfo": {
-                "name": "Low Kick",
+                "name": "(Most Damaging)",
                 "userID": 0,
                 "targetID": 2,
                 "options": {
@@ -240,7 +287,7 @@
                 }
             },
             "bossMoveInfo": {
-                "name": "Drum Beating",
+                "name": "(Most Damaging)",
                 "userID": 0,
                 "targetID": 3,
                 "options": {
@@ -261,7 +308,7 @@
                 }
             },
             "bossMoveInfo": {
-                "name": "Acrobatics",
+                "name": "(Most Damaging)",
                 "userID": 0,
                 "targetID": 4,
                 "options": {
@@ -282,7 +329,7 @@
                 }
             },
             "bossMoveInfo": {
-                "name": "Body Slam",
+                "name": "(Most Damaging)",
                 "userID": 0,
                 "targetID": 3,
                 "options": {
@@ -303,7 +350,7 @@
                 }
             },
             "bossMoveInfo": {
-                "name": "Low Kick",
+                "name": "(Most Damaging)",
                 "userID": 0,
                 "targetID": 4,
                 "options": {
@@ -324,7 +371,7 @@
                 }
             },
             "bossMoveInfo": {
-                "name": "Drum Beating",
+                "name": "(Most Damaging)",
                 "userID": 0,
                 "targetID": 2,
                 "options": {
@@ -335,6 +382,7 @@
         },
         {
             "id": 7,
+            "group": 4,
             "moveInfo": {
                 "name": "Collision Course",
                 "userID": 1,
@@ -344,7 +392,7 @@
                 }
             },
             "bossMoveInfo": {
-                "name": "(No Move)",
+                "name": "(Most Damaging)",
                 "userID": 0,
                 "targetID": 0,
                 "options": {
@@ -355,6 +403,12 @@
     ],
     "groups": [
         [
+            8
+        ],
+        [
+            0
+        ],
+        [
             1,
             2,
             3
@@ -363,6 +417,261 @@
             4,
             5,
             6
+        ],
+        [
+            7
+        ]
+    ],
+    "repeats": [
+        1,
+        1,
+        1,
+        1,
+        1
+    ],
+    "substitutes": [
+        [],
+        [
+            {
+                "raider": {
+                    "id": 2,
+                    "role": "Atk Debuff",
+                    "name": "Drifblim",
+                    "shiny": true,
+                    "ability": "(No Ability)",
+                    "item": "Flame Orb",
+                    "nature": "Timid",
+                    "evs": {
+                        "hp": 212,
+                        "atk": 0,
+                        "def": 252,
+                        "spa": 0,
+                        "spd": 0,
+                        "spe": 44
+                    },
+                    "ivs": {
+                        "hp": 31,
+                        "atk": 31,
+                        "def": 31,
+                        "spa": 31,
+                        "spd": 31,
+                        "spe": 31
+                    },
+                    "level": 100,
+                    "moves": [
+                        "Fling",
+                        "Helping Hand"
+                    ]
+                },
+                "substituteMoves": [
+                    "Fling",
+                    "Helping Hand"
+                ],
+                "substituteTargets": [
+                    0,
+                    1
+                ]
+            },
+            {
+                "raider": {
+                    "id": 2,
+                    "role": "Atk Debuff",
+                    "name": "Skeledirge",
+                    "shiny": true,
+                    "ability": "Unaware",
+                    "item": "Zoom Lens",
+                    "nature": "Bold",
+                    "evs": {
+                        "hp": 252,
+                        "atk": 0,
+                        "def": 252,
+                        "spa": 0,
+                        "spd": 0,
+                        "spe": 0
+                    },
+                    "ivs": {
+                        "hp": 31,
+                        "atk": 31,
+                        "def": 31,
+                        "spa": 31,
+                        "spd": 31,
+                        "spe": 31
+                    },
+                    "level": 100,
+                    "moves": [
+                        "Will-O-Wisp",
+                        "Helping Hand"
+                    ]
+                },
+                "substituteMoves": [
+                    "Will-O-Wisp",
+                    "Helping Hand"
+                ],
+                "substituteTargets": [
+                    0,
+                    1
+                ]
+            }
+        ],
+        [
+            {
+                "raider": {
+                    "id": 3,
+                    "role": "Screecher",
+                    "name": "Persian-Alola",
+                    "shiny": true,
+                    "ability": "Fur Coat",
+                    "item": "Zoom Lens",
+                    "nature": "Relaxed",
+                    "evs": {
+                        "hp": 252,
+                        "atk": 0,
+                        "def": 252,
+                        "spa": 0,
+                        "spd": 0,
+                        "spe": 0
+                    },
+                    "ivs": {
+                        "hp": 31,
+                        "atk": 31,
+                        "def": 31,
+                        "spa": 31,
+                        "spd": 31,
+                        "spe": 0
+                    },
+                    "level": 100,
+                    "moves": [
+                        "Screech"
+                    ]
+                },
+                "substituteMoves": [
+                    "Screech",
+                    "Attack Cheer"
+                ],
+                "substituteTargets": [
+                    0,
+                    4
+                ]
+            },
+            {
+                "raider": {
+                    "id": 3,
+                    "role": "Screecher",
+                    "name": "Umbreon",
+                    "shiny": false,
+                    "ability": "(No Ability)",
+                    "item": "Zoom Lens",
+                    "nature": "Relaxed",
+                    "evs": {
+                        "hp": 252,
+                        "atk": 0,
+                        "def": 252,
+                        "spa": 0,
+                        "spd": 0,
+                        "spe": 0
+                    },
+                    "ivs": {
+                        "hp": 31,
+                        "atk": 31,
+                        "def": 31,
+                        "spa": 31,
+                        "spd": 31,
+                        "spe": 31
+                    },
+                    "level": 100,
+                    "moves": [
+                        "Screech"
+                    ]
+                },
+                "substituteMoves": [
+                    "Screech",
+                    "Attack Cheer"
+                ],
+                "substituteTargets": [
+                    0,
+                    4
+                ]
+            }
+        ],
+        [
+            {
+                "raider": {
+                    "id": 4,
+                    "role": "Screecher",
+                    "name": "Persian-Alola",
+                    "shiny": true,
+                    "ability": "Fur Coat",
+                    "item": "Zoom Lens",
+                    "nature": "Relaxed",
+                    "evs": {
+                        "hp": 252,
+                        "atk": 0,
+                        "def": 252,
+                        "spa": 0,
+                        "spd": 0,
+                        "spe": 0
+                    },
+                    "ivs": {
+                        "hp": 0,
+                        "atk": 0,
+                        "def": 0,
+                        "spa": 0,
+                        "spd": 0,
+                        "spe": 0
+                    },
+                    "level": 100,
+                    "moves": [
+                        "Screech"
+                    ]
+                },
+                "substituteMoves": [
+                    "Screech",
+                    "Attack Cheer"
+                ],
+                "substituteTargets": [
+                    0,
+                    2
+                ]
+            },
+            {
+                "raider": {
+                    "id": 4,
+                    "role": "Screecher",
+                    "name": "Corviknight",
+                    "shiny": false,
+                    "ability": "(No Ability)",
+                    "item": "Zoom Lens",
+                    "nature": "Relaxed",
+                    "evs": {
+                        "hp": 252,
+                        "atk": 0,
+                        "def": 252,
+                        "spa": 0,
+                        "spd": 0,
+                        "spe": 0
+                    },
+                    "ivs": {
+                        "hp": 31,
+                        "atk": 31,
+                        "def": 31,
+                        "spa": 31,
+                        "spd": 31,
+                        "spe": 31
+                    },
+                    "level": 100,
+                    "moves": [
+                        "Screech"
+                    ]
+                },
+                "substituteMoves": [
+                    "Screech",
+                    "Attack Cheer"
+                ],
+                "substituteTargets": [
+                    0,
+                    2
+                ]
+            }
         ]
     ]
 }

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -5,7 +5,7 @@ import { RaidState } from "./RaidState";
 import { Raider } from "./Raider";
 import { AbilityName, StatIDExceptHP } from "../calc/data/interface";
 import { getQPBoostedStat, isGrounded } from "../calc/mechanics/util";
-import { isSuperEffective, safeStatStage, pokemonIsGrounded, ailmentToStatus, hasNoStatus } from "./util";
+import { isSuperEffective, pokemonIsGrounded, ailmentToStatus, hasNoStatus } from "./util";
 import persistentAbilities from "../data/persistent_abilities.json"
 import bypassProtectMoves from "../data/bypass_protect_moves.json"
 

--- a/src/raidcalc/hashData.ts
+++ b/src/raidcalc/hashData.ts
@@ -32,6 +32,12 @@ export type LightTurnInfo = {
     bossMoveInfo: LightMoveInfo,
 }
 
+export type LightSubstituteBuildInfo = {
+    raider: LightPokemon,
+    substituteMoves: string[],
+    substituteTargets: number[],
+}
+
 export type LightBuildInfo = {
     name?: string,
     notes?: string,
@@ -40,5 +46,6 @@ export type LightBuildInfo = {
     turns: LightTurnInfo[],
     groups?: number[][],
     repeats?: number[],
+    substitutes?: LightSubstituteBuildInfo[][]
 }
 

--- a/src/raidcalc/inputs.ts
+++ b/src/raidcalc/inputs.ts
@@ -1,10 +1,12 @@
 import { Raider } from "./Raider";
-import { TurnGroupInfo } from "./interface";
+import { SubstituteBuildInfo, TurnGroupInfo } from "./interface";
 
 // used for passing data to React components
 export type RaidInputProps = {
   pokemon: Raider[],
   setPokemon: ((r: Raider) => void)[],
+  // substitutes: SubstituteBuildInfo[][],
+  // setSubstitutes: ((s: SubstituteBuildInfo[]) => void)[],
   groups: TurnGroupInfo[],
   setGroups: (t: TurnGroupInfo[]) => void,
 }
@@ -15,4 +17,5 @@ export type BuildInfo = {
   credits: string;
   pokemon: Raider[],
   groups: TurnGroupInfo[],
+  substitutes: SubstituteBuildInfo[][],
 }

--- a/src/raidcalc/interface.ts
+++ b/src/raidcalc/interface.ts
@@ -144,3 +144,9 @@ export type TurnGroupInfo = {
     turns: RaidTurnInfo[],
     repeats?: number,
 }
+
+export type SubstituteBuildInfo = {
+    raider: Raider,
+    substituteMoves: MoveName[],
+    substituteTargets: number[],
+}

--- a/src/raidcalc/util.ts
+++ b/src/raidcalc/util.ts
@@ -3,7 +3,6 @@ import { AilmentName, RaidTurnInfo } from "./interface";
 import { Raider } from "./Raider";
 import { StatusName, AbilityName, ItemName, StatIDExceptHP } from "../calc/data/interface";
 import { getMoveEffectiveness, isGrounded } from "../calc/mechanics/util";
-import { get } from "http";
 
 const gen = Generations.get(9);
 

--- a/src/uicomponents/BuildControls.tsx
+++ b/src/uicomponents/BuildControls.tsx
@@ -900,7 +900,7 @@ function SubstituteMenuItem({ idx, pokemon, setPokemon, substitutes, setSubstitu
         const pokemonInfo = removedSubstitute.raider;
         const newPokemon = new Raider(
             pokemon.id, 
-            pokemon.role, 
+            pokemonInfo.role, 
             pokemonInfo.shiny, 
             new Field(), 
             new Pokemon(
@@ -972,26 +972,26 @@ function BuildControls({pokemon, abilities, moveSet, setPokemon, substitutes, se
         if (pokemon.name.includes("Ogerpon")) {
             if (pokemon.name === "Ogerpon") {
                 setTeraTypes(["Grass"]);
-                setPokemonProperties(["role", "teraType"])([pokemon.species.name, "Grass"]);
+                setPokemonProperties(["role", "teraType"])(["Ogerpon", "Grass"]);
             } else if (pokemon.name === "Ogerpon-Hearthflame") {
                 setTeraTypes(["Fire"]);
                 setItems(["Hearthflame Mask" as ItemName]);
-                setPokemonProperties(["role", "teraType", "item"])([pokemon.species.name, "Fire", "Hearthflame Mask"]);
+                setPokemonProperties(["role", "teraType", "item"])(["Ogerpon", "Fire", "Hearthflame Mask"]);
             } else if (pokemon.name === "Ogerpon-Wellspring") {
                 setTeraTypes(["Water"]);
                 setItems(["Wellspring Mask" as ItemName]);
-                setPokemonProperties(["role", "teraType", "item"])([pokemon.species.name, "Water", "Wellspring Mask"]);
+                setPokemonProperties(["role", "teraType", "item"])(["Ogerpon", "Water", "Wellspring Mask"]);
             } else { // (pokemmon.name === "Ogerpon-Cornerstone")
                 setTeraTypes(["Rock"]);
                 setItems(["Cornerstone Mask" as ItemName]);
-                setPokemonProperties(["role", "teraType", "item"])([pokemon.species.name, "Rock", "Cornerstone Mask"]);
+                setPokemonProperties(["role", "teraType", "item"])(["Ogerpon", "Rock", "Cornerstone Mask"]);
             }
         } else if (pokemon.name === "Zacian-Crowned") {
             setItems(["Rusted Sword" as ItemName]);
-            setPokemonProperties(["role","item"])([pokemon.species.name, "Rusted Sword"]);
+            setPokemonProperties(["role","item"])(["Zacian", "Rusted Sword"]);
         } else if (pokemon.name === "Zamazenta-Crowned") {
             setItems(["Rusted Shield" as ItemName]);
-            setPokemonProperties(["role","item"])([pokemon.species.name, "Rusted Shield"]);
+            setPokemonProperties(["role","item"])(["Zamazenta", "Rusted Shield"]);
         } else {
             setTeraTypes(genTypes);
             setItems(genItems);

--- a/src/uicomponents/BuildControls.tsx
+++ b/src/uicomponents/BuildControls.tsx
@@ -868,14 +868,6 @@ function SubstitutesMenuButton({pokemon, setPokemon, substitutes, setSubstitutes
                 anchorEl={anchorEl}
                 open={open}
                 onClose={handleClose}
-                anchorOrigin={{
-                    vertical: 'bottom',
-                    horizontal: 'left',
-                }}
-                transformOrigin={{
-                    vertical: 'top',
-                    horizontal: 'center',
-                }}
             >
                 {substitutes.map((sub, idx) => (
                     <SubstituteMenuItem 

--- a/src/uicomponents/HelpSection.tsx
+++ b/src/uicomponents/HelpSection.tsx
@@ -14,11 +14,12 @@ import IconButton from "@mui/material/IconButton";
 import Divider from "@mui/material/Divider";
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import CloseIcon from "@mui/icons-material/Close";
 
-function CollapseButton({open, setOpen}: {open: boolean, setOpen: React.Dispatch<React.SetStateAction<boolean>>}) {
+function CollapseButton({open, setOpen, setClosed = () => {}}: {open: boolean, setOpen: React.Dispatch<React.SetStateAction<boolean>>, setClosed?: () => void }) {
     return (
         <IconButton
-            onClick={() => setOpen(!open)}
+            onClick={() => { setOpen(!open); setClosed(); }}
             size="small"
         >
             {open ? <ExpandLessIcon /> : <ExpandMoreIcon />}
@@ -26,24 +27,32 @@ function CollapseButton({open, setOpen}: {open: boolean, setOpen: React.Dispatch
     )
 }
 
-function HelpSection() {
+function HelpSection({setOpen}: {setOpen: (b: boolean) => void}) {
     const [buildHelpOpen, setBuildHelpOpen] = useState(false);
     const [prettyHelpOpen, setPrettyHelpOpen] = useState(false);
     const [uiHelpOpen, setUiHelpOpen] = useState(false);
 
-
     return (
     <Stack spacing={0} sx={{ p: 2, minWidth: "575px" }}>
-        <Typography variant="body1" gutterBottom>
-            Click on the button to the right of a section header to expand or collapse that section.
-        </Typography>
+        <Stack direction="row" alignItems="center" justifyContent="center" sx={{ paddingBottom: 1 }} >
+            <Typography variant="body1" gutterBottom>
+                Click on the button to the right of a section header to expand or collapse that section.
+            </Typography>
+            <Box sx={{ flexGrow: 1 }} />
+            <IconButton
+                onClick={() => setOpen(false)}
+                size="medium"
+            >
+                <CloseIcon />
+            </IconButton>
+        </Stack>
         <Divider />
         <Box sx={{ p: 2 }}>
             <Stack direction="row" spacing={1} alignItems="center">
                 <Typography variant="h5" gutterBottom>
                     Building a Raid-Ready Pokémon
                 </Typography>
-                <CollapseButton open={buildHelpOpen} setOpen={setBuildHelpOpen} />
+                <CollapseButton open={buildHelpOpen} setOpen={setBuildHelpOpen} setClosed={() => { setPrettyHelpOpen(false); setUiHelpOpen(false); }}/>
             </Stack>
             <Collapse in={buildHelpOpen} >
                 <BuildHelpSection />
@@ -55,7 +64,7 @@ function HelpSection() {
                 <Typography variant="h5" gutterBottom>
                     Reading a Strategy
                 </Typography>
-                <CollapseButton open={prettyHelpOpen} setOpen={setPrettyHelpOpen} />
+                <CollapseButton open={prettyHelpOpen} setOpen={setPrettyHelpOpen} setClosed={() => { setBuildHelpOpen(false); setUiHelpOpen(false); }}/>
             </Stack>
             <Collapse in={prettyHelpOpen} >
                 <PrettyHelpSection />
@@ -67,7 +76,7 @@ function HelpSection() {
                 <Typography variant="h5" gutterBottom>
                     Creating a Strategy
                 </Typography>
-                <CollapseButton open={uiHelpOpen} setOpen={setUiHelpOpen} />
+                <CollapseButton open={uiHelpOpen} setOpen={setUiHelpOpen} setClosed={() => { setBuildHelpOpen(false); setPrettyHelpOpen(false); }} />
             </Stack>
             <Collapse in={uiHelpOpen} >
                 <UIHelpSection />
@@ -102,7 +111,7 @@ function BuildHelpSection() {
                     <Typography variant="h6" gutterBottom>
                         Individual Values (IVs)
                     </Typography>
-                    <CollapseButton open={ivHelpOpen} setOpen={setIvHelpOpen} />
+                    <CollapseButton open={ivHelpOpen} setOpen={setIvHelpOpen} setClosed={() => { setEvHelpOpen(false); setNatureHelpOpen(false); setEggMoveHelpOpen(false); setAbilitiesHelpOpen(false); }} />
                 </Stack>
                 <Collapse in={ivHelpOpen} >
                     <Typography variant="body1" gutterBottom>
@@ -178,7 +187,7 @@ function BuildHelpSection() {
                     <Typography variant="h6" gutterBottom>
                         Effort Values (EVs)
                     </Typography>
-                    <CollapseButton open={evHelpOpen} setOpen={setEvHelpOpen} />
+                    <CollapseButton open={evHelpOpen} setOpen={setEvHelpOpen} setClosed={() => { setIvHelpOpen(false); setNatureHelpOpen(false); setEggMoveHelpOpen(false); setAbilitiesHelpOpen(false); }} />
                 </Stack>
                 <Collapse in={evHelpOpen} >
                     <Typography variant="body1" gutterBottom>
@@ -218,7 +227,7 @@ function BuildHelpSection() {
                     <Typography variant="h6" gutterBottom>
                         Natures
                     </Typography>
-                    <CollapseButton open={natureHelpOpen} setOpen={setNatureHelpOpen} />
+                    <CollapseButton open={natureHelpOpen} setOpen={setNatureHelpOpen} setClosed={() => { setIvHelpOpen(false); setEvHelpOpen(false); setEggMoveHelpOpen(false); setAbilitiesHelpOpen(false); }} />
                 </Stack>
                 <Collapse in={natureHelpOpen} >
                     <Typography variant="body1" gutterBottom>
@@ -237,7 +246,7 @@ function BuildHelpSection() {
                     <Typography variant="h6" gutterBottom>
                         Egg Moves
                     </Typography>
-                    <CollapseButton open={eggMoveHelpOpen} setOpen={setEggMoveHelpOpen} />
+                    <CollapseButton open={eggMoveHelpOpen} setOpen={setEggMoveHelpOpen} setClosed={() => { setIvHelpOpen(false); setEvHelpOpen(false); setNatureHelpOpen(false); setAbilitiesHelpOpen(false); }} />
                 </Stack>
                 <Collapse in={eggMoveHelpOpen} >
                     <Typography variant="body1" gutterBottom>
@@ -258,7 +267,7 @@ function BuildHelpSection() {
                     <Typography variant="h6" gutterBottom>
                         Abilities
                     </Typography>
-                    <CollapseButton open={abilitiesHelpOpen} setOpen={setAbilitiesHelpOpen} />
+                    <CollapseButton open={abilitiesHelpOpen} setOpen={setAbilitiesHelpOpen} setClosed={() => { setIvHelpOpen(false); setEvHelpOpen(false); setNatureHelpOpen(false); setEggMoveHelpOpen(false); }} />
                 </Stack>
                 <Collapse in={abilitiesHelpOpen} >
                     <Typography variant="body1" gutterBottom>
@@ -298,7 +307,7 @@ function PrettyHelpSection() {
                 <Typography variant="h6" gutterBottom>
                     Raider Builds
                 </Typography>
-                <CollapseButton open={raiderHelpOpen} setOpen={setRaiderHelpOpen} />
+                <CollapseButton open={raiderHelpOpen} setOpen={setRaiderHelpOpen} setClosed={() => { setBossHelpOpen(false); setMoveHelpOpen(false); setCalcHelpOpen(false); }} />
             </Stack>
             <Collapse in={raiderHelpOpen} >
                 <Typography variant="body1" gutterBottom>
@@ -330,7 +339,7 @@ function PrettyHelpSection() {
                 <Typography variant="h6" gutterBottom>
                     Raid Boss Builds
                 </Typography>
-                <CollapseButton open={bossHelpOpen} setOpen={setBossHelpOpen} />
+                <CollapseButton open={bossHelpOpen} setOpen={setBossHelpOpen} setClosed={() => { setRaiderHelpOpen(false); setMoveHelpOpen(false); setCalcHelpOpen(false); }} />
             </Stack>
             <Collapse in={bossHelpOpen} >
                 <Typography variant="body1" gutterBottom>
@@ -351,7 +360,7 @@ function PrettyHelpSection() {
                 <Typography variant="h6" gutterBottom>
                     Move Order
                 </Typography>
-                <CollapseButton open={moveHelpOpen} setOpen={setMoveHelpOpen} />
+                <CollapseButton open={moveHelpOpen} setOpen={setMoveHelpOpen} setClosed={() => { setRaiderHelpOpen(false); setBossHelpOpen(false); setCalcHelpOpen(false); }}/>
             </Stack>
             <Collapse in={moveHelpOpen} >
                 <Typography variant="body1" gutterBottom>
@@ -373,7 +382,7 @@ function PrettyHelpSection() {
                 <Typography variant="h6" gutterBottom>
                     Calc Results
                 </Typography>
-                <CollapseButton open={calcHelpOpen} setOpen={setCalcHelpOpen} />
+                <CollapseButton open={calcHelpOpen} setOpen={setCalcHelpOpen} setClosed={() => { setRaiderHelpOpen(false); setBossHelpOpen(false); setMoveHelpOpen(false); }}/>
             </Stack>
             <Collapse in={calcHelpOpen} >
                 <Typography variant="body1" gutterBottom>
@@ -393,6 +402,7 @@ function PrettyHelpSection() {
 function UIHelpSection() {
     const [goalsHelpOpen, setGoalsHelpOpen] = useState(false);
     const [raiderHelpOpen, setRaiderHelpOpen] = useState(false);
+    const [subHelpOpen, setSubHelpOpen] = useState(false);
     const [bossHelpOpen, setBossHelpOpen] = useState(false);
     const [moveHelpOpen, setMoveHelpOpen] = useState(false);
     const [calcHelpOpen, setCalcHelpOpen] = useState(false);
@@ -407,7 +417,7 @@ function UIHelpSection() {
                 <Typography variant="h6" gutterBottom>
                     Strategy Goals
                 </Typography>
-                <CollapseButton open={goalsHelpOpen} setOpen={setGoalsHelpOpen} />
+                <CollapseButton open={goalsHelpOpen} setOpen={setGoalsHelpOpen} setClosed={() => { setRaiderHelpOpen(false); setSubHelpOpen(false); setBossHelpOpen(false); setMoveHelpOpen(false); setCalcHelpOpen(false); }}/>
             </Stack>
             <Collapse in={goalsHelpOpen} >
                 <Typography variant="body1" gutterBottom>
@@ -433,7 +443,7 @@ function UIHelpSection() {
                 <Typography variant="h6" gutterBottom>
                     Raider Builds
                 </Typography>
-                <CollapseButton open={raiderHelpOpen} setOpen={setRaiderHelpOpen} />
+                <CollapseButton open={raiderHelpOpen} setOpen={setRaiderHelpOpen} setClosed={() => { setGoalsHelpOpen(false); setSubHelpOpen(false); setBossHelpOpen(false); setMoveHelpOpen(false); setCalcHelpOpen(false); }}/>
             </Stack>
             <Collapse in={raiderHelpOpen} >
                 <Typography variant="body1" gutterBottom>
@@ -454,9 +464,32 @@ function UIHelpSection() {
         <Box sx={{ paddingLeft: 2, my: 1  }}>
             <Stack direction="row" spacing={1} alignItems="center">
                 <Typography variant="h6" gutterBottom>
+                    Substitute Builds
+                </Typography>
+                <CollapseButton open={subHelpOpen} setOpen={setSubHelpOpen} setClosed={() => { setGoalsHelpOpen(false); setRaiderHelpOpen(false); setBossHelpOpen(false); setMoveHelpOpen(false); setCalcHelpOpen(false); }}/>
+            </Stack>
+            <Collapse in={subHelpOpen} >
+                <Typography variant="body1" gutterBottom>
+                    Substitute builds can be created by pressing the "Add Substitute" button near the top of the Build controls. 
+                    Each raider slot can have multiple substitute builds.
+                </Typography>
+                <Typography variant="body1" gutterBottom>
+                    When the button "Add Substitute" button is clicked, the build information for that slot will be stored along with the order of moves it uses in the move selection UI.
+                    When moves are added or removed in the move selection UI, moves for each substitute build may need to be manually changed.
+                    For this reason, it is a good idea to add substitute builds as the last step in creating a strategy.
+                </Typography>
+                <Typography variant="body1" gutterBottom>
+                    Substitute builds can be loaded by selecting the desired build from the "Load Substitute" menu.
+                    When a substitute is loaded, the current build information is stored as a substitute in its place.
+                </Typography>
+            </Collapse>
+        </Box>
+        <Box sx={{ paddingLeft: 2, my: 1  }}>
+            <Stack direction="row" spacing={1} alignItems="center">
+                <Typography variant="h6" gutterBottom>
                     Raid Boss Builds
                 </Typography>
-                <CollapseButton open={bossHelpOpen} setOpen={setBossHelpOpen} />
+                <CollapseButton open={bossHelpOpen} setOpen={setBossHelpOpen} setClosed={() => { setGoalsHelpOpen(false); setRaiderHelpOpen(false); setSubHelpOpen(false); setMoveHelpOpen(false); setCalcHelpOpen(false); }}/>
             </Stack>
             <Collapse in={bossHelpOpen} >
                 <Typography variant="body1" gutterBottom>
@@ -474,7 +507,7 @@ function UIHelpSection() {
                 <Typography variant="h6" gutterBottom>
                     Move Order
                 </Typography>
-                <CollapseButton open={moveHelpOpen} setOpen={setMoveHelpOpen} />
+                <CollapseButton open={moveHelpOpen} setOpen={setMoveHelpOpen} setClosed={() => { setGoalsHelpOpen(false); setRaiderHelpOpen(false); setSubHelpOpen(false); setBossHelpOpen(false); setCalcHelpOpen(false); }}/>
             </Stack>
             <Collapse in={moveHelpOpen} >
                 <Typography variant="body1" gutterBottom>
@@ -504,7 +537,7 @@ function UIHelpSection() {
                 <Typography variant="h6" gutterBottom>
                     Calc Results
                 </Typography>
-                <CollapseButton open={calcHelpOpen} setOpen={setCalcHelpOpen} />
+                <CollapseButton open={calcHelpOpen} setOpen={setCalcHelpOpen} setClosed={() => { setGoalsHelpOpen(false); setRaiderHelpOpen(false); setSubHelpOpen(false); setBossHelpOpen(false); setMoveHelpOpen(false); }}/>
             </Stack>
             <Collapse in={calcHelpOpen} >
                 <Typography variant="body1" gutterBottom>

--- a/src/uicomponents/Navbar.tsx
+++ b/src/uicomponents/Navbar.tsx
@@ -72,7 +72,7 @@ function Navbar({lightMode, setLightMode, prettyMode, setPrettyMode}: {lightMode
             </AppBar>
             <Box>
                 <Collapse in={showHelp}>
-                    <HelpSection />
+                    <HelpSection setOpen={setShowHelp} />
                 </Collapse>
             </Box>
         </Box>

--- a/src/uicomponents/PokemonSummary.tsx
+++ b/src/uicomponents/PokemonSummary.tsx
@@ -12,7 +12,7 @@ import BuildControls from "./BuildControls";
 
 import PokedexService, { PokemonData } from '../services/getdata';
 import { getItemSpriteURL, getPokemonArtURL, getTypeIconURL, getTeraTypeIconURL } from "../utils";
-import { MoveSetItem } from "../raidcalc/interface";
+import { MoveSetItem, SubstituteBuildInfo, TurnGroupInfo } from "../raidcalc/interface";
 import { MOVES } from "../calc/data/moves";
 import { Raider } from "../raidcalc/Raider";
 import { AbilityName, MoveName } from "../calc/data/interface";
@@ -31,11 +31,14 @@ export function RoleField({pokemon, setPokemon}: {pokemon: Raider, setPokemon: (
             if (pokemon.role !== str) {
                 setStr(pokemon.role);
             }
-        } else if (nameRef.current !== pokemon.name) {
+            nameRef.current = pokemon.name;
+            console.log("case 1")
+        } else if ((nameRef.current !== pokemon.name) && ((str === "") || (str === nameRef.current as string))) {
             nameRef.current = pokemon.name;
             const name = pokemon.species.baseSpecies || pokemon.name; // some regional forms have long names
             setRole(name);
             setStr(name);
+            console.log("case 2")
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [pokemon.role, pokemon.name])
@@ -59,7 +62,10 @@ export function RoleField({pokemon, setPokemon}: {pokemon: Raider, setPokemon: (
     )
 }
 
-function PokemonSummary({pokemon, setPokemon, prettyMode}: {pokemon: Raider, setPokemon: (r: Raider) => void, prettyMode: boolean}) {
+function PokemonSummary({pokemon, setPokemon, groups, setGroups, substitutes, setSubstitutes, prettyMode}: 
+    {pokemon: Raider, setPokemon: (r: Raider) => void, groups: TurnGroupInfo[], setGroups: (g: TurnGroupInfo[]) => void, 
+     substitutes: SubstituteBuildInfo[], setSubstitutes: (s: SubstituteBuildInfo[]) => void, prettyMode: boolean}) {
+
     const [moveSet, setMoveSet] = useState<(MoveSetItem)[]>([])
     const [abilities, setAbilities] = useState<{name: AbilityName, hidden: boolean}[]>([])
   
@@ -91,7 +97,7 @@ function PokemonSummary({pokemon, setPokemon, prettyMode}: {pokemon: Raider, set
     return (
         <Box>
             <Paper elevation={3} sx={{ mx: 1, my: 1, width: 280, display: "flex", flexDirection: "column", padding: "0px"}}>                
-                <Stack direction="column" spacing={0} alignItems="center" justifyContent="top" minHeight= {prettyMode ? "640px" : "800px"} sx={{ marginTop: 1 }} >
+                <Stack direction="column" spacing={0} alignItems="center" justifyContent="top" minHeight= {prettyMode ? "666px" : "800px"} sx={{ marginTop: 1 }} >
                     <Box paddingBottom={0} width="90%">
                         <RoleField pokemon={pokemon} setPokemon={setPokemon} />
                     </Box>
@@ -167,7 +173,17 @@ function PokemonSummary({pokemon, setPokemon, prettyMode}: {pokemon: Raider, set
                             </Box>
                         </Box>
                     </Box>
-                    <BuildControls pokemon={pokemon} abilities={abilities} moveSet={moveSet} setPokemon={setPokemon} prettyMode={prettyMode}/>
+                    <BuildControls 
+                        pokemon={pokemon} 
+                        abilities={abilities} 
+                        moveSet={moveSet} 
+                        setPokemon={setPokemon} 
+                        groups={groups} 
+                        setGroups={setGroups} 
+                        substitutes={substitutes} 
+                        setSubstitutes={setSubstitutes} 
+                        prettyMode={prettyMode}
+                    />
                     <Box flexGrow={1} />
                     <StatRadarPlot nature={nature} evs={pokemon.evs} stats={pokemon.stats} />
                     {/* <Box flexGrow={1} /> */}
@@ -180,5 +196,6 @@ function PokemonSummary({pokemon, setPokemon, prettyMode}: {pokemon: Raider, set
 export default React.memo(PokemonSummary, 
     (prevProps, nextProps) => (
         JSON.stringify(prevProps.pokemon) === JSON.stringify(nextProps.pokemon) && 
+        JSON.stringify(prevProps.substitutes) === JSON.stringify(nextProps.substitutes) &&
         prevProps.prettyMode === nextProps.prettyMode)
     );

--- a/src/uicomponents/PokemonSummary.tsx
+++ b/src/uicomponents/PokemonSummary.tsx
@@ -23,7 +23,7 @@ const allMoves = Object.keys(MOVES[9]).slice(1).sort().slice(1).filter(m => m.su
 export function RoleField({pokemon, setPokemon}: {pokemon: Raider, setPokemon: (r: Raider) => void}) {
     const [str, setStr] = useState(pokemon.role);
     const roleRef = useRef(pokemon.role);
-    const nameRef = useRef(pokemon.name);
+    const nameRef = useRef(pokemon.species.baseSpecies || pokemon.name); // some regional forms have long names
 
     useEffect(() => {
         if (roleRef.current !== pokemon.role) {
@@ -31,10 +31,11 @@ export function RoleField({pokemon, setPokemon}: {pokemon: Raider, setPokemon: (
             if (pokemon.role !== str) {
                 setStr(pokemon.role);
             }
-            nameRef.current = pokemon.name;
+            nameRef.current = pokemon.species.baseSpecies || pokemon.name;
         } else if ((nameRef.current !== pokemon.name) && ((str === "") || (str === nameRef.current as string))) {
-            nameRef.current = pokemon.name;
-            const name = pokemon.species.baseSpecies || pokemon.name; // some regional forms have long names
+            const name = pokemon.species.baseSpecies || pokemon.name; 
+            nameRef.current = name;
+            roleRef.current = name;
             setRole(name);
             setStr(name);
         }

--- a/src/uicomponents/PokemonSummary.tsx
+++ b/src/uicomponents/PokemonSummary.tsx
@@ -32,13 +32,11 @@ export function RoleField({pokemon, setPokemon}: {pokemon: Raider, setPokemon: (
                 setStr(pokemon.role);
             }
             nameRef.current = pokemon.name;
-            console.log("case 1")
         } else if ((nameRef.current !== pokemon.name) && ((str === "") || (str === nameRef.current as string))) {
             nameRef.current = pokemon.name;
             const name = pokemon.species.baseSpecies || pokemon.name; // some regional forms have long names
             setRole(name);
             setStr(name);
-            console.log("case 2")
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [pokemon.role, pokemon.name])

--- a/src/uicomponents/RaidControls.tsx
+++ b/src/uicomponents/RaidControls.tsx
@@ -55,12 +55,12 @@ function HpDisplayLine({role, curhp, maxhp, kos}: {role: string, curhp: number, 
             </Box>
             <Box sx={{ width: 150 }}>
                 <Typography>
-                    {`${curhp}` + " / " + `${maxhp}`}
+                    { curhp + " / " + maxhp }
                 </Typography>
             </Box>
             <Box sx={{ width: 150 }}>
                 <Typography>
-                    {kos > 0 ? (`${kos}` + (kos > 1 ? " KOs" : " KO")) : ""}
+                    {kos > 0 ? ( kos  + (kos > 1 ? " KOs" : " KO")) : ""}
                 </Typography>
             </Box>
         </Stack>
@@ -85,6 +85,7 @@ function HpDisplay({results}: {results: RaidBattleResults}) {
         if (snapToEnd || displayedTurn > results.turnResults.length) {
             setDisplayedTurn(results.turnResults.length);
         }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [results.turnResults.length]);
 
     useEffect(() => {
@@ -93,6 +94,7 @@ function HpDisplay({results}: {results: RaidBattleResults}) {
         } else {
             setSnapToEnd(false);
         }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [displayedTurn]);
 
     return (
@@ -134,11 +136,7 @@ function RaidControls({raidInputProps, results, setResults, prettyMode}: {raidIn
     const pokemon2 = raidInputProps.pokemon[2];
     const pokemon3 = raidInputProps.pokemon[3];
     const pokemon4 = raidInputProps.pokemon[4];
-
-    const roles = raidInputProps.pokemon.map((raider) => raider.role);
-    const currenthps = results.endState.raiders.map((raider) => raider.originalCurHP);
-    const maxhps = results.endState.raiders.map((raider) => ( raider.maxHP === undefined ? new Pokemon(9, raider.name, {...raider}).maxHP() : raider.maxHP()) );
-
+    
     const handleChange = (event: React.SyntheticEvent, newValue: number) => {
         setValue(newValue);
     };  

--- a/src/uicomponents/RaidControls.tsx
+++ b/src/uicomponents/RaidControls.tsx
@@ -81,8 +81,6 @@ function HpDisplay({results}: {results: RaidBattleResults}) {
     koCounts[0] = Math.min(koCounts[0], 1);
     const roles = results.endState.raiders.map((raider) => raider.role);
 
-    console.log(koCounts)
-
     useEffect(() => { 
         if (snapToEnd || displayedTurn > results.turnResults.length) {
             setDisplayedTurn(results.turnResults.length);


### PR DESCRIPTION
Each raider slot can now have substitute builds which can be swapped as desired and saved with a strategy.

With the current implementation, substitute builds only make sense move order does not need to change.

Substitute builds have been added to some of the previous event strats. 

closes #2 