### PR TITLE
Add stat plots to graphics, UI tweaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "tera-raid-builder",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
@@ -28,7 +28,7 @@
         "firebase": "^10.6.0",
         "html2canvas": "^1.4.1",
         "pako": "^2.1.0",
-        "plotly.js": "^2.24.3",
+        "plotly.js": "^2.28.0",
         "react": "^18.2.0",
         "react-beautiful-dnd": "^13.1.1",
         "react-dom": "^18.2.0",
@@ -4287,6 +4287,38 @@
         "d3-collection": "^1.0.4",
         "d3-shape": "^1.2.0",
         "elementary-circuits-directed-graph": "^1.0.4"
+      }
+    },
+    "node_modules/@plotly/mapbox-gl": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@plotly/mapbox-gl/-/mapbox-gl-1.13.4.tgz",
+      "integrity": "sha512-sR3/Pe5LqT/fhYgp4rT4aSFf1rTsxMbGiH6Hojc7PH36ny5Bn17iVFUjpzycafETURuFbLZUfjODO8LvSI+5zQ==",
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.2",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.5.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^1.1.1",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.2",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.2.1",
+        "grid-index": "^1.1.0",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^7.1.0",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6.4.0"
       }
     },
     "node_modules/@plotly/point-cluster": {
@@ -14425,11 +14457,12 @@
       }
     },
     "node_modules/mapbox-gl": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.1.tgz",
-      "integrity": "sha512-0aHt+lFUpYfvh0kMIqXqNXqoYMuhuAsMlw87TbhWrw78Tx2zfuPI0Lx31/YPUgJ+Ire0tzQ4JnuBL7acDNXmMg==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.3.tgz",
+      "integrity": "sha512-p8lJFEiqmEQlyv+DQxFAOG/XPWN0Wp7j/Psq93Zywz7qt9CcUKFYDBOoOEKzqe6gudHVJY8/Bhqw6VDpX2lSBg==",
+      "peer": true,
       "dependencies": {
-        "@mapbox/geojson-rewind": "^0.5.0",
+        "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/geojson-types": "^1.0.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/mapbox-gl-supported": "^1.5.0",
@@ -14443,13 +14476,12 @@
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.2.1",
         "grid-index": "^1.1.0",
-        "minimist": "^1.2.5",
         "murmurhash-js": "^1.0.0",
         "pbf": "^3.2.1",
         "potpack": "^1.0.1",
         "quickselect": "^2.0.0",
         "rw": "^1.3.3",
-        "supercluster": "^7.0.0",
+        "supercluster": "^7.1.0",
         "tinyqueue": "^2.0.3",
         "vt-pbf": "^3.1.1"
       },
@@ -15565,16 +15597,18 @@
       }
     },
     "node_modules/plotly.js": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-2.27.1.tgz",
-      "integrity": "sha512-XeE0zTJWTxURYrUJqzf73l8lTb+HnyRvvhHkoSIEvWf58ins4saopo9l25kCm+xHAGz8E/2EOncE4DyXsJ34kA==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-2.28.0.tgz",
+      "integrity": "sha512-fEvAapXhFTFO/PM5LnUvoG+tgOxRjjW7C7nHwVaDLKfq0F+SF/p3zRgo7vKwk9588WfgEHvuk6yRnp1mxZ+YSw==",
       "dependencies": {
         "@plotly/d3": "3.8.1",
         "@plotly/d3-sankey": "0.7.2",
         "@plotly/d3-sankey-circular": "0.33.1",
+        "@plotly/mapbox-gl": "v1.13.4",
         "@turf/area": "^6.4.0",
         "@turf/bbox": "^6.4.0",
         "@turf/centroid": "^6.0.2",
+        "base64-arraybuffer": "^1.0.2",
         "canvas-fit": "^1.5.0",
         "color-alpha": "1.0.4",
         "color-normalize": "1.5.0",
@@ -15596,7 +15630,6 @@
         "has-hover": "^1.0.1",
         "has-passive-events": "^1.0.0",
         "is-mobile": "^4.0.0",
-        "mapbox-gl": "1.10.1",
         "mouse-change": "^1.4.0",
         "mouse-event-offset": "^3.0.2",
         "mouse-wheel": "^1.2.0",
@@ -15608,7 +15641,7 @@
         "regl": "npm:@plotly/regl@^2.1.2",
         "regl-error2d": "^2.0.12",
         "regl-line2d": "^3.1.2",
-        "regl-scatter2d": "^3.2.9",
+        "regl-scatter2d": "^3.3.1",
         "regl-splom": "^1.0.14",
         "strongly-connected-components": "^1.0.1",
         "superscript-text": "^1.0.0",
@@ -17636,9 +17669,9 @@
       }
     },
     "node_modules/regl-scatter2d": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.2.9.tgz",
-      "integrity": "sha512-PNrXs+xaCClKpiB2b3HZ2j3qXQXhC5kcTh/Nfgx9rLO0EpEhab0BSQDqAsbdbpdf+pSHSJvbgitB7ulbGeQ+Fg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.3.1.tgz",
+      "integrity": "sha512-seOmMIVwaCwemSYz/y4WE0dbSO9svNFSqtTh5RE57I7PjGo3tcUYKtH0MTSoshcAsreoqN8HoCtnn8wfHXXfKQ==",
       "dependencies": {
         "@plotly/point-cluster": "^3.1.9",
         "array-range": "^1.0.1",
@@ -23761,6 +23794,35 @@
         "d3-collection": "^1.0.4",
         "d3-shape": "^1.2.0",
         "elementary-circuits-directed-graph": "^1.0.4"
+      }
+    },
+    "@plotly/mapbox-gl": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@plotly/mapbox-gl/-/mapbox-gl-1.13.4.tgz",
+      "integrity": "sha512-sR3/Pe5LqT/fhYgp4rT4aSFf1rTsxMbGiH6Hojc7PH36ny5Bn17iVFUjpzycafETURuFbLZUfjODO8LvSI+5zQ==",
+      "requires": {
+        "@mapbox/geojson-rewind": "^0.5.2",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.5.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^1.1.1",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.2",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.2.1",
+        "grid-index": "^1.1.0",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^7.1.0",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.1"
       }
     },
     "@plotly/point-cluster": {
@@ -31426,11 +31488,12 @@
       }
     },
     "mapbox-gl": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.1.tgz",
