### PR TITLE
Refactor item consumption

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -105,7 +105,7 @@ describe('Specific Test Cases', () => {
     expect(result.turnResults[2].state.raiders[1].abilityOn).toEqual(true);
   })
   test('protection', async () => {
-    const hash = "#H4sIAAAAAAAAA71WTW/bMAz9K4ZOG6BDPtu1t6zttgJt0a0Begh8YG3aUSNLniQHDYr+91GynTjDVnhbF9iSKZrkE59Iw88sY6csebRaMc4cO10sBpwpKJDF3IsibYTECEcmFhOtUjCbiyzDxFlSGS2lNxpyVlk0l+c+EpgcXRB16YRW1luMOMuNrkrSFnqNlyrTJD5oa6/bZQ229CbgVjSnmHnYEsKchhm3ZnMj8hyNRxQF7lZ2KVCmZ6ASlOdQQI5bZb38Bu5Xqjka+I36bAkqxyZRpR363BODqQgslHqFRc1iZZTXhFQDQVgiBCNbPVgnXOWdaz6IPL+PwHjAVRt6CjtTmytco/Q8PAgpXFA7LIIxQXhzXPugIsyysc5RpTUhtOf5psSGbNsyXUknSimCDT45A9fN2zZpByyOOVuz02dGBfGBM9bci6A44UT9uYFcKxFI7MgZSIvNzN7d6GhWb/4946qSkrMvYFJKJQQ6okDbK35plePhTze9Gg4I86YJsmAzNAJkNEs8/AUYt/xewSosKCMsMLorEX3pesdFXIc+3sdrEU84HehVlYARvhy30iu5sHuElUJro1stReLP5lqnaN02s9F0FHCa5x9ldwPWbaJbqX3DfdJJZaOPEnxwdmuo8BLXNzEqsDun1aOmkgwHvrc60GHdixSjzxXF6rvtMSUqVpAsK9aRXjuPmqU7sEv2ZjWW123Xc88TzuYgtcpk3crdxYGI/lqJZNWP6bjp5WlQBXGyqy5qiEY53t97IRTbJU0e3UYckFvj5EyF9cQKeAourdOUH7V25N8t9eHO/+1Bh9QLrX+nIPmob6bdr0xf0BFV8nbTTTmRavz/EKdUh4dFHBNm698tQNpIX2b3Ptm9gSdUSP+Q6t+BHtN1MFBq0sWApiP/z+F/F2hMaYxpTGgcx+FnZO/yPjFv7zh+efkBkfu69OMJAAA=";
+    const hash = "#H4sIAAAAAAAAA71W3U/bMBD/Vyo/bZIf+gmMtw7YhgSoG5V4qPJwJJfU1LEz26moEP/7zk7Spmig7IPKiWNf7vy7+/nO8hNL2SmLH6xWjDPHTheLPmcKcmQR90OR1IPYCEcqFmOtEjCbizTF2FkSGS2lVxpwVlo0l+d+JTAZujDUhRNaWa8x5CwzuixImus1XqpU0/BeW3vdTElrxNlSOFvjLr02uBX1CabegwJCn4Qet2pzI7IMjQcXOe5mdilQJmegYpTnkEOGW2E1/QHud6I5GnhFfLYElWEds9IOPQ2xwUQEQgq9wrwitDTKS0LUgSssEIKSLe+tE670xhU1xKP3I5AfcNWGvsJO1eYK1yg9D/dCChfEDvOgTBBeHdd+URF6WWtnqJKKEPJ5vimw5t02pJfSiUKKoIOPzsB1/bcJ2gGLIs7W7PSJUW584ozVzyIIBn1O3J8byLQSgcXWOAVpse7Zhxvdm1bef2RclVJy9g1MQrGElY55f9ei50Y4Grx46NegT5g39SILNkUjQPamsYe/AOOWP0tYhQmFhDn2bgtEn8becBFVS5/s4zWIFBBt6VUZgxE+N7ejN4Jhdwgrhdb2ZlqK2O/OtU7Qum1ow8kwANXfPwrvBqzb9GZS++r7ouPS9j5L8IuzmaHUi13nyCjHbp1WD5qyMuz53uxA23UnEux9LWmtzn7TgTATK4iXJWuN3tqRiqdbsEv239Isq0qvq9NjzuYgtUplVc/tyYGo/l6KeNWN66gu6EkQheF4l2BUE4NKONr3PReK7aImi3Yx9ndGzpRYdSyHx2DSGE34UaNH9u1sf1fQAVVDY99KSZIOu4G2T5quoENK5a3TdT6RaPR+iBPKw8MijgizsW8nIDky7oi6d2x3Bh5TIv1DqH8Hekzt4KAn1F4HPdoHhXVGpdQJ9lXLcD4s+tQd+TuPv67QO/F3NXrH9B7TexKFC9GL5i0j3jxR9Pz8C4/drlB0CgAA";
     const result = await resultsFromHash(hash);
     // T1 Lucario Protects, no damage
     expect(result.turnResults[0].results[1].damage[1]).toEqual(0);
@@ -115,16 +115,18 @@ describe('Specific Test Cases', () => {
     expect(result.turnResults[2].results[1].damage[2]).toEqual(0);
     // T4 Stonjourner's Wide Guard blocks Earthquake for ally
     expect(result.turnResults[3].results[1].damage[3]).toEqual(0);
-    // T5 Stonjourner's Wide Guard wore off for ally, damage inflicted (Focus Sash used)
+    // T5 Stonjourner's Wide Guard wore off for ally (since "turn 1" is over), damage inflicted (Focus Sash used)
     expect(result.turnResults[4].results[1].damage[3]).toBeGreaterThan(0);
     expect(result.turnResults[4].state.raiders[3].originalCurHP).toEqual(1);
     // T6 Talonflame's Quick Guard blocks Extreme Speed
     expect(result.turnResults[5].results[1].damage[4]).toEqual(0);
     // T7 Talonflame's Quick Guard blocks Extreme Speed for ally
     expect(result.turnResults[6].results[0].damage[3]).toEqual(0);
-    // T8 Talonflame's Quick Guard wore off for ally, damage inflicted
-    expect(result.turnResults[7].results[0].damage[3]).toBeGreaterThan(0);
-    expect(result.turnResults[7].state.raiders[3].originalCurHP).toEqual(0);
+    // T8 Talonflame's Quick Guard blocks Extreme Speed for ally (Still on T2)
+    expect(result.turnResults[7].results[0].damage[3]).toEqual(0);
+    // T9 Talonflame's Quick Guard wore off for ally (T2 is over), damage inflicted
+    expect(result.turnResults[8].results[0].damage[3]).toBeGreaterThan(0);
+    expect(result.turnResults[8].state.raiders[3].originalCurHP).toEqual(0);
   })
   test('sapsipper_eartheater_flashfire_stormdrain', async () => {
     const hash = "#H4sIAAAAAAAAA7VUwW7bMAz9FYOnDdAhjtOtyK1A063Asg3IboEPqk0nWmXJoOSkWZF/HyXbRdIhW4AusEFQlB7fI0X7GSqYQvHTWQMCPEyXy5EAI2uEXARXlb1TkPJ8xGFhTSlpN6sqLLzjEFmtw6FUQOuQ7m9DJkkr9NG1jVfWuHBiLGBFtm04WtsN3pvKsvtgnZsPyy6PsR5D6oKwVJGksY9YdyJbMiESM7le3TrklP6RbYlV0NnIaMtosWdnqQh9fXz+QWnld+wpj3WMc/Kwg5vAoKLVuEEdeJHkj12DvXg3KG+1V41WSAH35EnO426eC9jA9Bm4px8EQP8uY+BasOY5bmGw777a5KaT8x6EabUW8FlSyeIi4CMDXp58PwSz9NXLW+lo1CVYwkySXyff7TaKu9Nctl9Tv1y0FBo1lytVSJ18QVlxlwJ6mQ8M14Iv4+ZXW0tSOjTh0F/IJlmopgnZ/pPiP/n50r5xEVtL4YIO3K62mfQXpc+4ZCqkUSbc+4HLzXTr5E6FcbkY+0TAJ+k82TJO/qG/8NyG5JakMhcQkPdzeiX6vbiadHMa5puHNOW9GM5EJbXD3kLNijjD/gVzNGEMSgeYpxY7A7V8iqABdsW1nyIen0t8PPAHxB3gFHP6duajD+/ciscnebM3V/xX4uwk8eRc4u5n8i/CPA7X/jfO8D3QdQYAAA==";

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -712,6 +712,10 @@ export class RaidMove {
                         if (this.moveData.name === "Fling" && this._user.item) {
                             this._flingItem = moveUser.item;
                             this._raidState.loseItem(this.userID);
+                            this._user.lastConsumedItem = this._flingItem;
+                            if (this._user.hasAbility("Cud Chew") && this._flingItem!.includes("Berry")) {
+                                this._user.isCudChew = 2;
+                            }
                         }
                     } 
                     catch {

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -61,7 +61,7 @@ export class RaidState implements State.RaidState{
             if (pokemon.item === "Focus Sash" || pokemon.ability === "Sturdy") {
                 if (pokemon.originalCurHP <= 0 && originalHP === maxHP) { 
                     pokemon.originalCurHP = 1;
-                    if (pokemon.ability !== "Sturdy") { this.loseItem(id); } 
+                    if (pokemon.ability !== "Sturdy") { this.consumeItem(id, pokemon.item!); } 
                     fainted = false;
                 }
             }
@@ -91,85 +91,71 @@ export class RaidState implements State.RaidState{
             // TO DO - abilities that let users use berries more than once
             if (isSuperEffective) {
                 if (!fainted && pokemon.item === "Weakness Policy") { // weakness policy isn't consumed if the target faints (?)
-                    this.applyStatChange(id, {atk: 2, spa: 2}, true, id)
-                    this.loseItem(id);
+                    this.consumeItem(id, pokemon.item, true);
                 } else if (!unnerve) {
                     switch (pokemon.item) {
                         case "Occa Berry":  // the calc alread takes the berry into account, so we can just remove it here
-                            if (moveType === "Fire") { this.loseItem(id); }
+                            if (moveType === "Fire") { this.consumeItem(id, pokemon.item); }
                             break;
                         case "Passho Berry":
-                            if (moveType === "Water") { this.loseItem(id); }
+                            if (moveType === "Water") { this.consumeItem(id, pokemon.item); }
                             break;
                         case "Wacan Berry":
-                            if (moveType === "Electric") { this.loseItem(id); }
+                            if (moveType === "Electric") { this.consumeItem(id, pokemon.item); }
                             break;
                         case "Rindo Berry":
-                            if (moveType === "Grass") { this.loseItem(id); }
+                            if (moveType === "Grass") { this.consumeItem(id, pokemon.item); }
                             break;
                         case "Yache Berry":
-                            if (moveType === "Ice") { this.loseItem(id); }
+                            if (moveType === "Ice") { this.consumeItem(id, pokemon.item); }
                             break;
                         case "Chople Berry":
-                            if (moveType === "Fighting") { this.loseItem(id); }
+                            if (moveType === "Fighting") { this.consumeItem(id, pokemon.item); }
                             break;
                         case "Kebia Berry":
-                            if (moveType === "Poison") { this.loseItem(id); }
+                            if (moveType === "Poison") { this.consumeItem(id, pokemon.item); }
                             break;
                         case "Shuca Berry":
-                            if (moveType === "Ground") { this.loseItem(id); }
+                            if (moveType === "Ground") { this.consumeItem(id, pokemon.item); }
                             break;
                         case "Coba Berry":
-                            if (moveType === "Flying") { this.loseItem(id); }
+                            if (moveType === "Flying") { this.consumeItem(id, pokemon.item); }
                             break;
                         case "Payapa Berry":
-                            if (moveType === "Psychic") { this.loseItem(id); }
+                            if (moveType === "Psychic") { this.consumeItem(id, pokemon.item); }
                             break;
                         case "Tanga Berry":
-                            if (moveType === "Bug") { this.loseItem(id); }
+                            if (moveType === "Bug") { this.consumeItem(id, pokemon.item); }
                             break;
                         case "Charti Berry":
-                            if (moveType === "Rock") { this.loseItem(id); }
+                            if (moveType === "Rock") { this.consumeItem(id, pokemon.item); }
                             break;
                         case "Kasib Berry":
-                            if (moveType === "Ghost") { this.loseItem(id); }
+                            if (moveType === "Ghost") { this.consumeItem(id, pokemon.item); }
                             break;
                         case "Haban Berry":
-                            if (moveType === "Dragon") { this.loseItem(id); }
+                            if (moveType === "Dragon") { this.consumeItem(id, pokemon.item); }
                             break;
                         case "Colbur Berry":
-                            if (moveType === "Dark") { this.loseItem(id); }
+                            if (moveType === "Dark") { this.consumeItem(id, pokemon.item); }
                             break;
                         case "Babiri Berry":
-                            if (moveType === "Steel") { this.loseItem(id); }
+                            if (moveType === "Steel") { this.consumeItem(id, pokemon.item); }
                             break;
                         case "Roseli Berry":
-                            if (moveType === "Fairy") { this.loseItem(id); }
+                            if (moveType === "Fairy") { this.consumeItem(id, pokemon.item); }
                             break;
                         default: break;
                     }
                 }
             }
             /// Non-super effective items consumed after damage
-            // Chilan Berry
-            if (!unnerve && pokemon.item === "Chilan Berry" && moveType === "Normal") {
-                this.loseItem(id);
-            // Absorb Bulb
-            } else if (pokemon.item === "Absorb Bulb" && moveType === "Water") {
-                this.applyStatChange(id, {spa: 1}, true, id);
-                this.loseItem(id);
-            // Cell Battery
-            } else if (pokemon.item === "Cell Battery" && moveType === "Electric") {
-                this.applyStatChange(id, {atk: 1}, true, id);
-                this.loseItem(id);
-            // Luminous Moss
-            } else if (pokemon.item === "Luminous Moss" && moveType === "Water") {
-                this.applyStatChange(id, {spd: 1}, true, id);
-                this.loseItem(id);
-            // Snowball
-            } else if (pokemon.item === "Snowball" && moveType === "Ice") {
-                this.applyStatChange(id, {atk: 1}, true, id);
-                this.loseItem(id);
+            if ( (!unnerve && pokemon.item === "Chilan Berry" && moveType === "Normal") ||
+                 (pokemon.item === "Absorb Bulb" && moveType === "Water") ||
+                 (pokemon.item === "Cell Battery" && moveType === "Electric") || 
+                 (pokemon.item === "Luminous Moss" && moveType === "Water") ||
+                 (pokemon.item === "Snowball" && moveType === "Ice") ) {
+                this.consumeItem(id, pokemon.item, true);
             }
  
             /// abilities triggered by damage even if the target faints
@@ -252,12 +238,8 @@ export class RaidState implements State.RaidState{
         if (!unnerve && pokemon.item && pokemon.item?.includes("Berry")) {
             // 50% HP Berries
             if (pokemon.originalCurHP <= maxHP / 2) {
-                if (pokemon.item === "Sitrus Berry") {
-                    pokemon.originalCurHP += Math.floor(maxHP / 4);
-                    this.loseItem(id);
-                } else if (pokemon.item === "Oran Berry") {
-                    pokemon.originalCurHP = Math.min(maxHP, pokemon.originalCurHP + 10);
-                    this.loseItem(id);
+                if (pokemon.item === "Sitrus Berry" || pokemon.item === "Oran Berry") {
+                    this.consumeItem(id, pokemon.item as ItemName, true)
                 }
             }
             // 33% HP Berries
@@ -271,40 +253,210 @@ export class RaidState implements State.RaidState{
             if ((pokemon.originalCurHP <= maxHP / 4) || (pokemon.hasAbility("Gluttony") && (pokemon.originalCurHP <= maxHP / 2))) {
                 switch (pokemon.item) {
                     case "Liechi Berry":
-                        this.applyStatChange(id, {atk: 1}, true, id);
-                        this.loseItem(id);
-                        break;
                     case "Ganlon Berry":
-                        this.applyStatChange(id, {def: 1}, true, id);
-                        this.loseItem(id);
-                        break;
                     case "Petaya Berry":
-                        this.applyStatChange(id, {spa: 1}, true, id);
-                        this.loseItem(id);
-                        break;
                     case "Apicot Berry":
-                        this.applyStatChange(id, {spd: 1}, true, id);
-                        this.loseItem(id);
-                        break;
                     case "Salac Berry":
-                        this.applyStatChange(id, {spe: 1}, true, id);
-                        this.loseItem(id);
-                        break;
                     case "Lansat Berry":
-                        if (!pokemon.isPumped) {
-                            pokemon.isPumped = 2;
-                            this.loseItem(id);
-                        }
-                        break;
                     case "Micle Berry":
-                        pokemon.isMicle = true;
-                        this.loseItem(id);
+                        this.consumeItem(id, pokemon.item as ItemName, true);
                         break;
                 }
             }
         }
         // Final Check for fainting
         if (fainted) { this.faint(id); }
+    }
+
+    public consumeItem(id: number, item: ItemName, lost: boolean = true) {
+        const pokemon = this.getPokemon(id);
+        switch (item) {
+            case "White Herb":
+                for (let stat in pokemon.boosts) {
+                    const statId = stat as StatIDExceptHP;
+                    if ((pokemon.boosts[statId] || 0) < 0) { 
+                        pokemon.boosts[statId] = 0; 
+                        pokemon.lastConsumedItem = item as ItemName;
+                        this.loseItem(id);
+                    }
+                }
+                break;
+            // Status-Curing Berries
+            case "Cheri Berry":
+                if (pokemon.status === "par") { 
+                    pokemon.status = "";
+                    pokemon.lastConsumedItem = item as ItemName; 
+                    pokemon.isCudChew = 2;
+                }
+                break;
+            case "Chesto Berry":
+                if (pokemon.status === "slp") { 
+                    pokemon.status = "";
+                    pokemon.lastConsumedItem = item as ItemName; 
+                    pokemon.isCudChew = 2;
+                }
+                break;
+            case "Pecha Berry":
+                if (pokemon.status === "psn") { 
+                    pokemon.status = "";
+                    pokemon.lastConsumedItem = item as ItemName; 
+                    pokemon.isCudChew = 2;
+                }
+                break;
+            case "Rawst Berry":
+                if (pokemon.status === "brn") { 
+                    pokemon.status = "";
+                    pokemon.lastConsumedItem = item as ItemName; 
+                    pokemon.isCudChew = 2;
+                }
+                break;
+            case "Aspear Berry":
+                if (pokemon.status === "frz") { 
+                    pokemon.status = "";
+                    pokemon.lastConsumedItem = item as ItemName; 
+                    pokemon.isCudChew = 2;
+                }
+                break;
+            case "Lum Berry":
+                if (pokemon.status !== "") { 
+                    pokemon.status = "";
+                    pokemon.lastConsumedItem = item as ItemName; 
+                    pokemon.isCudChew = 2;
+                }
+                if (pokemon.volatileStatus.includes("confusion")) { 
+                    pokemon.volatileStatus = pokemon.volatileStatus.filter(status => status !== "confusion"); 
+                    pokemon.lastConsumedItem = item as ItemName;
+                    pokemon.isCudChew = 2;
+                }
+                break;
+            case "Persim Berry": 
+                if (pokemon.volatileStatus.includes("confusion")) { 
+                    pokemon.volatileStatus = pokemon.volatileStatus.filter(status => status !== "confusion"); 
+                    pokemon.lastConsumedItem = item as ItemName;
+                    pokemon.isCudChew = 2;
+                }
+                break;
+            // Stat-Boosting Berries
+            case "Liechi Berry":
+                const atkDiff = this.applyStatChange(id, {atk: 1});
+                if (atkDiff.atk){
+                    pokemon.lastConsumedItem = item as ItemName;
+                    pokemon.isCudChew = 2;
+                }
+                break;
+            case "Ganlon Berry":
+                const defDiff = this.applyStatChange(id, {def: 1});
+                if (defDiff.def){
+                    pokemon.lastConsumedItem = item as ItemName;
+                    pokemon.isCudChew = 2;
+                }
+                break;
+            case "Petaya Berry":
+                const spaDiff = this.applyStatChange(id, {spa: 1});
+                if (spaDiff.spa){
+                    pokemon.lastConsumedItem = item as ItemName;
+                    pokemon.isCudChew = 2;
+                }
+                break;
+            case "Apicot Berry":
+                const spdDiff = this.applyStatChange(id, {spd: 1});
+                if (spdDiff.spd){
+                    pokemon.lastConsumedItem = item as ItemName;
+                    pokemon.isCudChew = 2;
+                }
+                break;
+            case "Salac Berry":
+                const speDiff = this.applyStatChange(id, {spe: 1});
+                if (speDiff.spe){
+                    pokemon.lastConsumedItem = item as ItemName;
+                    pokemon.isCudChew = 2;
+                }
+                break;
+            case "Lansat Berry":
+                if (!pokemon.isPumped) {
+                    pokemon.lastConsumedItem = item as ItemName;
+                    pokemon.isCudChew = 2;
+                }
+                pokemon.isPumped = 2;
+                break;
+            case "Micle Berry":
+                if (!pokemon.isMicle) {
+                    pokemon.lastConsumedItem = item as ItemName;
+                    pokemon.isCudChew = 2;
+                }
+                pokemon.isMicle = true;
+                break;
+            // Healing Berries (TO DO, other healing berries that confuse depending on nature)
+            case "Sitrus Berry":
+                const maxhp = pokemon.maxHP();
+                if (pokemon.originalCurHP < maxhp) {
+                    pokemon.originalCurHP = Math.min(maxhp, pokemon.originalCurHP + Math.floor(maxhp / 4));
+                    pokemon.lastConsumedItem = item as ItemName;
+                    pokemon.isCudChew = 2;
+                }
+                break;
+            case "Oran Berry":
+                if (pokemon.originalCurHP < pokemon.maxHP()) {
+                    pokemon.originalCurHP = Math.min(pokemon.maxHP(), pokemon.originalCurHP + 10);
+                    pokemon.lastConsumedItem = item as ItemName;
+                    pokemon.isCudChew = 2;
+                }
+                break;
+            // Terrain Seeds
+            case "Electric Seed": 
+            case "Grassy Seed":
+                const gsdiff = this.applyStatChange(id, {def: 1}, true, id);
+                if (gsdiff.def){
+                    pokemon.lastConsumedItem = item as ItemName;
+                }
+                break;
+            case "Psychic Seed":
+            case "Misty Seed":
+                const msdiff = this.applyStatChange(id, {spd: 1}, true, id);
+                if (msdiff.spd){
+                    pokemon.lastConsumedItem = item as ItemName;
+                }
+                break;
+            // Other boosting items
+            case "Weakness Policy":
+                const wpdiff = this.applyStatChange(id, {atk: 2, spa: 2}, true, id);
+                if (wpdiff.atk || wpdiff.spa){
+                    pokemon.lastConsumedItem = item as ItemName;
+                }
+                break;
+            case "Absorb Bulb":
+            case "Throat Spray":
+                const tsdiff = this.applyStatChange(id, {spa: 1}, true, id);
+                if (tsdiff.spa){
+                    pokemon.lastConsumedItem = item as ItemName;
+                }
+                break;
+            case "Luminous Moss":
+                const lmdiff = this.applyStatChange(id, {spd: 1}, true, id);
+                if (lmdiff.spd){
+                    pokemon.lastConsumedItem = item as ItemName;
+                }
+                break;
+            case "Cell Battery":
+            case "Snowball":
+                const sbdiff = this.applyStatChange(id, {atk: 1}, true, id);
+                if (sbdiff.atk){
+                    pokemon.lastConsumedItem = item as ItemName;
+                }
+                break;
+            // Other
+            case "Mental Herb":
+                const vslen = pokemon.volatileStatus.length;
+                pokemon.volatileStatus = [...pokemon.volatileStatus].filter(status => !["infatuation", "taunt", "encore", "disable", "torment", "heal-block"].includes(status));
+                if (pokemon.volatileStatus.length < vslen) {
+                    pokemon.lastConsumedItem = item as ItemName;
+                }
+                break;
+            default: 
+                pokemon.lastConsumedItem = item as ItemName;
+                break;
+        }
+        if (lost) { this.loseItem(id); }
     }
 
     public applyStatChange(id: number, boosts: Partial<StatsTable>, copyable: boolean = true, sourceID: number = id, ignoreAbility: boolean = false, fromMirrorArmor = false): StatsTable {
@@ -377,23 +529,17 @@ export class RaidState implements State.RaidState{
                         }
                     }
                     if (hasPositiveBoost) {
-                        this.applyStatChange(opponentId, positiveDiff, false, id);
-                        if (opponent.item === "Mirror Herb") { this.loseItem(opponentId); }
+                        const changes = this.applyStatChange(opponentId, positiveDiff, false, id);
+                        if (Object.values(changes).some(val => val > 0) && opponent.item === "Mirror Herb") { 
+                            this.consumeItem(opponentId, opponent.item); 
+                        }
                     }
                 }
             }
         }
         // White Herb
         if (pokemon.item === "White Herb") {
-            let used = false
-            for (const stat in pokemon.boosts) {
-                const statId = stat as StatIDExceptHP;
-                if ((pokemon.boosts[statId] || 0) < 0) {
-                    pokemon.boosts[statId] = 0;
-                    used = true;
-                }
-            }
-            if (used) { this.loseItem(id); }
+            this.consumeItem(id, pokemon.item, false); // It will be consumed and removed only if there are negative stat changes
         }
  
         return diff;
@@ -437,15 +583,13 @@ export class RaidState implements State.RaidState{
         }
 
         // Status curing berries
-        if (pokemon.item === "Cheri Berry" && pokemon.status === "par") { pokemon.status = ""; this.loseItem(id); }
-        if (pokemon.item === "Chesto Berry" && pokemon.status === "slp") { pokemon.status = ""; pokemon.isSleep = 0; this.loseItem(id); }
-        if (pokemon.item === "Pecha Berry" && pokemon.status === "psn") { pokemon.status = ""; this.loseItem(id); }
-        if (pokemon.item === "Rawst Berry" && pokemon.status === "brn") { pokemon.status = ""; this.loseItem(id); }
-        if (pokemon.item === "Aspear Berry" && pokemon.status === "frz") { pokemon.status = ""; this.loseItem(id); }
-        if (pokemon.item === "Lum Berry" && pokemon.status !== "") { 
-            pokemon.status = ""; 
-            pokemon.volatileStatus = pokemon.volatileStatus.filter(status => status !== "confusion"); 
-            this.loseItem(id); 
+        if ( (pokemon.item === "Cheri Berry" && pokemon.status === "par") || 
+             (pokemon.item === "Chesto Berry" && pokemon.status === "slp") ||
+             (pokemon.item === "Pecha Berry" && pokemon.status === "psn") ||
+             (pokemon.item === "Rawst Berry" && pokemon.status === "brn") ||
+             (pokemon.item === "Aspear Berry" && pokemon.status === "frz") ||
+             (pokemon.item === "Lum Berry" && pokemon.status !== "") ) { 
+            this.consumeItem(id, pokemon.item, true);
         }
     }
 
@@ -496,22 +640,16 @@ export class RaidState implements State.RaidState{
             }
         }
 
-        // Volatile Status curing berries
-        if (pokemon.hasItem("Persim Berry", "Lum Berry") && pokemon.volatileStatus.includes("confusion")) { 
-            pokemon.volatileStatus = pokemon.volatileStatus.filter(status => status !== "confusion"); 
-            this.loseItem(id);
-        }
-        // Mental herb
-        if (pokemon.hasItem("Mental Herb")) {
-            const originalVolatileStatus = [...pokemon.volatileStatus];
-            pokemon.volatileStatus = pokemon.volatileStatus.filter(status => !["infatuation", "taunt", "encore", "disable", "torment", "heal-block"].includes(status));
-            if (originalVolatileStatus.length > pokemon.volatileStatus.length) { this.loseItem(id); }
+        // Volatile Status curing berries + Mental Herb
+        if ( (pokemon.hasItem("Persim Berry", "Lum Berry") && pokemon.volatileStatus.includes("confusion")) || 
+             (pokemon.hasItem("Mental Herb") && ["infatuation", "taunt", "encore", "disable", "torment", "heal-block"].includes(ailment)) ) {
+            this.consumeItem(id, pokemon.item!, true);
         } 
     }
 
-    public loseItem(id: number, consumed: boolean = true) {
+    public loseItem(id: number) {
         const pokemon = this.getPokemon(id);
-        pokemon.loseItem(consumed);
+        pokemon.loseItem();
         // Symbiosis
         if (id > 0) {
             const symbiosisIds: number[] = []
@@ -590,18 +728,11 @@ export class RaidState implements State.RaidState{
                 }
             }
             // Terrain Seeds
-            if (pokemon.item === "Electric Seed" && pokemon.field.hasTerrain("Electric")) {
-                this.applyStatChange(id, {def: 1}, true, id);
-                this.loseItem(id);
-            } else if (pokemon.item === "Grassy Seed" && pokemon.field.hasTerrain("Grassy")) {
-                this.applyStatChange(id, {def: 1}, true, id);
-                this.loseItem(id);
-            } else if (pokemon.item === "Psychic Seed" && pokemon.field.hasTerrain("Psychic")) {
-                this.applyStatChange(id, {spd: 1}, true, id);
-                this.loseItem(id);
-            } else if (pokemon.item === "Misty Seed" && pokemon.field.hasTerrain("Misty")) {
-                this.applyStatChange(id, {spd: 1}, true, id);
-                this.loseItem(id);
+            if ( (pokemon.item === "Electric Seed" && pokemon.field.hasTerrain("Electric")) ||
+                 (pokemon.item === "Grassy Seed" && pokemon.field.hasTerrain("Grassy")) ||
+                 (pokemon.item === "Psychic Seed" && pokemon.field.hasTerrain("Psychic")) ||
+                 (pokemon.item === "Misty Seed" && pokemon.field.hasTerrain("Misty")) ) {
+                this.consumeItem(id, pokemon.item, true);
             }
         }
     }

--- a/src/raidcalc/RaidTurn.ts
+++ b/src/raidcalc/RaidTurn.ts
@@ -596,9 +596,6 @@ export class RaidTurn {
                         this._endFlags.push(pokemon.role + ` — ${pokemon.lastConsumedItem} restored (Harvest)`);
                     }
                     break;
-                // case "Cud Chew":
-                //     if this.turnNumber
-                //     break;
                 case "Slow Start": 
                     if (pokemon.slowStartCounter) {
                         pokemon.slowStartCounter--;
@@ -607,7 +604,21 @@ export class RaidTurn {
                             this._endFlags.push(pokemon.role + " — Slow Start ended");
                         }
                     }
-                break
+                    break;
+                default: break;
+            }
+        }
+        for (const pokemon of this._raidState.raiders) {
+            switch (pokemon.ability) {
+                case "Cud Chew":
+                    if (pokemon.isCudChew && this.turnNumber % 4 === 3) {
+                        pokemon.isCudChew--;
+                        if (pokemon.isCudChew === 0 && (pokemon.lastConsumedItem || "").includes("Berry")) {
+                            this._raidState.consumeItem(pokemon.id, pokemon.lastConsumedItem!, false);
+                            this._endFlags.push(pokemon.role + " — " + pokemon.lastConsumedItem + " consumed via Cud Chew");
+                        }
+                    }
+                    break;
                 default: break;
             }
         }

--- a/src/raidcalc/Raider.ts
+++ b/src/raidcalc/Raider.ts
@@ -52,6 +52,7 @@ export class Raider extends Pokemon implements State.Raider {
     syrupBombSource?: number; // id of the pokemon that inflicted the user with Syrup Bomb
 
     lastConsumedItem?: ItemName; // stores the last berry consumed by the raider (via normal consuption of Fling)
+    isCudChew?: number;          // store number of "turns" (each made of 4 moves) until Cud Chew activates
 
     isTransformed?: boolean; // indicates that the pokemon has been transformed by Transform or Imposter
     isChangedForm?: boolean; // indicates that the pokemon has been changed form (e.g. Eiscue, Terapagos, Minior)
@@ -104,6 +105,7 @@ export class Raider extends Pokemon implements State.Raider {
         syrupBombDrops: number | undefined = 0,
         syrupBombSource: number | undefined = undefined,
         lastConsumedItem: ItemName | undefined = undefined,
+        isCudChew: number | undefined = 0,
         isTransformed: boolean | undefined = undefined,
         isChangedForm: boolean | undefined = undefined,
         originalSpecies: SpeciesName | undefined = undefined,
@@ -152,6 +154,7 @@ export class Raider extends Pokemon implements State.Raider {
         this.syrupBombDrops = syrupBombDrops;
         this.syrupBombSource = syrupBombSource;
         this.lastConsumedItem = lastConsumedItem;
+        this.isCudChew = isCudChew;
         this.isTransformed = isTransformed;
         this.isChangedForm = isChangedForm;
         this.originalSpecies  = originalSpecies;
@@ -241,6 +244,7 @@ export class Raider extends Pokemon implements State.Raider {
             this.syrupBombDrops,
             this.syrupBombSource,
             this.lastConsumedItem,
+            this.isCudChew,
             this.isTransformed,
             this.isChangedForm,
             this.originalSpecies,
@@ -289,13 +293,10 @@ export class Raider extends Pokemon implements State.Raider {
         return diff;
     }
 
-    public loseItem(consumed: boolean = true) {
+    public loseItem() {
         // Unburden
         if (this.ability === "Unburden" && this.item !== undefined) {
             this.abilityOn = true;
-        }
-        if (consumed) {
-            this.lastConsumedItem = this.item;
         }
         if (this.hasItem("Choice Band", "Choice Specs", "Choice Scarf")) {
             this.isChoiceLocked = false;

--- a/src/raidcalc/interface.ts
+++ b/src/raidcalc/interface.ts
@@ -145,6 +145,7 @@ export interface Raider extends Pokemon {
     syrupBombDrops?: number;
     syrupBombSource?: number;
     lastConsumedItem?: ItemName;
+    isCudChew?: number;    // store number of "turns" (each made of 4 moves) until Cud Chew activates
     isTransformed?: boolean;
     originalSpecies?: SpeciesName;
     originalMoves?: MoveData[];


### PR DESCRIPTION
Avoid having effects for items rewritten in a few places by putting them in a new `consumeItem` method in `RaidState`.

Make Cud Chew possible (without rewriting all Berry effects *again*) by allowing for items to be consumed without being held.