### PR TITLE
Differentiate Optional Moves in Graphic

### DIFF
--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -311,6 +311,7 @@ const MoveLabel = styled(Typography)({
 
 const OptionalMoveLabel = styled(Typography)({
     color: "#dedede",
+    opacity: "50%",
     height: "100px",
     lineHeight: "100px",
     fontSize: "1.3em",
@@ -647,13 +648,13 @@ function generateGraphic(theme: any, raidInputProps: RaidInputProps, isHiddenAbi
                                                             const noMove = (raider.moves[index] && raider.moves[index] !== "(No Move)");
                                                             return (
                                                                 <MoveBox key={"move_box_" + index}>
-                                                                    {noMove ? <MoveTypeIcon src={getTypeIconURL(moveTypes[raider.id][index])} /> : null}
+                                                                    {noMove ? <MoveTypeIcon src={getTypeIconURL(moveTypes[raider.id][index])} sx={{opacity: `${optionalMove[raider.id][index] ? '50%' : '100%'}`}}/> : null}
                                                                     {noMove ? (
                                                                         optionalMove[raider.id][index] ? 
                                                                             <OptionalMoveLabel>{ getTranslation(raider.moves[index] + "*", translationKey, "moves") }</OptionalMoveLabel> : 
                                                                             <MoveLabel>{ getTranslation(raider.moves[index], translationKey, "moves") }</MoveLabel>
                                                                     ) : null}
-                                                                    {noMove ? <MoveLearnMethodIcon src={getMoveMethodIcon(learnMethods[raider.id][index], moveTypes[raider.id][index])} /> : null}
+                                                                    {noMove ? <MoveLearnMethodIcon src={getMoveMethodIcon(learnMethods[raider.id][index], moveTypes[raider.id][index])} sx={{opacity: `${optionalMove[raider.id][index] ? '50%' : '100%'}`}}/> : null}
                                                                 </MoveBox>
                                                             )
                                                         })

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -684,7 +684,7 @@ function generateGraphic(theme: any, raidInputProps: RaidInputProps, isHiddenAbi
                         {(optionalMove.reduce((a,b) => a + b.reduce((c,d) => c + (d ? 1 : 0), 0), 0) > 0) &&
                             <FootnoteContainer>
                                 <FootnoteText>
-                                    * {getTranslation("optional learned moves", translationKey)}
+                                    * {getTranslation("Optional Moves", translationKey)}
                                 </FootnoteText>
                             </FootnoteContainer>
                         }

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -310,7 +310,7 @@ const MoveLabel = styled(Typography)({
 });
 
 const OptionalMoveLabel = styled(Typography)({
-    color: "#dedede",
+    color: "white",
     opacity: "50%",
     height: "100px",
     lineHeight: "100px",
@@ -322,6 +322,21 @@ const MoveLearnMethodIcon = styled("img")({
     height: "80px",
     position: "absolute",
     right: "20px"
+});
+
+const FootnoteContainer = styled(Box)({
+    width: "auto",
+    display: "flex",
+    justifyContent: "right",
+    padding: "0px 100px",
+    margin: "30px 0px"
+});
+
+const FootnoteText = styled(Typography)({
+    color: "white",
+    fontSize: "4em",
+    whiteSpace: "nowrap",
+    fontStyle: "italic"
 });
 
 const ExecutionSection = styled(Box)({
@@ -666,6 +681,13 @@ function generateGraphic(theme: any, raidInputProps: RaidInputProps, isHiddenAbi
                                 ))
                             }
                         </BuildsContainer>
+                        {(optionalMove.reduce((a,b) => a + b.reduce((c,d) => c + (d ? 1 : 0), 0), 0) > 0) &&
+                            <FootnoteContainer>
+                                <FootnoteText>
+                                    * {getTranslation("optional learned moves", translationKey)}
+                                </FootnoteText>
+                            </FootnoteContainer>
+                        }
                     </BuildsSection>
                     <ExecutionSection>
                         <Separator>
@@ -905,9 +927,11 @@ function GraphicsButton({title, notes, credits, raidInputProps, results, setLoad
             const moveTypes = moves.map((ms) => ms.map((move) => move.type));
             // identify moves that aren't used in the strat
             const optionalMove = moves.map((ms,id) => ms.map(m => {
+                if (id === 0) { return false; }
                 const move = results.turnResults.find((r) => r.moveInfo.moveData.name === m.name && r.moveInfo.userID === id);
-                return !move;
+                return !move && (m.name !== undefined) && (m.name !== "(No Move)");
             }))
+            console.log(optionalMove)
             // sort moves into groups
             const moveGroups = getMoveGroups(raidInputProps.groups, results);
             const repeats = raidInputProps.groups.map((group) => group.repeats || 1);


### PR DESCRIPTION
"Optional" moves are those that aren't used by a raider at all during the execution of a strategy. The graphic can indicate which moves are optional via italicization, font color, asterisk with message, or some other visual cue.