-      "integrity": "sha512-0aHt+lFUpYfvh0kMIqXqNXqoYMuhuAsMlw87TbhWrw78Tx2zfuPI0Lx31/YPUgJ+Ire0tzQ4JnuBL7acDNXmMg==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.3.tgz",
+      "integrity": "sha512-p8lJFEiqmEQlyv+DQxFAOG/XPWN0Wp7j/Psq93Zywz7qt9CcUKFYDBOoOEKzqe6gudHVJY8/Bhqw6VDpX2lSBg==",
+      "peer": true,
       "requires": {
-        "@mapbox/geojson-rewind": "^0.5.0",
+        "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/geojson-types": "^1.0.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/mapbox-gl-supported": "^1.5.0",
@@ -31444,13 +31507,12 @@
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.2.1",
         "grid-index": "^1.1.0",
-        "minimist": "^1.2.5",
         "murmurhash-js": "^1.0.0",
         "pbf": "^3.2.1",
         "potpack": "^1.0.1",
         "quickselect": "^2.0.0",
         "rw": "^1.3.3",
-        "supercluster": "^7.0.0",
+        "supercluster": "^7.1.0",
         "tinyqueue": "^2.0.3",
         "vt-pbf": "^3.1.1"
       }
@@ -32270,16 +32332,18 @@
       }
     },
     "plotly.js": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-2.27.1.tgz",
-      "integrity": "sha512-XeE0zTJWTxURYrUJqzf73l8lTb+HnyRvvhHkoSIEvWf58ins4saopo9l25kCm+xHAGz8E/2EOncE4DyXsJ34kA==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-2.28.0.tgz",
+      "integrity": "sha512-fEvAapXhFTFO/PM5LnUvoG+tgOxRjjW7C7nHwVaDLKfq0F+SF/p3zRgo7vKwk9588WfgEHvuk6yRnp1mxZ+YSw==",
       "requires": {
         "@plotly/d3": "3.8.1",
         "@plotly/d3-sankey": "0.7.2",
         "@plotly/d3-sankey-circular": "0.33.1",
+        "@plotly/mapbox-gl": "v1.13.4",
         "@turf/area": "^6.4.0",
         "@turf/bbox": "^6.4.0",
         "@turf/centroid": "^6.0.2",
+        "base64-arraybuffer": "^1.0.2",
         "canvas-fit": "^1.5.0",
         "color-alpha": "1.0.4",
         "color-normalize": "1.5.0",
@@ -32301,7 +32365,6 @@
         "has-hover": "^1.0.1",
         "has-passive-events": "^1.0.0",
         "is-mobile": "^4.0.0",
-        "mapbox-gl": "1.10.1",
         "mouse-change": "^1.4.0",
         "mouse-event-offset": "^3.0.2",
         "mouse-wheel": "^1.2.0",
@@ -32313,7 +32376,7 @@
         "regl": "npm:@plotly/regl@^2.1.2",
         "regl-error2d": "^2.0.12",
         "regl-line2d": "^3.1.2",
-        "regl-scatter2d": "^3.2.9",
+        "regl-scatter2d": "^3.3.1",
         "regl-splom": "^1.0.14",
         "strongly-connected-components": "^1.0.1",
         "superscript-text": "^1.0.0",
@@ -33630,9 +33693,9 @@
       }
     },
     "regl-scatter2d": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.2.9.tgz",
