### PR TITLE
Add Transform and Mimic

### DIFF
--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -1363,6 +1363,7 @@ export class RaidMove {
                 const lastMove = target.lastMove;
                 if (lastMove) {
                     this._user.mimicMove(lastMove, target.id)
+                    this._desc[this.targetID] = this._user.name + " copied " + lastMove.name + " from " + target.name + "!";
                 }
                 break;
             default: break;

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -84,9 +84,6 @@ export class RaidMove {
 
     public result(): RaidMoveResult {
         this.setOutputRaidState();
-        if (this.moveData.name === "Fake Tears") {
-            console.log(this.userID, this.moveData, this._raidState.getPokemon(this.userID).moveData)
-        }
         if (!this.checkIfMoves()) {
             const output = this.output;
             return output;

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -1355,6 +1355,16 @@ export class RaidMove {
                     this._user.stockpile = 0;
                 }
                 break;
+            case "Transform":
+                this._raidState.transform(this.userID, target.id);
+                this._desc[this.targetID] = this._user.name + " transformed into " + target.name + "!";
+                break;
+            case "Mimic":
+                const lastMove = target.lastMove;
+                if (lastMove) {
+                    this._user.mimicMove(lastMove, target.id)
+                }
+                break;
             default: break;
             }
     }

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -84,6 +84,9 @@ export class RaidMove {
 
     public result(): RaidMoveResult {
         this.setOutputRaidState();
+        if (this.moveData.name === "Fake Tears") {
+            console.log(this.userID, this.moveData, this._raidState.getPokemon(this.userID).moveData)
+        }
         if (!this.checkIfMoves()) {
             const output = this.output;
             return output;

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -1366,6 +1366,13 @@ export class RaidMove {
                     this._desc[this.targetID] = this._user.name + " copied " + lastMove.name + " from " + target.name + "!";
                 }
                 break;
+            case "Sketch":
+                const lastMove2 = target.lastMove;
+                if (lastMove2) {
+                    this._user.sketchMove(lastMove2, target.id)
+                    this._desc[this.targetID] = this._user.name + " copied " + lastMove2.name + " from " + target.name + "!";
+                }
+                break;
             default: break;
             }
     }

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -607,6 +607,12 @@ export class RaidState implements State.RaidState{
     public addAbilityFieldEffect(id: number, ability: AbilityName | "(No Ability)" | undefined, switchIn: boolean = false, restore: boolean = false): string[][] {
         const pokemon = this.getPokemon(id);
         const flags: string[][] = [[],[],[],[],[]];
+        /// Imposter
+        if (ability === "Imposter") {
+            const target = id === 0 ? this.raiders[1] : this.raiders[0];
+            this.transform(id, target.id);
+            flags[id].push("Imposter transforms " + pokemon.name + " into " + target.name);
+        }
         /// Trace (handled separately so the traced ability can activate if applicable)
         if (ability === "Trace") {
             const opponentIds = id === 0 ? [1,2,3,4] : [0];
@@ -1109,10 +1115,15 @@ export class RaidState implements State.RaidState{
         return flags;
     }
 
-    public transform(id:number, target: number) {
+    public transform(id:number, target: number): boolean {
         const pokemon = this.getPokemon(id);
         const targetPokemon = this.getPokemon(target);
-        pokemon.transformInto(targetPokemon);
-        this.changeAbility(id, targetPokemon.ability || "(No Ability)");
+        if (!pokemon.isTransformed && !targetPokemon.isTransformed) {
+            pokemon.transformInto(targetPokemon);
+            this.changeAbility(id, targetPokemon.ability || "(No Ability)");
+            return true;
+        } else {
+            return false;
+        }
     }
 }

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -1024,6 +1024,19 @@ export class RaidState implements State.RaidState{
             }
         }
         // reset stats, status, etc, keeping a few things. HP is reset upon switch-in
+        if (pokemon.isTransformed && pokemon.originalSpecies && pokemon.originalMoves) {
+            const originalSpecies = new Pokemon(9, pokemon.originalSpecies, {
+                ivs: pokemon.ivs,
+                evs: pokemon.evs,
+                nature: pokemon.nature,
+                statMultipliers: pokemon.statMultipliers,
+            });
+            pokemon.name = originalSpecies.name;
+            pokemon.species = originalSpecies.species;
+            pokemon.weightkg = originalSpecies.weightkg;
+            pokemon.stats = originalSpecies.stats;
+            pokemon.rawStats = originalSpecies.rawStats;
+        }
         pokemon.ability = pokemon.originalAbility as AbilityName; // restore original ability
         pokemon.abilityOn = false;
         pokemon.boosts = {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0, eva: 0, acc: 0};
@@ -1041,6 +1054,8 @@ export class RaidState implements State.RaidState{
         pokemon.moveRepeated = undefined;
         pokemon.changedTypes = undefined;
         pokemon.types = new Pokemon(9, pokemon.name).types;
+        pokemon.moveData = pokemon.originalMoves || pokemon.moveData;
+        pokemon.moves = pokemon.moveData.map(m => m.name);
         
         // remove ability effects that are removed upon fainting
         this.removeAbilityFieldEffect(id, ability);
@@ -1092,5 +1107,12 @@ export class RaidState implements State.RaidState{
             flags[id].push(pokemon.name + " is going to go all out against this formidable opponent!")
         }
         return flags;
+    }
+
+    public transform(id:number, target: number) {
+        const pokemon = this.getPokemon(id);
+        const targetPokemon = this.getPokemon(target);
+        pokemon.transformInto(targetPokemon);
+        this.changeAbility(id, targetPokemon.ability || "(No Ability)");
     }
 }

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -1042,6 +1042,8 @@ export class RaidState implements State.RaidState{
             pokemon.weightkg = originalSpecies.weightkg;
             pokemon.stats = originalSpecies.stats;
             pokemon.rawStats = originalSpecies.rawStats;
+            pokemon.isTransformed = false;
+            pokemon.originalAbility = pokemon.originalFormAbility as AbilityName;
         }
         pokemon.ability = pokemon.originalAbility as AbilityName; // restore original ability
         pokemon.abilityOn = false;

--- a/src/raidcalc/RaidTurn.ts
+++ b/src/raidcalc/RaidTurn.ts
@@ -68,8 +68,8 @@ export class RaidTurn {
             this.raiderMoveData = this.raidState.raiders[this.raiderID].moveData.find((move) => move.name === info.moveInfo.moveData.name) || {name: info.moveInfo.moveData.name} as MoveData;
         }
         this.bossMoveData = info.bossMoveInfo.moveData;
-        if (Object.keys(info.moveInfo.moveData).length === 1) {
-            this.bossMoveData = this.raidState.raiders[0].moveData.find((move) => move.name === info.moveInfo.moveData.name) || {name: info.moveInfo.moveData.name} as MoveData;
+        if (Object.keys(info.bossMoveInfo.moveData).length === 1) {
+            this.bossMoveData = this.raidState.raiders[0].moveData.find((move) => move.name === info.bossMoveInfo.moveData.name) || {name: info.bossMoveInfo.moveData.name} as MoveData;
         }
         this.id = info.id;
         this.group = info.group;

--- a/src/raidcalc/RaidTurn.ts
+++ b/src/raidcalc/RaidTurn.ts
@@ -64,7 +64,13 @@ export class RaidTurn {
         this.raiderID = info.moveInfo.userID;
         this.targetID = info.moveInfo.targetID;
         this.raiderMoveData = info.moveInfo.moveData;
+        if (Object.keys(info.moveInfo.moveData).length === 1) { // Transform or Mimic can cause issues with loading full movedata from hashes
+            this.raiderMoveData = this.raidState.raiders[this.raiderID].moveData.find((move) => move.name === info.moveInfo.moveData.name) || {name: info.moveInfo.moveData.name} as MoveData;
+        }
         this.bossMoveData = info.bossMoveInfo.moveData;
+        if (Object.keys(info.moveInfo.moveData).length === 1) {
+            this.bossMoveData = this.raidState.raiders[0].moveData.find((move) => move.name === info.moveInfo.moveData.name) || {name: info.moveInfo.moveData.name} as MoveData;
+        }
         this.id = info.id;
         this.group = info.group;
 

--- a/src/raidcalc/Raider.ts
+++ b/src/raidcalc/Raider.ts
@@ -45,6 +45,7 @@ export class Raider extends Pokemon implements State.Raider {
     isTransformed?: boolean; // indicates that the pokemon has been transformed by Transform or Imposter
     originalSpecies?: SpeciesName; // stores the state of the pokemon before transformation
     originalMoves?: State.MoveData[]; // stores the moves of the pokemon before transformation or Mimic
+    originalFormAbility?: AbilityName | "(No Ability)"; // stores the ability of the pokemon before transformation
 
     constructor(
         id: number, 
@@ -77,6 +78,7 @@ export class Raider extends Pokemon implements State.Raider {
         isTransformed: boolean | undefined = undefined,
         originalSpecies: SpeciesName | undefined = undefined,
         originalMoves: State.MoveData[] | undefined = undefined,
+        originalFormAbility: AbilityName | "(No Ability)" | undefined = undefined,
     ) {
         super(pokemon.gen, pokemon.name, {...pokemon})
         this.id = id;
@@ -108,6 +110,7 @@ export class Raider extends Pokemon implements State.Raider {
         this.isTransformed = isTransformed;
         this.originalSpecies  = originalSpecies;
         this.originalMoves = originalMoves;
+        this.originalFormAbility = originalAbility || pokemon.ability || "(No Ability)";
     }
 
     clone(): Raider {
@@ -177,6 +180,7 @@ export class Raider extends Pokemon implements State.Raider {
             this.isTransformed,
             this.originalSpecies,
             this.originalMoves,
+            this.originalFormAbility,
         )
     }
 
@@ -280,13 +284,14 @@ export class Raider extends Pokemon implements State.Raider {
         this.name = pokemon.name;
         this.species = pokemon.species;
         this.weightkg = pokemon.weightkg;
-        this.rawStats = {...pokemon.rawStats};
+        this.rawStats = {...pokemon.rawStats, hp: this.rawStats.hp}; // HP is retained
         this.types = pokemon.types.slice() as [TypeName] | [TypeName, TypeName];
         // copy stats and moves
         this.boosts = {...pokemon.boosts};
         this.moves = pokemon.moves.slice();
         this.moveData = pokemon.moveData.slice();
         this.stats = {...pokemon.stats, hp: this.stats.hp}; // HP is retained
+        this.originalAbility = pokemon.ability as AbilityName;
         // this.ability = pokemon.ability; // handle ability change in the RaidState
     }
 

--- a/src/raidcalc/Raider.ts
+++ b/src/raidcalc/Raider.ts
@@ -303,9 +303,10 @@ export class Raider extends Pokemon implements State.Raider {
         const mimicIndex = this.moves.findIndex(m => m === "Mimic");
         if (mimicIndex === -1) { return; }
         this.moves[mimicIndex] = move.name;
-        this.moveData[mimicIndex] = move;
+        this.moveData[mimicIndex] = {...move};
         this.lastMove = move;
         this.lastTarget = targetID;
         this.moveRepeated = 0;
+        console.log(this.moveData)
     }
 }

--- a/src/raidcalc/Raider.ts
+++ b/src/raidcalc/Raider.ts
@@ -296,7 +296,7 @@ export class Raider extends Pokemon implements State.Raider {
     }
 
     public mimicMove(move: State.MoveData, targetID: number) {
-        if (targetID === 0) { return; } // ???
+        // if (targetID === 0) { return; } // ???
         if (!this.originalMoves) {
             this.originalMoves = this.moveData.slice();
         }
@@ -304,6 +304,17 @@ export class Raider extends Pokemon implements State.Raider {
         if (mimicIndex === -1) { return; }
         this.moves[mimicIndex] = move.name;
         this.moveData[mimicIndex] = {...move};
+        this.lastMove = move;
+        this.lastTarget = targetID;
+        this.moveRepeated = 0;
+    }
+
+    public sketchMove(move: State.MoveData, targetID: number) {
+        // if (targetID === 0) { return; } // ???
+        const sketchIndex = this.moves.findIndex(m => m === "Sketch");
+        if (sketchIndex === -1) { return; }
+        this.moves[sketchIndex] = move.name;
+        this.moveData[sketchIndex] = {...move};
         this.lastMove = move;
         this.lastTarget = targetID;
         this.moveRepeated = 0;

--- a/src/raidcalc/Raider.ts
+++ b/src/raidcalc/Raider.ts
@@ -307,6 +307,5 @@ export class Raider extends Pokemon implements State.Raider {
         this.lastMove = move;
         this.lastTarget = targetID;
         this.moveRepeated = 0;
-        console.log(this.moveData)
     }
 }

--- a/src/raidcalc/interface.ts
+++ b/src/raidcalc/interface.ts
@@ -1,5 +1,5 @@
 import { Pokemon, Field, StatID } from "../calc";
-import { AbilityName, ItemName, MoveName, TypeName } from "../calc/data/interface";
+import { AbilityName, ItemName, MoveName, SpeciesName, TypeName } from "../calc/data/interface";
 
 export type MoveSetItem = {
     name: string,
@@ -121,6 +121,9 @@ export interface Raider extends Pokemon {
     syrupBombDrops?: number;
     syrupBombSource?: number;
     lastConsumedItem?: ItemName;
+    isTransformed?: boolean;
+    originalSpecies?: SpeciesName;
+    originalMoves?: MoveData[];
 }
 
 export interface RaidState {

--- a/src/uicomponents/RaidControls.tsx
+++ b/src/uicomponents/RaidControls.tsx
@@ -58,7 +58,7 @@ type Modifiers = {
     endure?: boolean,
     ingrain?: boolean,
     micleBerry?: boolean,
-    pumped?: boolean,
+    pumped?: number,
     saltCure?: boolean,
     stockpile?: number,
     taunt?: boolean,
@@ -380,8 +380,8 @@ function HpDisplay({results, translationKey}: {results: RaidBattleResults, trans
             kos + ((turn.state.raiders[i].originalCurHP === 0 && (i === 0 || turn.moveInfo.userID === i)) ? 1 : 0),
         0));
     koCounts[0] = Math.min(koCounts[0], 1);
-    const roles = results.endState.raiders.map((raider) => raider.role);
-    const names = results.endState.raiders.map((raider) => raider.name);
+    const roles = turnState.raiders.map((raider) => raider.role);
+    const names = turnState.raiders.map((raider) => raider.name);
     const items = turnState.raiders.map((raider) => raider.item);
     const abilities = turnState.raiders.map((raider) => raider.ability);
 

--- a/src/uicomponents/RaidControls.tsx
+++ b/src/uicomponents/RaidControls.tsx
@@ -361,8 +361,7 @@ function HpDisplayLine({role, name, item, ability, curhp, prevhp, maxhp, kos, st
 function HpDisplay({results, translationKey}: {results: RaidBattleResults, translationKey: any}) {
     const [displayedTurn, setDisplayedTurn] = useState<number>(0);
     const [snapToEnd, setSnapToEnd] = useState<boolean>(true);
-    const maxhps = results.endState.raiders.map((raider) => ( raider.maxHP === undefined ? new Pokemon(9, raider.name, {...raider}).maxHP() : raider.maxHP()) );
-    
+
     const turnState = (
         (displayedTurn === 0) ? results.turnZeroState :
         (displayedTurn > results.turnResults.length) ? results.endState : 
@@ -373,6 +372,7 @@ function HpDisplay({results, translationKey}: {results: RaidBattleResults, trans
         (displayedTurn > results.turnResults.length) ? results.endState :
         results.turnResults[Math.min(results.turnResults.length, displayedTurn) - 2].state
     );
+    const maxhps = turnState.raiders.map((raider) => ( raider.maxHP === undefined ? new Pokemon(9, (raider.isTransformed && raider.originalSpecies) ? raider.originalSpecies  : raider.name, {...raider}).maxHP() : raider.maxHP()) );
     const currenthps = displayedTurn === 0 ? maxhps : turnState.raiders.map((raider) => raider.originalCurHP); 
     const prevhps = displayedTurn <= 1 ? maxhps : prevTurnState.raiders.map((raider) => raider.originalCurHP);
 
@@ -714,7 +714,7 @@ function RaidControls({raidInputProps, results, setResults, prettyMode, translat
                 <Box hidden={value !== 1}>
                     <Box sx={{ height: 560, overflowY: "auto" }}>
                         {!prettyMode &&
-                            <MoveSelection raidInputProps={raidInputProps} rollCase={rollCase} translationKey={translationKey}/>
+                            <MoveSelection raidInputProps={raidInputProps} results={results} rollCase={rollCase} translationKey={translationKey}/>
                         }
                         {prettyMode &&
                             <MoveDisplay groups={raidInputProps.groups} raiders={raidInputProps.pokemon} results={results} translationKey={translationKey}/>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
 import { StatID, StatsTable } from "./calc";
-import { TurnGroupInfo } from "./raidcalc/interface";
+import { Raider } from "./raidcalc/Raider";
+import { RaidInputProps } from "./raidcalc/inputs";
+import { MoveData, TurnGroupInfo } from "./raidcalc/interface";
 
 const SPECIAL_NAMES = {
     // Hyphenated Pokemon Names
@@ -260,6 +262,51 @@ export function sortGroupsIntoTurns(turnNumbers: number[], groups: TurnGroupInfo
         } 
     }
     return [turns, labels];
+}
+
+export function getModifiedRaidersForMoveSelection(raidInputProps: RaidInputProps): {raider: Raider, moveidx: number}[][] {
+    const modifiedRaiders = (raidInputProps.pokemon.map((raider) => {return [{raider: raider, moveidx: 0}]}))
+    // imposter check
+    for (let raider of raidInputProps.pokemon) {
+        if (raider.ability === "Imposter") {
+            const newRaider = raider.clone();
+            const target = raider.id === 0 ? raidInputProps.pokemon[1] : raidInputProps.pokemon[0];
+            newRaider.transformInto(target);
+            modifiedRaiders[raider.id][0] = {raider: newRaider, moveidx: 0};
+        }
+    }
+    // transform and mimic checks
+    let moveidx = 0;
+    const lastMovesUsed: (MoveData | undefined)[] = [];
+    for (let i=0; i<raidInputProps.groups.length; i++) {
+        const g = raidInputProps.groups[i]
+        for (let j=0; j<g.turns.length; j++) {
+            moveidx += 1; // modifications will only appear on the next move
+            const t = g.turns[j];
+            const raiderID = t.moveInfo.userID;
+            const targetID = t.moveInfo.targetID;
+            const moveName = t.moveInfo.moveData.name;
+            const moveData = t.moveInfo.moveData;
+            if (moveName === "Transform") {
+                const raider = modifiedRaiders[raiderID][modifiedRaiders[raiderID].length-1].raider;
+                const target = modifiedRaiders[targetID][modifiedRaiders[targetID].length-1].raider;
+                const newRaider = raider.clone();
+                newRaider.transformInto(target);
+                modifiedRaiders[raiderID].push({raider: newRaider, moveidx: moveidx});
+            } else if (moveName === "Mimic" || moveName === "Sketch") {
+                const raider = modifiedRaiders[raiderID][modifiedRaiders[raiderID].length-1].raider;
+                const newRaider = raider.clone();
+                const copiedMove = lastMovesUsed[targetID];
+                if (copiedMove && !["Attack Cheer", "Defense Cheer", "Heal Cheer", "(Most Damaging)", "(No Move)", "Remove Negative Effects", "Clear Boosts / Abilities"].includes(copiedMove.name)) {
+                    newRaider.mimicMove(copiedMove, targetID);
+                    console.log(copiedMove, newRaider.moves)
+                }
+                modifiedRaiders[raiderID].push({raider: newRaider, moveidx: moveidx});
+            }
+            lastMovesUsed[raiderID] = moveData;
+        }
+    }
+    return modifiedRaiders;
 }
 
 export function getTranslation(word: string, translationKey: any, translationCategory: string = "ui") {


### PR DESCRIPTION
Implement Transform (as well as Imposter) and Mimic in raid simulations, and allow them to influence move selection in the UI

