### PR TITLE
More thorough faint probability calculation

### DIFF
--- a/src/calc/desc.ts
+++ b/src/calc/desc.ts
@@ -59,7 +59,6 @@ export interface RawDesc {
   isDefenderDynamaxed?: boolean;
   isCharged?: boolean;
   shieldActive?: boolean;
-  koTextOverride?: string;
 }
 
 export function display(
@@ -84,7 +83,7 @@ export function display(
   const damageText = `${min}-${max} (${minDisplay} - ${maxDisplay}${notation}${getBossMultiplierDesc(defender)})`;
 
   if (move.category === 'Status' && !move.named('Nature Power')) return `${desc}: ${damageText}`;
-  const koChanceText = rawDesc.koTextOverride || getKOChance(gen, attacker, defender, move, field, damage, err).text;
+  const koChanceText = getKOChance(gen, attacker, defender, move, field, damage, err).text;
   return koChanceText ? `${desc}: ${damageText} -- ${koChanceText}` : `${desc}: ${damageText}`;
 }
 

--- a/src/calc/desc.ts
+++ b/src/calc/desc.ts
@@ -59,6 +59,7 @@ export interface RawDesc {
   isDefenderDynamaxed?: boolean;
   isCharged?: boolean;
   shieldActive?: boolean;
+  koTextOverride?: string;
 }
 
 export function display(
@@ -83,7 +84,7 @@ export function display(
   const damageText = `${min}-${max} (${minDisplay} - ${maxDisplay}${notation}${getBossMultiplierDesc(defender)})`;
 
   if (move.category === 'Status' && !move.named('Nature Power')) return `${desc}: ${damageText}`;
-  const koChanceText = getKOChance(gen, attacker, defender, move, field, damage, err).text;
+  const koChanceText = rawDesc.koTextOverride || getKOChance(gen, attacker, defender, move, field, damage, err).text;
   return koChanceText ? `${desc}: ${damageText} -- ${koChanceText}` : `${desc}: ${damageText}`;
 }
 

--- a/src/raidcalc/RaidBattle.ts
+++ b/src/raidcalc/RaidBattle.ts
@@ -4,6 +4,7 @@ import { TurnGroupInfo } from "./interface";
 import { RaidState } from "./RaidState";
 import { RaidMove } from "./RaidMove";
 import { RaidTurn, RaidTurnResult } from "./RaidTurn";
+import { getCumulativeKOChance } from "./util";
 
 const gen = Generations.get(9);
 

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -677,6 +677,9 @@ export class RaidMove {
                                     hitRoll = catRollCounts(hitRoll, getRollCounts([otherResult.damage as number[]], 0, target.maxHP(), [otherRollChance]));
                                 }
                             }
+                            if (accFraction > 0 && accFraction < 1) {
+                                hitRoll = catRollCounts(hitRoll, getRollCounts([[0]], 0, target.maxHP(), [1 - accFraction]));
+                            }
                             const bypassSubstitute = this.moveData.bypassSub || moveUser.hasAbility("Infiltrator");
                             this._raidState.applyDamage(id, hitDamage, hitRoll, 1, result.rawDesc.isCritical, superEffective, this.move.name, this._moveType, this.move.category, this.moveData.isWind, bypassSubstitute, this._isSheerForceBoosted);
                             totalDamage += hitDamage;

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -5,7 +5,7 @@ import { RaidState } from "./RaidState";
 import { Raider } from "./Raider";
 import { AbilityName, ItemName, SpeciesName, StatIDExceptHP, StatusName, TypeName } from "../calc/data/interface";
 import { isGrounded } from "../calc/mechanics/util";
-import { absoluteFloor, isSuperEffective, pokemonIsGrounded, isStatus, getAccuracy, getBpModifier, isRegularMove, isRaidAction, getCumulativeKOChance } from "./util";
+import { absoluteFloor, isSuperEffective, pokemonIsGrounded, isStatus, getAccuracy, getBpModifier, isRegularMove, isRaidAction, getCumulativeKOChance, getCritChance, getRollCounts, catRollCounts, combineRollCounts } from "./util";
 import persistentAbilities from "../data/persistent_abilities.json"
 import bypassProtectMoves from "../data/bypass_protect_moves.json"
 import chargeMoves from "../data/charge_moves.json";
@@ -67,7 +67,7 @@ export class RaidMove {
     _moveType!: TypeName;
     _isSpread?: boolean;
     _damage!: number[];
-    _damageRolls!: number[][][];
+    _damageRolls!: Map<number,number>[][];
     _healing!: number[];
     _drain!: number[];
     _eot!: ({damage: number, texts: string[]} | undefined)[];
@@ -224,7 +224,7 @@ export class RaidMove {
         this._causesFlinch = [false, false, false, false, false];
         this._moveType = this.move.type;
         this._damage = [0,0,0,0,0];
-        this._damageRolls = [[],[],[],[],[]]
+        this._damageRolls = [[],[],[],[],[]];
         this._drain = [0,0,0,0,0];
         this._healing = [0,0,0,0,0];
         this._eot = [undefined, undefined, undefined, undefined];
@@ -599,7 +599,8 @@ export class RaidMove {
             } else if (this._blockedBy[id] !== "")  {
                 this._desc[id] = this.move.name + " was blocked by " + this._blockedBy[id] + "!";
             } else if (this._affectedIDs.includes(id)) {
-                const crit = this.options.crit || false;
+                const critChance = getCritChance(this.move, moveUser, target);
+                const crit = this.options.crit || critChance >= 1;
                 const roll = this.options.roll || "avg";
                 const superEffective = isSuperEffective(this.move, this._moveType, target.field, this._user, target);
                 let results = [];
@@ -609,6 +610,8 @@ export class RaidMove {
                 const attackerIgnoresAbility = this._user.hasAbility("Mold Breaker", "Teravolt", "Turboblaze") && !target.hasItem("Ability Shield");
                 const [accuracy, accEffectsList] = getAccuracy(this.moveData, this.move.category, moveUser, target, !this.movesFirst, attackerIgnoresAbility);
                 const bpModifier = getBpModifier(this.moveData, target, this.damaged);
+                const accFraction = Math.min(1,accuracy/100);
+                const rollChance = accFraction * (crit ? critChance : (1 - critChance));
                 if (accuracy > 0) {
                     try {
                         // calculate each hit from a multi-hit move
@@ -636,6 +639,13 @@ export class RaidMove {
                             // get calc result
                             const moveField = this.getMoveField(this.userID, id);
                             const result = calculate(9, moveUser, target, calcMove, moveField);
+                            let otherResult = undefined;
+                            if (critChance > 0 && critChance < 1) {
+                                const otherCalcMove = calcMove.clone();
+                                otherCalcMove.isCrit = !crit;
+                                otherResult = calculate(9, moveUser, target, otherCalcMove, moveField);
+                            }
+                            
                             results.push(result);
                             // ignore the possibility that result.damage is [number[], number[]]. When would that come up?
                             if (damageResult === undefined) {
@@ -647,22 +657,31 @@ export class RaidMove {
                                 damageResult = (damageResult as number[]).map((val, i) => val + (result.damage as number[])[i]);
                             }
                             let hitDamage = 0;
-                            let hitRoll = [0];
+                            let hitRoll = undefined;
                             if (typeof(result.damage) === "number") {
                                 hitDamage = result.damage as number;
-                                hitRoll = [hitDamage];
+                                hitRoll = getRollCounts([[hitDamage]], 0, target.maxHP(), [rollChance]);
                             } else {
                                 //@ts-ignore
                                 hitDamage = roll === "max" ? result.damage[result.damage.length-1] : roll === "min" ? result.damage[0] : result.damage[Math.floor(result.damage.length/2)];
-                                hitRoll = result.damage as number[];
+                                hitRoll = getRollCounts([result.damage as number[]], 0, target.maxHP(), [rollChance]);
                             }
                             if (calcMove.name === "False Swipe") {
                                 hitDamage = Math.min(hitDamage, target.originalCurHP - 1);
+                            }
+                            if (otherResult) {
+                                const otherRollChance = accFraction * (crit ? 1 - critChance : critChance);
+                                if (typeof(otherResult.damage) === "number") {
+                                    hitRoll = catRollCounts(hitRoll, getRollCounts([[otherResult.damage as number]], 0, target.maxHP(), [otherRollChance]));
+                                } else {
+                                    hitRoll = catRollCounts(hitRoll, getRollCounts([otherResult.damage as number[]], 0, target.maxHP(), [otherRollChance]));
+                                }
                             }
                             const bypassSubstitute = this.moveData.bypassSub || moveUser.hasAbility("Infiltrator");
                             this._raidState.applyDamage(id, hitDamage, hitRoll, 1, result.rawDesc.isCritical, superEffective, this.move.name, this._moveType, this.move.category, this.moveData.isWind, bypassSubstitute, this._isSheerForceBoosted);
                             totalDamage += hitDamage;
                             this._damageRolls[id].push(hitRoll);
+        
                             // remove buffs to user after damage
                             if (totalDamage > 0) {
                                 hasCausedDamage = true;
@@ -820,15 +839,19 @@ export class RaidMove {
         const damage = this._damage.reduce((a,b) => a + b, 0);
         if (drainPercent) {
             // scripted Matcha Gotcha could potentially drain from multiple raiders
-            let drainRolls: number[][] | undefined = undefined;
+            let drainRolls: Map<number,number> | undefined = undefined;
             if (damage > 0) {
                 for (let id of this._affectedIDs) {
                     this._drain[this.userID] = this._drain[this.userID] + absoluteFloor(this._damage[id] * drainPercent/100);
                     for (let hitRolls of this._damageRolls[id]) {
+                        const scaledRolls = new Map<number,number>();
+                        for (let [key, val] of hitRolls) {
+                            scaledRolls.set(absoluteFloor(key * -drainPercent/100), val);
+                        }
                         if (drainRolls === undefined) {
-                            drainRolls = [hitRolls.map(val => Math.floor(val * -drainPercent/100))];
+                            drainRolls = scaledRolls;
                         } else {
-                            drainRolls.push(hitRolls.map(val => Math.floor(val * -drainPercent/100)));
+                            drainRolls = combineRollCounts(drainRolls, scaledRolls, -this._raidState.raiders[id].maxHP(), this._raidState.raiders[id].maxHP());
                         }
                     }
                 }
@@ -875,7 +898,7 @@ export class RaidMove {
         }
         for (let id=1; id<5; id++) {
             if (this._healing[id] && this.getPokemon(id).originalCurHP > 0) {
-                this._raidState.applyDamage(id, -this._healing[id], healingRolls[id])
+                this._raidState.applyDamage(id, -this._healing[id], healingRolls[id] ? getRollCounts([healingRolls[id] as number[]], -Infinity, 0) : undefined);
             }
         }
     }

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -5,7 +5,7 @@ import { RaidState } from "./RaidState";
 import { Raider } from "./Raider";
 import { AbilityName, ItemName, SpeciesName, StatIDExceptHP, StatusName, TypeName } from "../calc/data/interface";
 import { isGrounded } from "../calc/mechanics/util";
-import { absoluteFloor, isSuperEffective, pokemonIsGrounded, isStatus, getAccuracy, getBpModifier, isRegularMove, isRaidAction } from "./util";
+import { absoluteFloor, isSuperEffective, pokemonIsGrounded, isStatus, getAccuracy, getBpModifier, isRegularMove, isRaidAction, getCumulativeKOChance } from "./util";
 import persistentAbilities from "../data/persistent_abilities.json"
 import bypassProtectMoves from "../data/bypass_protect_moves.json"
 import chargeMoves from "../data/charge_moves.json";
@@ -30,6 +30,8 @@ export type RaidMoveResult= {
 // we'll always use generation 9
 const gen = Generations.get(9);
 const dummyMove = new Move(gen, "Splash");
+
+const healCheerRoll = Array.from(Array(16).keys()).map((i) => (0.2 + 0.8 * i/15));
 
 export class RaidMove {
     move: Move;
@@ -65,6 +67,7 @@ export class RaidMove {
     _moveType!: TypeName;
     _isSpread?: boolean;
     _damage!: number[];
+    _damageRolls!: number[][][];
     _healing!: number[];
     _drain!: number[];
     _eot!: ({damage: number, texts: string[]} | undefined)[];
@@ -221,6 +224,7 @@ export class RaidMove {
         this._causesFlinch = [false, false, false, false, false];
         this._moveType = this.move.type;
         this._damage = [0,0,0,0,0];
+        this._damageRolls = [[],[],[],[],[]]
         this._drain = [0,0,0,0,0];
         this._healing = [0,0,0,0,0];
         this._eot = [undefined, undefined, undefined, undefined];
@@ -633,6 +637,7 @@ export class RaidMove {
                             const moveField = this.getMoveField(this.userID, id);
                             const result = calculate(9, moveUser, target, calcMove, moveField);
                             results.push(result);
+                            // ignore the possibility that result.damage is [number[], number[]]. When would that come up?
                             if (damageResult === undefined) {
                                 // @ts-ignore
                                 damageResult = result.damage;
@@ -642,18 +647,22 @@ export class RaidMove {
                                 damageResult = (damageResult as number[]).map((val, i) => val + (result.damage as number[])[i]);
                             }
                             let hitDamage = 0;
+                            let hitRoll = [0];
                             if (typeof(result.damage) === "number") {
                                 hitDamage = result.damage as number;
+                                hitRoll = [hitDamage];
                             } else {
                                 //@ts-ignore
                                 hitDamage = roll === "max" ? result.damage[result.damage.length-1] : roll === "min" ? result.damage[0] : result.damage[Math.floor(result.damage.length/2)];
+                                hitRoll = result.damage as number[];
                             }
                             if (calcMove.name === "False Swipe") {
                                 hitDamage = Math.min(hitDamage, target.originalCurHP - 1);
                             }
                             const bypassSubstitute = this.moveData.bypassSub || moveUser.hasAbility("Infiltrator");
-                            this._raidState.applyDamage(id, hitDamage, 1, result.rawDesc.isCritical, superEffective, this.move.name, this._moveType, this.move.category, this.moveData.isWind, bypassSubstitute, this._isSheerForceBoosted);
+                            this._raidState.applyDamage(id, hitDamage, hitRoll, 1, result.rawDesc.isCritical, superEffective, this.move.name, this._moveType, this.move.category, this.moveData.isWind, bypassSubstitute, this._isSheerForceBoosted);
                             totalDamage += hitDamage;
+                            this._damageRolls[id].push(hitRoll);
                             // remove buffs to user after damage
                             if (totalDamage > 0) {
                                 hasCausedDamage = true;
@@ -722,6 +731,11 @@ export class RaidMove {
                         result.damage = damageResult as number | number[];
                         result.rawDesc.hits = this.hits > 1 ? this.hits : undefined;
                         this._damage[id] = Math.min(totalDamage, this.raidState.raiders[id].originalCurHP);
+                        // adjust desc with cumulative KO chance
+                        const koChance = getCumulativeKOChance(target.cumDamageRolls, target.maxHP());
+                        if (koChance > 0) {
+                            result.rawDesc.koTextOverride = koChance === 100 ? "guaranteed KO" : `${koChance}% cumulative chance to KO`;
+                        }
                         this._desc[id] = result.desc();
                         // for Fling / Symbiosis interactions, the Flinger should lose their item *after* the target recieves damage
                         if (this.moveData.name === "Fling" && this._user.item) {
@@ -806,23 +820,35 @@ export class RaidMove {
         const damage = this._damage.reduce((a,b) => a + b, 0);
         if (drainPercent) {
             // scripted Matcha Gotcha could potentially drain from multiple raiders
+            let drainRolls: number[][] | undefined = undefined;
             if (damage > 0) {
-                this._drain[this.userID] = absoluteFloor(this._damage[this._targetID] * drainPercent/100);
+                for (let id of this._affectedIDs) {
+                    this._drain[this.userID] = this._drain[this.userID] + absoluteFloor(this._damage[id] * drainPercent/100);
+                    for (let hitRolls of this._damageRolls[id]) {
+                        if (drainRolls === undefined) {
+                            drainRolls = [hitRolls.map(val => Math.floor(val * -drainPercent/100))];
+                        } else {
+                            drainRolls.push(hitRolls.map(val => Math.floor(val * -drainPercent/100)));
+                        }
+                    }
+                }
             }
             if (this._drain[this.userID] && this._user.originalCurHP > 0) {
-                this._raidState.applyDamage(this.userID, -this._drain[this.userID])
+                this._raidState.applyDamage(this.userID, -this._drain[this.userID], drainRolls)
             }
         }
     }
 
     private applyHealing() {
         let healingPercent = this.moveData.healing;
+        const healingRolls: (number[] | undefined)[] = [undefined, undefined, undefined, undefined, undefined];
         for (let id of this._affectedIDs) {
             if (this._doesNotAffect[id] || this._blockedBy[id] !== "") { continue; }
             const target = this.getPokemon(id);
             const maxHP = target.maxHP();
             if (this.move.name === "Heal Cheer") {
                 const roll = this.options.roll || "avg";
+                healingRolls[id] = healCheerRoll.map(val => -Math.floor(val * maxHP));
                 this._healing[id] += roll === "min" ? Math.floor(maxHP * 0.2) : roll === "max" ? maxHP : Math.floor(maxHP * 0.6);
                 const pokemon = this.getPokemon(id);
                 pokemon.status = "";
@@ -849,7 +875,7 @@ export class RaidMove {
         }
         for (let id=1; id<5; id++) {
             if (this._healing[id] && this.getPokemon(id).originalCurHP > 0) {
-                this._raidState.applyDamage(id, -this._healing[id])
+                this._raidState.applyDamage(id, -this._healing[id], healingRolls[id])
             }
         }
     }
@@ -1500,7 +1526,7 @@ export class RaidMove {
                 break;
             case "Curse": 
                 if (this._user.hasType("Ghost")) {
-                    this._raidState.applyDamage(this.userID, this._user.maxHP() / 2, 0);
+                    this._raidState.applyDamage(this.userID, this._user.maxHP() / 2);
                     // (Ghost) Curse probably doesn't work in raids
                 }
                 break;

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -34,8 +34,14 @@ export class RaidState implements State.RaidState{
 
     public applyDamage(id: number, damage: number, damageRolls: Map<number,number> | undefined = undefined, nHits: number = 0, isCrit: boolean = false, isSuperEffective: boolean = false, moveName?: MoveName, moveType?: TypeName, moveCategory?: "Physical" | "Special" | "Status" | undefined, isWind: boolean = false, bypassSubstitute: boolean = false, isSheerForceBoosted = false) {
         const pokemon = this.getPokemon(id);
-        if (pokemon.originalCurHP === 0) { return; } // prevent healing KOd Pokemon, and there's no need to subtract damage from 0HP
         const originalHP = pokemon.originalCurHP;
+        const originalDamageRolls = new Map<number,number>(pokemon.cumDamageRolls);
+        if (pokemon.originalCurHP === 0) {          // prevent healing KOd Pokemon, and there's no need to subtract damage from 0HP
+            if (damage !== 0 && damageRolls) {
+                pokemon.addDamageRoll(damageRolls); // but we should still record the damage rolls
+            }
+            return; 
+        } 
 
         for (let hit = 0; hit < Math.max(1, nHits); hit++) {
             if (pokemon.substitute && !bypassSubstitute) {
@@ -57,35 +63,42 @@ export class RaidState implements State.RaidState{
                 pokemon.hitsTaken = pokemon.hitsTaken + nHits;
             }
             // Item consumption / Ability Activation triggered by damage
-            // Focus Sash
-            if (pokemon.item === "Focus Sash" || pokemon.ability === "Sturdy") {
-                if (pokemon.originalCurHP <= 0 && originalHP === maxHP) { 
-                    pokemon.originalCurHP = 1;
-                    if (pokemon.ability !== "Sturdy") { this.consumeItem(id, pokemon.item!); } 
-                    fainted = false;
-                }
-            }
             // Ice Face
             if (pokemon.ability === "Ice Face" && !pokemon.abilityOn && pokemon.name.includes("Eiscue") && moveCategory === "Physical") {
                 pokemon.changeForm("Eiscue-Noice" as SpeciesName);
                 pokemon.abilityOn = true;
                 pokemon.originalCurHP = originalHP; // no damage is done
+                pokemon.cumDamageRolls = originalDamageRolls;
                 fainted = false;
                 return; // don't trigger item use
-            }
-            // Air Balloon
-            if (pokemon.item === "Air Balloon") {
-                this.loseItem(id);
             }
             // Disguise
             if (pokemon.ability === "Disguise" && !pokemon.abilityOn && pokemon.name.includes("Mimikyu")) {
                 pokemon.abilityOn = true;
                 pokemon.originalCurHP = originalHP; // negate damage from attack
-                pokemon.applyDamage(Math.floor(pokemon.maxHP()/8)); // bust disguise, 1/8 max HP damage
+                pokemon.cumDamageRolls = originalDamageRolls;
+                pokemon.applyDamage(Math.floor(pokemon.maxHP()/8)); // bust disguise, 1/8 max HP damage                
                 if (pokemon.originalCurHP === 0) {
                     this.faint(id);
                 }
                 return; // don't trigger item use (except for Air Balloon)
+            }
+            // Focus Sash
+            if (pokemon.item === "Focus Sash" || pokemon.ability === "Sturdy") {
+                if (pokemon.originalCurHP <= 0 && originalHP === maxHP) { 
+                    pokemon.originalCurHP = 1;
+                    pokemon.cumDamageRolls = originalDamageRolls;
+                    const sashDamageRolls = new Map<number,number>(originalDamageRolls);
+                    const faintChance = originalDamageRolls.get(maxHP) || 0;
+                    originalDamageRolls.delete(maxHP);
+                    sashDamageRolls.set(maxHP-1, faintChance + (originalDamageRolls.get(maxHP-1) || 0));
+                    if (pokemon.ability !== "Sturdy") { this.consumeItem(id, pokemon.item!); } 
+                    fainted = false;
+                }
+            }
+            // Air Balloon
+            if (pokemon.item === "Air Balloon") {
+                this.loseItem(id);
             }
             // Weakness Policy and Super-Effective reducing Berries
             // TO DO - abilities that let users use berries more than once

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -32,7 +32,7 @@ export class RaidState implements State.RaidState{
         return this.raiders[id];
     }
 
-    public applyDamage(id: number, damage: number, damageRolls: number[] | number[][] | undefined = undefined, nHits: number = 0, isCrit: boolean = false, isSuperEffective: boolean = false, moveName?: MoveName, moveType?: TypeName, moveCategory?: "Physical" | "Special" | "Status" | undefined, isWind: boolean = false, bypassSubstitute: boolean = false, isSheerForceBoosted = false) {
+    public applyDamage(id: number, damage: number, damageRolls: Map<number,number> | undefined = undefined, nHits: number = 0, isCrit: boolean = false, isSuperEffective: boolean = false, moveName?: MoveName, moveType?: TypeName, moveCategory?: "Physical" | "Special" | "Status" | undefined, isWind: boolean = false, bypassSubstitute: boolean = false, isSheerForceBoosted = false) {
         const pokemon = this.getPokemon(id);
         if (pokemon.originalCurHP === 0) { return; } // prevent healing KOd Pokemon, and there's no need to subtract damage from 0HP
         const originalHP = pokemon.originalCurHP;
@@ -1360,7 +1360,6 @@ export class RaidState implements State.RaidState{
         let ability = pokemon.ability;
         // reset HP
         pokemon.originalCurHP = pokemon.maxHP();
-        pokemon.damageHistory = [];
         pokemon.cumDamageRolls = new Map<number, number>();
         // check Neutralizing Gas
         const neutralizingGas = this.raiders.reduce((p, c) => p || c.ability === "Neutralizing Gas", false);

--- a/src/raidcalc/interface.ts
+++ b/src/raidcalc/interface.ts
@@ -117,6 +117,8 @@ export interface Raider extends Pokemon {
     moveData: MoveData[];
     extraMoves?: MoveName[];// for special boss actions
     extraMoveData?: MoveData[];
+    damageHistory: number[][];
+    cumDamageRolls: Map<number, number>;
     isEndure?: boolean;     // store that a Pokemon can't faint until its next move
     isTaunt?: number;       // store number of turns that a Pokemon can't use status moves
     isSleep?: number;       // store number of turns that a Pokemon is asleep

--- a/src/raidcalc/interface.ts
+++ b/src/raidcalc/interface.ts
@@ -117,7 +117,6 @@ export interface Raider extends Pokemon {
     moveData: MoveData[];
     extraMoves?: MoveName[];// for special boss actions
     extraMoveData?: MoveData[];
-    damageHistory: number[][];
     cumDamageRolls: Map<number, number>;
     isEndure?: boolean;     // store that a Pokemon can't faint until its next move
     isTaunt?: number;       // store number of turns that a Pokemon can't use status moves

--- a/src/raidcalc/util.ts
+++ b/src/raidcalc/util.ts
@@ -411,7 +411,7 @@ export function addRollsToCounts(cumRolls: Map<number, number>, newRolls: number
         const roll = newRolls[i];
         for (let j=0; j<prevRolls.length; j++) {
             const prevRoll = prevRolls[j];
-            const combinedRoll = Math.max(min, Math.min(max, roll + prevRoll));
+            const combinedRoll = prevRoll >= max ? max : Math.max(min, Math.min(max, roll + prevRoll)); // disallow healing if already fainted
             const prevChance = prevCumRolls.get(combinedRoll) || 1;
             const newChance = cumRolls.get(combinedRoll) || 0;
             cumRolls.set(combinedRoll, newChance + prevChance * rollChance);


### PR DESCRIPTION
This adds an attempt to assess the "cumulative" probability of fainting across all moves, rather than just reporting the KO chance for a single move, factoring in miss chance and crit chance.  Any stat boosts, secondary effects, shield activation, etc, are *not* considered for this calculation. They are fixed by the chosen damage roll.

Example readout (obtained by reducing the Maushold HP EVs by 4, and then Optimizing Boss Moves for the Tom & Jerry Swampert strat):

`0 Atk Tera Poison Swampert Earthquake vs. -1 248 HP / 0+ Def Maushold through Def Cheer on a critical hit: 217-256 (61.8 - 72.9%) -- 1.88e-7% cumulative chance to KO`



Inspired by:
https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/page-38#post-10141275

Luckily, we don't need to worry about scaling things up to 10^12 moves, so a simple O(H^2) implementation should be good enough.