-      "integrity": "sha512-PNrXs+xaCClKpiB2b3HZ2j3qXQXhC5kcTh/Nfgx9rLO0EpEhab0BSQDqAsbdbpdf+pSHSJvbgitB7ulbGeQ+Fg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.3.1.tgz",
+      "integrity": "sha512-seOmMIVwaCwemSYz/y4WE0dbSO9svNFSqtTh5RE57I7PjGo3tcUYKtH0MTSoshcAsreoqN8HoCtnn8wfHXXfKQ==",
       "requires": {
         "@plotly/point-cluster": "^3.1.9",
         "array-range": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "firebase": "^10.6.0",
     "html2canvas": "^1.4.1",
     "pako": "^2.1.0",
-    "plotly.js": "^2.24.3",
+    "plotly.js": "^2.28.0",
     "react": "^18.2.0",
     "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -252,7 +252,7 @@ function App() {
   const gen = Generations.get(9); 
 
   const [raidBoss, setRaidBoss] = useState(
-    new Raider(0, "Raid Boss", false, new Field(), new Pokemon(gen, "Pikachu", {
+    new Raider(0, "Raid Boss", false, false, new Field(), new Pokemon(gen, "Pikachu", {
       shieldData: {hpTrigger: 0, timeTrigger: 0, shieldCancelDamage: 0, shieldDamageRate: 0, shieldDamageRateTera: 0, shieldDamageRateTeraChange: 0}
     }), 
     [], 
@@ -260,19 +260,19 @@ function App() {
     [])
   );
   const [raider1, setRaider1] = useState(
-    new Raider(1, "Loading...", false, new Field(), new Pokemon(gen, "Pikachu"), 
+    new Raider(1, "Loading...", false, false, new Field(), new Pokemon(gen, "Pikachu"), 
     [])
   );
   const [raider2, setRaider2] = useState(
-    new Raider(2, "Loading...", false, new Field(), new Pokemon(gen, "Pikachu"), 
+    new Raider(2, "Loading...", false, false, new Field(), new Pokemon(gen, "Pikachu"), 
     [])
   );
   const [raider3, setRaider3] = useState(
-    new Raider(3, "Loading...", false, new Field(), new Pokemon(gen, "Pikachu"), 
+    new Raider(3, "Loading...", false, false, new Field(), new Pokemon(gen, "Pikachu"), 
     [])
   );
   const [raider4, setRaider4] = useState(
-    new Raider(4, "Loading...", false, new Field(), new Pokemon(gen, "Pikachu"), 
+    new Raider(4, "Loading...", false, false, new Field(), new Pokemon(gen, "Pikachu"), 
     [])
   );
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -456,6 +456,11 @@ function App() {
         </Grid>
       </Stack>
     </Stack>
+    {/* For graphic generation */}
+    <Box id={"statplot1"} display="none" />
+    <Box id={"statplot2"} display="none" />
+    <Box id={"statplot3"} display="none" />
+    <Box id={"statplot4"} display="none" />
   </ThemeProvider>
   );
 }

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -1178,6 +1178,7 @@ export class RaidState implements State.RaidState{
                 id,
                 pokemon.role,
                 pokemon.shiny,
+                false,
                 pokemon.field.clone(),
                 new Pokemon(
                     gen,

--- a/src/raidcalc/Raider.ts
+++ b/src/raidcalc/Raider.ts
@@ -11,6 +11,7 @@ export class Raider extends Pokemon implements State.Raider {
     id: number;
     role: string;
     shiny: boolean;
+    isAnyLevel: boolean;        // keeps track of whether or not the Raider should be displayed as having "Any" level for display/graphic purposes
     field: Field;               // each pokemon gets its own field to deal with things like Helping Hand and Protect
     moveData: State.MoveData[];   
     extraMoves?: MoveName[];    // for special boss actions
@@ -54,7 +55,8 @@ export class Raider extends Pokemon implements State.Raider {
     constructor(
         id: number, 
         role: string, 
-        shiny: boolean | undefined, 
+        shiny: boolean | undefined,
+        isAnyLevel: boolean | undefined,
         field: Field, 
         pokemon: Pokemon, 
         moveData: State.MoveData[], 
@@ -91,6 +93,7 @@ export class Raider extends Pokemon implements State.Raider {
         this.id = id;
         this.role = role;
         this.shiny = !!shiny;
+        this.isAnyLevel = !!isAnyLevel;
         this.field = field;
         this.moveData = moveData;
         this.extraMoves = extraMoves;
@@ -128,6 +131,7 @@ export class Raider extends Pokemon implements State.Raider {
             this.id, 
             this.role, 
             this.shiny,
+            this.isAnyLevel,
             this.field.clone(),
             new Pokemon(this.gen, this.name, {
                 level: this.level,

--- a/src/raidcalc/hashData.ts
+++ b/src/raidcalc/hashData.ts
@@ -5,6 +5,7 @@ export type LightPokemon = {
     role: string,
     name: string,
     shiny?: boolean,
+    isAnyLevel?: boolean,
     ability?: string,
     item?: string,
     nature?: string,

--- a/src/raidcalc/interface.ts
+++ b/src/raidcalc/interface.ts
@@ -99,6 +99,7 @@ export interface Raider extends Pokemon {
     id: number;
     role: string;
     shiny?: boolean;
+    isAnyLevel?: boolean;
     field: Field;
     moveData: MoveData[];
     extraMoves?: MoveName[];// for special boss actions
@@ -173,6 +174,7 @@ export type SetOption = {
     name: string,
     pokemon: SpeciesName,
     shiny?: boolean,
+    isAnyLevel?: boolean,
     level?: number,
     gender?: GenderName,
     item?: ItemName,

--- a/src/uicomponents/BuildControls.tsx
+++ b/src/uicomponents/BuildControls.tsx
@@ -1346,16 +1346,14 @@ function BuildControls({pokemon, abilities, moveSet, setPokemon, substitutes, se
                                                 onChange={(e) => {
                                                     if (e.target.value === "") {
                                                         setLevel(0);
-                                                        setPokemonProperty("level")(1);
-                                                        setPokemonProperty("isAnyLevel")(true);
+                                                        setPokemonProperties(["level", "isAnyLevel"])([1, true]);
                                                         return;
                                                     }
                                                     let lvl = parseInt(e.target.value);
                                                     if (lvl < 0) lvl = 0;
                                                     if (lvl > 100) lvl = 100;
                                                     setLevel(lvl);
-                                                    setPokemonProperty("level")(lvl || 1);
-                                                    if (lvl !== 0){ setPokemonProperty("isAnyLevel")(false); }
+                                                    setPokemonProperties(["level", "isAnyLevel"])([lvl || 1, lvl === 0]);
                                                 }}
                                             />
                                         }

--- a/src/uicomponents/BuildControls.tsx
+++ b/src/uicomponents/BuildControls.tsx
@@ -1167,6 +1167,7 @@ function BuildControls({pokemon, abilities, moveSet, setPokemon, substitutes, se
 
         const poke = new Pokemon(gen, set.pokemon, {
             level: set.level || 100,
+            gender: set.gender,
             bossMultiplier: undefined,
             teraType: undefined,
             ability: set.ability || "(No Ability)" as AbilityName,
@@ -1699,6 +1700,7 @@ function BossBuildControls({moveSet, pokemon, setPokemon, allMoves, prettyMode, 
 
         const poke = new Pokemon(gen, set.pokemon, {
             level: set.level || 100,
+            gender: set.gender,
             bossMultiplier: set.bossMultiplier || 100,
             teraType: set.teraType || undefined,
             ability: set.ability, // || "(No Ability)" as AbilityName,

--- a/src/uicomponents/BuildControls.tsx
+++ b/src/uicomponents/BuildControls.tsx
@@ -1129,10 +1129,15 @@ function BuildControls({pokemon, abilities, moveSet, setPokemon, substitutes, se
     }, [pokemon.name, pokemon.item])
 
     useEffect(() => {
-        if ((pokemon.level !== level) && !(level === 0 && pokemon.level === 1)) {
+        if (pokemon.isAnyLevel) {
+            setLevel(0);
+            if (pokemon.level !== 1) {
+                setPokemonProperty("level")(1);
+            }
+        } else if ((pokemon.level !== level) && !(level === 0 && pokemon.level === 1)) {
             setLevel(pokemon.level);
         }
-    }, [pokemon.level])
+    }, [pokemon.level, pokemon.isAnyLevel])
 
     const setPokemonProperty = (propName: string) => {
         return (val: any) => {
@@ -1337,20 +1342,23 @@ function BuildControls({pokemon, abilities, moveSet, setPokemon, substitutes, se
                                                 type="number"
                                                 InputProps={{
                                                     inputProps: { 
-                                                        max: 100, min: 0 
+                                                        max: 100, min: isBoss ? 1 : 0 
                                                     }
                                                 }}
                                                 fullWidth={false}
                                                 value={level || ""}
                                                 placeholder={getTranslation("Any", translationKey)}
                                                 onChange={(e) => {
+                                                    const min = isBoss ? 1 : 0;
                                                     if (e.target.value === "") {
-                                                        setLevel(0);
-                                                        setPokemonProperties(["level", "isAnyLevel"])([1, true]);
+                                                        console.log("set to min", min)
+                                                        setLevel(min);
+                                                        setPokemonProperties(["level", "isAnyLevel"])([1, min === 0]);
                                                         return;
                                                     }
                                                     let lvl = parseInt(e.target.value);
-                                                    if (lvl < 0) lvl = 0;
+                                                    if (isNaN(lvl)) lvl = min;
+                                                    if (lvl < min) lvl = min;
                                                     if (lvl > 100) lvl = 100;
                                                     setLevel(lvl);
                                                     setPokemonProperties(["level", "isAnyLevel"])([lvl || 1, lvl === 0]);

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -287,8 +287,8 @@ const StatPlotContainer = styled(Box)({
 const StatPlot = styled("img")({
     height: "auto",
     width: "auto",
-    maxHeight: "475px",
-    maxWidth: "775px",
+    maxHeight: "460px",
+    maxWidth: "750px",
 
 });
 

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -15,7 +15,7 @@ import watermark from "watermarkjs";
 import { saveAs } from 'file-saver';
 
 import Button from "@mui/material/Button"
-import { TextField } from "@mui/material";
+import { Checkbox, TextField } from "@mui/material";
 import { styled } from "@mui/material/styles"
 
 import { createRoot } from 'react-dom/client';
@@ -954,6 +954,7 @@ function GraphicsButton({title, notes, credits, raidInputProps, results, allSpec
     const loadedImageURLRef = useRef<string>(getMiscImageURL("default"));
     const [subtitle, setSubtitle] = useState<string>("");
     const [watermarkText, setWatermarkText] = useState<string>("");
+    const [plotsEnabled, setPlotsEnable] = useState<boolean>(false);
 
     const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
@@ -1004,7 +1005,7 @@ function GraphicsButton({title, notes, credits, raidInputProps, results, allSpec
             // sort moves into groups
             const [turnGroups, turnNumbers] = getTurnGroups(raidInputProps.groups, results);
             // generate radar plots
-            const statPlots = await Promise.all(
+            const statPlots = !plotsEnabled ? undefined : await Promise.all(
                 raidInputProps.pokemon.slice(1).map((poke) => {
                     const nature = gen.natures.get(toID(poke.nature));
                     return getStatRadarPlotPNG(poke.id, nature, poke.evs, poke.stats, translationKey, 20);
@@ -1040,49 +1041,82 @@ function GraphicsButton({title, notes, credits, raidInputProps, results, allSpec
                     horizontal: 'center',
                   }}
             >
-                <MenuItem>
-                    <input
-                        accept="image/*"
-                        style={{ display: 'none' }}
-                        id="graphic-button-file"
-                        type="file"
-                        onChange={handleFileInputChange}
-                    />
-                    <label htmlFor="graphic-button-file">
-                        <Button
+                <li>
+                    <Box width="100%" alignItems="center" justifyContent="center" sx={{ px: "12px", py: "6px" }}>
+                        <input
+                            accept="image/*"
+                            style={{ display: 'none' }}
+                            id="graphic-button-file"
+                            type="file"
+                            onChange={handleFileInputChange}
+                        />
+                        <Stack direction="row">
+                            <Box flexGrow={1} />
+                            <label htmlFor="graphic-button-file">
+                                <Button
+                                    variant="outlined"
+                                    component="span"
+                                >
+                                    { getTranslation("Choose background", translationKey) }
+                                </Button>
+                            </label>
+                            <Box flexGrow={1} />
+                        </Stack>
+                    </Box>
+                </li>
+                <li>
+                    <Box width="100%" alignItems="center" justifyContent="center" sx={{ px: "12px", py: "6px" }}>
+                        <TextField 
                             variant="outlined"
-                            component="span"
-                        >
-                            { getTranslation("Choose background", translationKey) }
-                        </Button>
-                    </label>
-                </MenuItem>
-                <MenuItem>
-                    <TextField 
-                        variant="outlined"
-                        placeholder={getTranslation("Subtitle", translationKey)}
-                        value={subtitle}
-                        onChange={(e) => setSubtitle(e.target.value)}
-                    />
-                </MenuItem>
-                <MenuItem>
-                    <TextField 
-                        variant="outlined"
-                        placeholder={getTranslation("Watermark text", translationKey)}
-                        value={watermarkText}
-                        inputProps={{ maxLength: 50 }}
-                        onChange={(e) => setWatermarkText(e.target.value)}
-                    />
-                </MenuItem>
-                <MenuItem>
-                  <Button
-                    variant="outlined"
-                    onClick={() => { handleDownload(); handleClose(); }}
-                    endIcon={<DownloadIcon />}
-                  >
-                    { getTranslation("Download", translationKey) }
-                  </Button>
-                </MenuItem>
+                            placeholder={getTranslation("Subtitle", translationKey)}
+                            value={subtitle}
+                            onChange={(e) => setSubtitle(e.target.value)}
+                        />
+                    </Box>
+                </li>
+                <li>
+                    <Box width="100%" alignItems="center" justifyContent="center" sx={{ px: "12px", py: "6px" }}>
+                        <TextField 
+                            variant="outlined"
+                            placeholder={getTranslation("Watermark text", translationKey)}
+                            value={watermarkText}
+                            inputProps={{ maxLength: 50 }}
+                            onChange={(e) => setWatermarkText(e.target.value)}
+                        />
+                    </Box>
+                </li>
+                <li>
+                    <Box width="100%" alignItems="center" justifyContent="center" sx={{ px: "12px", py: "6px" }}>
+                        <Stack direction="row" alignItems="center" justifyContent="center">
+                            <Box flexGrow={1} />
+                            <Typography>
+                                { getTranslation("Enable Stat Plots", translationKey) + ":" }
+                            </Typography>
+                            <Box flexGrow={2} />
+                            <Checkbox
+                                checked={plotsEnabled}
+                                onChange={(e) => setPlotsEnable(!plotsEnabled)}
+                            />
+                            <Box flexGrow={1} />
+                        </Stack>
+                    </Box>
+                </li>
+                <li>
+                    <Box width="100%" alignItems="center" justifyContent="center" sx={{ px: "12px", py: "6px" }}>
+                        <Stack direction="row">
+                            <Box flexGrow={1} />
+                            <Button
+                                variant="outlined"
+                                component="span"
+                                onClick={() => { handleDownload(); handleClose(); }}
+                                endIcon={<DownloadIcon />}
+                            >
+                                { getTranslation("Download", translationKey) }
+                            </Button>
+                            <Box flexGrow={1} />
+                        </Stack>
+                    </Box>
+                </li>
             </Menu>
         </Box>
 

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -285,11 +285,8 @@ const StatPlotContainer = styled(Box)({
 });
 
 const StatPlot = styled("img")({
-    height: "auto",
-    width: "auto",
-    maxHeight: "460px",
-    maxWidth: "750px",
-
+    height: "460px",
+    width: "750px",
 });
 
 const BuildMovesSection = styled(Box)({
@@ -704,12 +701,11 @@ function generateGraphic(theme: any, raidInputProps: RaidInputProps, results: Ra
                                                 {getIVDescription(raider.ivs, translationKey) ? 
                                                     <BuildInfo>{ getTranslation("IVs", translationKey) + ": " + getIVDescription(raider.ivs, translationKey)}</BuildInfo> : null}
                                             </BuildInfoContainer>
-                                            { statplots && statplots[index] && 
+                                            { statplots && 
                                                 <StatPlotContainer>
                                                     <StatPlot src={statplots[index]} />
                                                 </StatPlotContainer>
                                             }
-       
                                             <BuildMovesSection>
                                                 <MovesHeader>{ getTranslation("Moves", translationKey) + ":" }</MovesHeader>
                                                 <MovesContainer>
@@ -1005,13 +1001,14 @@ function GraphicsButton({title, notes, credits, raidInputProps, results, allSpec
             // sort moves into groups
             const [turnGroups, turnNumbers] = getTurnGroups(raidInputProps.groups, results);
             // generate radar plots
-            const statPlots = await Promise.all(
+            let statPlots: undefined | (string | undefined)[] = await Promise.all(
                 raidInputProps.pokemon.slice(1).map((poke, i) => {
                     if (!plotsEnabled[i]) { return undefined; }
                     const nature = gen.natures.get(toID(poke.nature));
                     return getStatRadarPlotPNG(poke.id, nature, poke.evs, poke.stats, translationKey, 20);
                 })
             );
+            if (statPlots.every((plot) => plot === undefined)) { statPlots = undefined; }
             // generate graphic
             const graphicTop = generateGraphic(theme, raidInputProps, results, isHiddenAbility, learnMethods, moveTypes, optionalMove, turnGroups, turnNumbers, loadedImageURLRef.current, title, subtitle, notes, credits, statPlots, translationKey);
             saveGraphic(graphicTop, title, watermarkText, setLoading);

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -741,7 +741,7 @@ function generateGraphic(theme: any, raidInputProps: RaidInputProps, results: Ra
                                                                     {noMove ? <MoveTypeIcon src={getTypeIconURL(moveTypes[raider.id][index])} sx={{opacity: `${optionalMove[raider.id][index] ? '50%' : '100%'}`}}/> : null}
                                                                     {noMove ? (
                                                                         optionalMove[raider.id][index] ? 
-                                                                            <OptionalMoveLabel>{ getTranslation(raider.moves[index] + "*", translationKey, "moves") }</OptionalMoveLabel> : 
+                                                                            <OptionalMoveLabel>{ getTranslation(raider.moves[index], translationKey, "moves") + "*" }</OptionalMoveLabel> : 
                                                                             <MoveLabel>{ getTranslation(raider.moves[index], translationKey, "moves") }</MoveLabel>
                                                                     ) : null}
                                                                     {noMove ? <MoveLearnMethodIcon src={getMoveMethodIcon(learnMethods[raider.id][index], moveTypes[raider.id][index])} sx={{opacity: `${optionalMove[raider.id][index] ? '50%' : '100%'}`}}/> : null}

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -633,7 +633,7 @@ function getTurnGroups(groups: TurnGroupInfo[], results: RaidBattleResults): [{i
     return [preparedTurnGroups, turnNumbers];
 }
 
-function generateGraphic(theme: any, raidInputProps: RaidInputProps, results: RaidBattleResults, isHiddenAbility: boolean[], learnMethods: string[][], moveTypes: TypeName[][], optionalMove: boolean[][], turnGroups: {id: number, move: string, info: RaidMoveInfo, isSpread: boolean, repeats: number, teraActivated: boolean}[][][], turnNumbers: number[], backgroundImageURL: string, title?: string, subtitle?: string, notes?: string, credits?: string, statplots?: string[], translationKey?: any) {
+function generateGraphic(theme: any, raidInputProps: RaidInputProps, results: RaidBattleResults, isHiddenAbility: boolean[], learnMethods: string[][], moveTypes: TypeName[][], optionalMove: boolean[][], turnGroups: {id: number, move: string, info: RaidMoveInfo, isSpread: boolean, repeats: number, teraActivated: boolean}[][][], turnNumbers: number[], backgroundImageURL: string, title?: string, subtitle?: string, notes?: string, credits?: string, statplots?: (string | undefined)[], translationKey?: any) {
     const graphicTop = document.createElement('graphic_top');
     graphicTop.setAttribute("style", "width: 3600px");
     const root = createRoot(graphicTop);
@@ -954,7 +954,7 @@ function GraphicsButton({title, notes, credits, raidInputProps, results, allSpec
     const loadedImageURLRef = useRef<string>(getMiscImageURL("default"));
     const [subtitle, setSubtitle] = useState<string>("");
     const [watermarkText, setWatermarkText] = useState<string>("");
-    const [plotsEnabled, setPlotsEnable] = useState<boolean>(false);
+    const [plotsEnabled, setPlotsEnable] = useState<boolean[]>([false, false, false, false]);
 
     const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
@@ -1005,8 +1005,9 @@ function GraphicsButton({title, notes, credits, raidInputProps, results, allSpec
             // sort moves into groups
             const [turnGroups, turnNumbers] = getTurnGroups(raidInputProps.groups, results);
             // generate radar plots
-            const statPlots = !plotsEnabled ? undefined : await Promise.all(
-                raidInputProps.pokemon.slice(1).map((poke) => {
+            const statPlots = await Promise.all(
+                raidInputProps.pokemon.slice(1).map((poke, i) => {
+                    if (!plotsEnabled[i]) { return undefined; }
                     const nature = gen.natures.get(toID(poke.nature));
                     return getStatRadarPlotPNG(poke.id, nature, poke.evs, poke.stats, translationKey, 20);
                 })
@@ -1087,18 +1088,33 @@ function GraphicsButton({title, notes, credits, raidInputProps, results, allSpec
                 </li>
                 <li>
                     <Box width="100%" alignItems="center" justifyContent="center" sx={{ px: "12px", py: "6px" }}>
-                        <Stack direction="row" alignItems="center" justifyContent="center">
-                            <Box flexGrow={1} />
-                            <Typography>
-                                { getTranslation("Enable Stat Plots", translationKey) + ":" }
+                        <Stack>
+                            <Typography variant="body1" fontWeight={600}>
+                                {getTranslation("Enable Stat Plots", translationKey) + ":"}
                             </Typography>
-                            <Box flexGrow={2} />
-                            <Checkbox
-                                checked={plotsEnabled}
-                                onChange={(e) => setPlotsEnable(!plotsEnabled)}
-                            />
-                            <Box flexGrow={1} />
-                        </Stack>
+                            {[0,1,2,3].map((i) => (
+                        
+                            <Stack key={i} direction="row" alignItems="center" justifyContent="center">
+                                <Box flexGrow={1} />
+                                <Typography>
+                                    { `${getTranslation("Raider", translationKey)} ${i+1}` }
+                                </Typography>
+                                <Box flexGrow={2} />
+                                <Checkbox
+                                    checked={plotsEnabled[i]}
+                                    onChange={(e) => {
+                                        const newPlotsEnabled = plotsEnabled.slice();
+                                        newPlotsEnabled[i] = !newPlotsEnabled[i];
+                                        setPlotsEnable(newPlotsEnabled);
+                                    }}
+                                />
+                                <Box flexGrow={1} />
+                            </Stack>
+                        ))
+                            
+                        }
+
+                    </Stack>
                     </Box>
                 </li>
                 <li>

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -648,7 +648,7 @@ function generateGraphic(theme: any, raidInputProps: RaidInputProps, results: Ra
     graphicTop.setAttribute("style", "width: 3600px");
     const root = createRoot(graphicTop);
 
-    const ignoreStats = raidInputProps.pokemon.slice(1).map((raider) => (raider.level === 13) || (Object.entries(raider.ivs).reduce((acc, val) => val[1] + acc, 0) === 0 && Object.entries(raider.evs).reduce((acc, val) => val[1] + acc, 0) === 0));
+    const ignoreStats = raidInputProps.pokemon.slice(1).map((raider) => (raider.isAnyLevel) || (Object.entries(raider.ivs).reduce((acc, val) => val[1] + acc, 0) === 0 && Object.entries(raider.evs).reduce((acc, val) => val[1] + acc, 0) === 0));
     console.log(ignoreStats)
     flushSync(() => {
         root.render(
@@ -693,7 +693,7 @@ function generateGraphic(theme: any, raidInputProps: RaidInputProps, results: Ra
                                                 <BuildHeaderSeparator />
                                             </BuildHeader>
                                             <BuildInfoContainer>
-                                                <BuildInfo>{ getTranslation("Level", translationKey) + ": " + (raider.level === 13 ? getTranslation("Any",translationKey) : raider.level) }</BuildInfo>
+                                                <BuildInfo>{ getTranslation("Level", translationKey) + ": " + (raider.isAnyLevel ? getTranslation("Any",translationKey) : raider.level) }</BuildInfo>
                                                 {(raider.teraType || "???") !== "???" &&
                                                     <BuildInfo>{ getTranslation("Tera Type", translationKey) + ": " + getTranslation(raider.teraType!, translationKey, "types") }</BuildInfo>
                                                 }

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -199,9 +199,11 @@ const BuildWrapper = styled(Box)({
     color: "white"
 });
 
-const Build = styled(Box)({
+const Build = styled(Stack)({
     width: "675px",
-    margin: "50px"
+    margin: "50px",
+    paddingBottom: "100px",
+    height: "100%"
 });
 
 const BuildHeader = styled(Box)({
@@ -258,7 +260,7 @@ const BuildHeaderSeparator = styled("hr")({
 });
 
 const BuildInfoContainer = styled(Stack)({
-    height: "430px",
+    minHeight: "430px",
 });
 
 const BuildInfo = styled(Typography)({
@@ -285,7 +287,7 @@ const StatPlotContainer = styled(Box)({
 });
 
 const StatPlot = styled("img")({
-    height: "460px",
+    height: "625px",
     width: "750px",
 });
 
@@ -701,6 +703,7 @@ function generateGraphic(theme: any, raidInputProps: RaidInputProps, results: Ra
                                                 {getIVDescription(raider.ivs, translationKey) ? 
                                                     <BuildInfo>{ getTranslation("IVs", translationKey) + ": " + getIVDescription(raider.ivs, translationKey)}</BuildInfo> : null}
                                             </BuildInfoContainer>
+                                            <Box flexGrow={1}/>
                                             { statplots && 
                                                 <StatPlotContainer>
                                                     <StatPlot src={statplots[index]} />

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -260,7 +260,7 @@ const BuildHeaderSeparator = styled("hr")({
 });
 
 const BuildInfoContainer = styled(Stack)({
-    minHeight: "430px",
+    
 });
 
 const BuildInfo = styled(Typography)({

--- a/src/uicomponents/ImportExportArea.tsx
+++ b/src/uicomponents/ImportExportArea.tsx
@@ -317,7 +317,7 @@ function ImportExportArea({pokemon, setPokemon, allMoves, translationKey}: { pok
 							const newPoke = addSet(textValue)
 							const newMoveData = ( allMoves ? newPoke.moves.map((move) => allMoves.get(move)) : await Promise.all(newPoke.moves.map(async (move) => PokedexService.getMoveByName(move))) ) as MoveData[];
 							if (newPoke) {
-								const newRaider = new Raider(pokemon.id, pokemon.role, false, pokemon.field, newPoke, newMoveData, [], [])
+								const newRaider = new Raider(pokemon.id, pokemon.role, false, false, pokemon.field, newPoke, newMoveData, [], [])
 								setPokemon(newRaider)
 							}
 						}}

--- a/src/uicomponents/LinkButton.tsx
+++ b/src/uicomponents/LinkButton.tsx
@@ -90,7 +90,7 @@ export async function deserializeInfo(hash: string): Promise<BuildInfo | null> {
 
 export async function lightToFullBuildInfo(obj: LightBuildInfo, allMoves?: Map<MoveName,MoveData> | null): Promise<BuildInfo | null> {
     try {
-        const pokemon = await Promise.all((obj.pokemon as LightPokemon[]).map(async (r, i) => new Raider(i, r.role, r.shiny, new Field(), 
+        const pokemon = await Promise.all((obj.pokemon as LightPokemon[]).map(async (r, i) => new Raider(i, r.role, r.shiny, r.isAnyLevel, new Field(), 
             new Pokemon(gen, r.name, {
                 ability: r.ability || undefined,
                 item: r.item || undefined,
@@ -201,7 +201,7 @@ export async function lightToFullBuildInfo(obj: LightBuildInfo, allMoves?: Map<M
             await Promise.all(subsList.map(async (s,i) => 
                     {
                         const r = s.raider;
-                        const subPoke = new Raider(i+1, r.role, r.shiny, new Field(), 
+                        const subPoke = new Raider(i+1, r.role, r.shiny, r.isAnyLevel, new Field(), 
                             new Pokemon(gen, r.name, {
                                 ability: r.ability || undefined,
                                 item: r.item || undefined,

--- a/src/uicomponents/LinkButton.tsx
+++ b/src/uicomponents/LinkButton.tsx
@@ -248,6 +248,7 @@ function serializeInfo(info: RaidBattleInfo, substitutes: SubstituteBuildInfo[][
                 role: r.role,
                 name: r.name,
                 shiny: r.shiny,
+                isAnyLevel: r.isAnyLevel,
                 ability: r.ability,
                 item: r.item,
                 nature: r.nature,

--- a/src/uicomponents/StatRadarPlot.tsx
+++ b/src/uicomponents/StatRadarPlot.tsx
@@ -196,12 +196,12 @@ export async function getStatRadarPlotPNG(id: number, nature: Nature | undefined
             type: "scatterpolar", // Hack to get hexagonal axis
             mode: "lines",
             line: {
-                width: 1.5 * scale,
-                color: "#cccccc",
+                width: 2.5 * scale,
+                color: "#888888",
             },
             name: "axis",
-            r: [.99, .99, .99, .99, .99, .99, .99],
-            theta: ticktexts,
+            r: [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+            theta: ticktexts.map((t) => [t,t]).flat(),
             fill: "toself",
             fillcolor: "rgba(0, 0, 0, .1)",
         },
@@ -209,12 +209,12 @@ export async function getStatRadarPlotPNG(id: number, nature: Nature | undefined
             type: "scatterpolar", // Hack to get hexagonal axis
             mode: "lines",
             line: {
-                width: scale,
-                color: "#888888",
+                width: 4 * scale,
+                color: "#cccccc",
             },
             name: "axis",
-            r: [0.0, .99, 0.0, .99, 0.0, .99, 0.0, .99, 0.0, .99, 0.0, .99, 0.0, .99],
-            theta: ticktexts.map((t) => [t,t]).flat(),
+            r: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            theta: ticktexts,
             fill: "toself",
             fillcolor: "rgba(0, 0, 0, .1)",
         },
@@ -222,11 +222,11 @@ export async function getStatRadarPlotPNG(id: number, nature: Nature | undefined
             type: "scatterpolar",
             mode: "lines",
             line: {
-                width: scale,
+                width: 2.5 * scale,
                 color: statsColor,
             },
             marker: {
-                width: scale,
+                width: 2.5 * scale,
                 color: statsColor,
             },
             name: "stats",
@@ -270,7 +270,7 @@ export async function getStatRadarPlotPNG(id: number, nature: Nature | undefined
             bgcolor: 'rgba(0,0,0,0)',
             angularaxis: {
                 tickfont: {
-                    size: 14 * scale,
+                    size: 17 * scale,
                     color: "#ffffff",
                 },
                 linewidth: 0, // 0 Makes circular axis invisible 
@@ -280,7 +280,7 @@ export async function getStatRadarPlotPNG(id: number, nature: Nature | undefined
             },
             radialaxis: {
                 visible: false,
-                range: [0, 1],
+                range: [0, 1.05],
                 fixedrange: true,
             }
         }

--- a/src/uicomponents/StatRadarPlot.tsx
+++ b/src/uicomponents/StatRadarPlot.tsx
@@ -18,16 +18,22 @@ const lowEVColor    = "#fcca00"; // for non-maxed EVs
 const maxedEVColor  = "#00c8c8"; // for when total EVs are 510
 const badEVColor    = "#d44a4a"; // for wehn total EVs exceeding 510 (shouldn't happen unless something goes wrong)
 
-const tickorder = ["HP", "SpA", "SpD", "Spe", "Def", "Atk", "HP"];
-const rightAligned = ["SpA", "SpD"];
+const tickOrder = ["HP", "Sp. Atk", "Sp. Def", "Speed", "Defense", "Attack", "HP"];
+const shortTickOrder = ["HP", "SpA", "SpD", "Spe", "Def", "Atk", "HP"];
+const statOrder = ["hp", "spa", "spd", "spe", "def", "atk", "hp"];
+const rightAligned = ["spa", "spd"];
 
-const ticktext = (tickOrder: string[], index: number, stats: StatsTable, nature: Nature | undefined, evs: StatsTable, translationKey: any, pluscolor: string = plusColor, minuscolor: string = minusColor) => {
+const ticktext = (index: number, stats: StatsTable, nature: Nature | undefined, evs: StatsTable, translationKey: any, shorten: boolean = false, pluscolor: string = plusColor, minuscolor: string = minusColor) => {
     const stat = tickOrder[index];
-    const lcStat = stat.toLowerCase() as keyof StatsTable;
+    const lcStat = statOrder[index] as keyof StatsTable;
     const isPlus = nature ? nature.plus !== nature.minus && nature.plus === lcStat : false;
     const isMinus = nature ? nature.plus !== nature.minus && nature.minus === lcStat : false;
     const isMaxedEV = evs[lcStat] === 252;
-    let text = '<b>' + getTranslation(stat, translationKey, "stats") + '</b>';
+    let statTranslation = getTranslation(stat, translationKey, "stats");
+    if (shorten && !(index === 0 || index === 3 || index === 6) && statTranslation.length > 8) { // hack for avoiding overflow, mostly for the German translation of "Defense"
+        statTranslation = getTranslation(shortTickOrder[index], translationKey, "stats");
+    }
+    let text = '<b>' + statTranslation + '</b>';
     if (isPlus) {
         text = '<span style="color:' + pluscolor + '"><b>' + text + '</b></span>';    } else if (isMinus) {
     } 
@@ -35,7 +41,7 @@ const ticktext = (tickOrder: string[], index: number, stats: StatsTable, nature:
         text = '<span style="color:' + minuscolor + '"><b>' + text + '</b></span>';
     }
     if (isMaxedEV) {
-        if (rightAligned.includes(stat)) {
+        if (rightAligned.includes(lcStat)) {
             text = "\u2728"+text;
         } else {
             text += "\u2728";
@@ -66,7 +72,7 @@ function StatRadarPlot({nature, evs, stats, translationKey, bossMultiplier=100}:
     // };
 
 
-    const ticktexts = tickorder.map((s,i) => ticktext(tickorder, i, stats, nature, evs, translationKey));
+    const ticktexts = tickOrder.map((s,i) => ticktext(i, stats, nature, evs, translationKey));
     const evTotal = Object.values(evs).reduce((a,b) => a + b, 0)
     const evColor = evTotal > 510 ? badEVColor : (
                     evTotal < 510 ? lowEVColor : maxedEVColor);
@@ -159,15 +165,15 @@ function StatRadarPlot({nature, evs, stats, translationKey, bossMultiplier=100}:
                     }
                 }}
                 config={{ 
-                    staticPlot: false,
-                    modeBarButtonsToRemove: ['zoom2d'],  
-                    toImageButtonOptions: {
-                        format: "svg",
-                        filename: "statplot",
-                        // height: 800,
-                        // width: 600,
-                        // scale: 2,
-                    }
+                    staticPlot: true,
+                    // modeBarButtonsToRemove: ['zoom2d'],  
+                    // toImageButtonOptions: {
+                    //     format: "svg",
+                    //     filename: "statplot",
+                    //     // height: 800,
+                    //     // width: 600,
+                    //     // scale: 2,
+                    // }
                 }}
             />
             <Box height="10px"/>
@@ -177,7 +183,7 @@ function StatRadarPlot({nature, evs, stats, translationKey, bossMultiplier=100}:
 
 export async function getStatRadarPlotPNG(id: number, nature: Nature | undefined, evs: StatsTable, stats: StatsTable, translationKey: any, scale: number = 10, bossMultiplier: number = 100) {
     
-    const ticktexts = tickorder.map((s,i) => ticktext(tickorder, i, stats, nature, evs, translationKey, "#fdbab4", "#b3dbff"));
+    const ticktexts = tickOrder.map((s,i) => ticktext(i, stats, nature, evs, translationKey, true, "#fdbab4", "#b3dbff"));
     const evTotal = Object.values(evs).reduce((a,b) => a + b, 0)
     const evColor = evTotal > 510 ? badEVColor : (
                     evTotal < 510 ? lowEVColor : maxedEVColor);

--- a/src/uicomponents/StatRadarPlot.tsx
+++ b/src/uicomponents/StatRadarPlot.tsx
@@ -28,7 +28,6 @@ const ticktext = (tickOrder: string[], index: number, stats: StatsTable, nature:
     const isMinus = nature ? nature.plus !== nature.minus && nature.minus === lcStat : false;
     const isMaxedEV = evs[lcStat] === 252;
     let text = '<b>' + getTranslation(stat, translationKey, "stats") + '</b>';
-    console.log(nature?.name, nature?.plus, nature?.minus, lcStat, isPlus, isMinus)
     if (isPlus) {
         text = '<span style="color:' + pluscolor + '"><b>' + text + '</b></span>';    } else if (isMinus) {
     } 

--- a/src/uicomponents/StatRadarPlot.tsx
+++ b/src/uicomponents/StatRadarPlot.tsx
@@ -192,7 +192,9 @@ export async function getStatRadarPlotPNG(id: number, nature: Nature | undefined
     const evColor = evTotal > 510 ? badEVColor : (
                     evTotal < 510 ? lowEVColor : maxedEVColor);
 
-    const hpPlotVal = ((stats.hp*100/bossMultiplier)+100)/500
+    const sigmoid = (stat: number) => {
+        return 1.75 / (1 + Math.exp(stat / -125)) - .75;
+    };
 
     const data = [
         {
@@ -233,7 +235,7 @@ export async function getStatRadarPlotPNG(id: number, nature: Nature | undefined
                 color: statsColor,
             },
             name: "stats",
-            r: [hpPlotVal, ...[stats.spa, stats.spd, stats.spe, stats.def, stats.atk].map(stat => (stat+50)/350), hpPlotVal],
+            r: [stats.hp, stats.spa, stats.spd, stats.spe, stats.def, stats.atk, stats.hp].map(stat => sigmoid(stat)),
             theta: ticktexts,
             fill: "toself",
         },
@@ -266,7 +268,7 @@ export async function getStatRadarPlotPNG(id: number, nature: Nature | undefined
         },
         showlegend: false,
         font: {
-            family: "Roboto",
+            family: "Poppins, sans-serif"
         },
         dragmode: false,
         polar: {

--- a/src/uicomponents/StatRadarPlot.tsx
+++ b/src/uicomponents/StatRadarPlot.tsx
@@ -248,10 +248,10 @@ export async function getStatRadarPlotPNG(id: number, nature: Nature | undefined
         paper_bgcolor: 'rgba(0,0,0,0)',
         plot_bgcolor: 'rgba(0,0,0,0)',
         margin: {
-            r: 10 * scale,
-            l: 10 * scale,
-            t: 25 * scale,
-            b: 25 * scale,
+            r: 50 * scale,
+            l: 50 * scale,
+            t: 50 * scale,
+            b: 50 * scale,
         },
         showlegend: false,
         font: {
@@ -282,7 +282,7 @@ export async function getStatRadarPlotPNG(id: number, nature: Nature | undefined
 
     //@ts-ignore
     const image = await Plotly.newPlot("statplot"+id, data, layout, config).then(async (gd) => {
-        return await Plotly.toImage(gd, {format: "png", width: 325*scale, height: 200*scale})
+        return await Plotly.toImage(gd, {format: "png", width: 300*scale, height: 250*scale})
     });
     
     return image as string;

--- a/src/uicomponents/StatRadarPlot.tsx
+++ b/src/uicomponents/StatRadarPlot.tsx
@@ -60,7 +60,10 @@ function StatRadarPlot({nature, evs, stats, translationKey, bossMultiplier=100}:
     const evColor = evTotal > 510 ? badEVColor : (
                     evTotal < 510 ? lowEVColor : maxedEVColor);
 
-    const hpPlotVal = ((stats.hp*100/bossMultiplier)+100)/500
+    const sigmoid = (stat: number) => {
+        return 1.75 / (1 + Math.exp(stat / -125)) - .75;
+    };
+    
     return (
         <Box>
             <Plot
@@ -93,7 +96,7 @@ function StatRadarPlot({nature, evs, stats, translationKey, bossMultiplier=100}:
                             color: statsColor,
                         },
                         name: "stats",
-                        r: [hpPlotVal, ...[stats.spa, stats.spd, stats.spe, stats.def, stats.atk].map(stat => (stat+50)/350), hpPlotVal],
+                        r: [stats.hp, stats.spa, stats.spd, stats.spe, stats.def, stats.atk, stats.hp].map(stat => sigmoid(stat)),
                         theta: ticktexts,
                         fill: "toself",
                     },

--- a/src/uicomponents/StatsControls.tsx
+++ b/src/uicomponents/StatsControls.tsx
@@ -135,6 +135,7 @@ function StatsControls({ pokemon, setPokemon, translationKey}: { pokemon: Raider
             setPokemon(new Raider(pokemon.id, pokemon.role, pokemon.shiny, pokemon.isAnyLevel, pokemon.field,
                 new Pokemon(gen, pokemon.name, {
                     level: pokemon.level,
+                    gender: pokemon.gender,
                     ability: pokemon.ability,
                     nature: pokemon.nature,
                     item: pokemon.item,
@@ -163,6 +164,7 @@ function StatsControls({ pokemon, setPokemon, translationKey}: { pokemon: Raider
             setPokemon(new Raider(pokemon.id, pokemon.role, pokemon.shiny, pokemon.isAnyLevel, pokemon.field,
                 new Pokemon(gen, pokemon.name, {
                     level: pokemon.level,
+                    gender: pokemon.gender,
                     ability: pokemon.ability,
                     nature: pokemon.nature,
                     item: pokemon.item,

--- a/src/uicomponents/StatsControls.tsx
+++ b/src/uicomponents/StatsControls.tsx
@@ -132,7 +132,7 @@ function StatsControls({ pokemon, setPokemon, translationKey}: { pokemon: Raider
             const newEVs = {...pokemon.evs};
             //@ts-ignore
             newEVs[evName] = safeValue;
-            setPokemon(new Raider(pokemon.id, pokemon.role, pokemon.shiny, pokemon.field,
+            setPokemon(new Raider(pokemon.id, pokemon.role, pokemon.shiny, pokemon.isAnyLevel, pokemon.field,
                 new Pokemon(gen, pokemon.name, {
                     level: pokemon.level,
                     ability: pokemon.ability,
@@ -160,7 +160,7 @@ function StatsControls({ pokemon, setPokemon, translationKey}: { pokemon: Raider
             const newIVs = {...pokemon.ivs};
             //@ts-ignore
             newIVs[ivName] = safeValue;
-            setPokemon(new Raider(pokemon.id, pokemon.role, pokemon.shiny, pokemon.field,
+            setPokemon(new Raider(pokemon.id, pokemon.role, pokemon.shiny, pokemon.isAnyLevel, pokemon.field,
                 new Pokemon(gen, pokemon.name, {
                     level: pokemon.level,
                     ability: pokemon.ability,

--- a/src/workers/raidcalc.worker.ts
+++ b/src/workers/raidcalc.worker.ts
@@ -11,7 +11,7 @@ const gen = Generations.get(9);
 
 self.onmessage = (event: MessageEvent<{raiders: Raider[], groups: TurnGroupInfo[]}>) => {
     const raidersMessage = event.data.raiders;
-    const raiders = raidersMessage.map((r) => new Raider(r.id, r.role, r.shiny, new Field(), new Pokemon(gen, r.name, {
+    const raiders = raidersMessage.map((r) => new Raider(r.id, r.role, r.shiny, false, new Field(), new Pokemon(gen, r.name, {
         level: r.level,
         gender: r.gender,
         bossMultiplier: r.bossMultiplier,


### PR DESCRIPTION
Adds radar plots to each raider in the graphic. The plots use the same format as the ones in `PokemonSummary`, with small tweaks for readability. These are toggleable, since they might not be desired much of the time. 

Also included are some other UI changes and fixes:
- Raider level can be decreased to 0, showing "Any" in the input field and in the graphic. Stats for level 1 are used. This is probably more intuitive than using lv13
- The Gender selection is not reset when changing EVs/IVs

