### PR TITLE
Fixes to Ability Nullification

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -10,6 +10,7 @@ import { deserialize } from './utilities/shrinkstring';
 
 import { TextEncoder, TextDecoder } from 'util';
 import exp from 'constants';
+import { FlashOnOutlined } from '@mui/icons-material';
 Object.assign(global, { TextDecoder, TextEncoder });
 
 // RaidCalc tests
@@ -481,49 +482,49 @@ describe('Specific Test Cases', () => {
     expect(result.turnResults[0].results[1].state.raiders[1].field.attackerSide.friendGuards).toEqual(1);
     expect(result.turnResults[0].results[1].desc[1].includes("1 ally's Friend Guards")).toEqual(true);
     // T2: abilities nullified
-    expect(result.turnResults[1].state.raiders[1].ability).toEqual("(No Ability)");
-    expect(result.turnResults[1].state.raiders[2].ability).toEqual("(No Ability)");
-    expect(result.turnResults[1].state.raiders[3].ability).toEqual("(No Ability)");
-    expect(result.turnResults[1].state.raiders[4].ability).toEqual("(No Ability)");
+    expect(result.turnResults[1].state.raiders[1].hasAbility("Pure Power")).toEqual(false);
+    expect(result.turnResults[1].state.raiders[2].hasAbility("Liquid Ooze")).toEqual(false);
+    expect(result.turnResults[1].state.raiders[3].hasAbility("Blaze")).toEqual(false);
+    expect(result.turnResults[1].state.raiders[4].hasAbility("Friend Guard")).toEqual(false);
     // T3: no Friend Guard, Pure Power restored to Medi
     expect(result.turnResults[2].results[1].state.raiders[1].field.attackerSide.friendGuards).toEqual(0);
     expect(result.turnResults[2].results[1].desc[1].includes("Friend Guards")).toEqual(false);
-    expect(result.turnResults[2].results[1].state.raiders[1].ability).toEqual("(No Ability)");
-    expect(result.turnResults[2].state.raiders[1].ability).toEqual("Pure Power");
+    expect(result.turnResults[2].results[1].state.raiders[1].hasAbility("Pure Power")).toEqual(false);
+    expect(result.turnResults[2].state.raiders[1].hasAbility("Pure Power")).toEqual(true);
     // T4: Friend Guard restored
     expect(result.turnResults[3].results[1].state.raiders[4].field.attackerSide.friendGuards).toEqual(0);
     expect(result.turnResults[3].results[1].desc[4].includes("Friend Guards")).toEqual(false);
-    expect(result.turnResults[3].results[1].state.raiders[4].ability).toEqual("(No Ability)");
-    expect(result.turnResults[3].state.raiders[4].ability).toEqual("Friend Guard");
+    expect(result.turnResults[3].results[1].state.raiders[4].hasAbility("Friend Guard")).toEqual(false);
+    expect(result.turnResults[3].state.raiders[4].hasAbility("Friend Guard")).toEqual(true);
     // T5: one Friend Guard (only Jigglypuff), Blaze restored to Delphox
     expect(result.turnResults[4].results[1].state.raiders[3].field.attackerSide.friendGuards).toEqual(1);
     expect(result.turnResults[4].results[1].desc[3].includes("1 ally's Friend Guards")).toEqual(true);
-    expect(result.turnResults[4].results[1].state.raiders[3].ability).toEqual("(No Ability)");
-    expect(result.turnResults[4].state.raiders[3].ability).toEqual("Blaze");
+    expect(result.turnResults[4].results[1].state.raiders[3].hasAbility("Blaze")).toEqual(false);
+    expect(result.turnResults[4].state.raiders[3].hasAbility("Blaze")).toEqual(true);
     // T6: one Friend Guard (only Jigglypuff)
     expect(result.turnResults[5].results[1].state.raiders[1].field.attackerSide.friendGuards).toEqual(1);
     expect(result.turnResults[5].results[1].desc[1].includes("1 ally's Friend Guards")).toEqual(true);
     // T7: Medi Skill Swap vs Jigglypuff, no Friend Guard in defensive calc
     expect(result.turnResults[6].results[1].state.raiders[1].field.attackerSide.friendGuards).toEqual(0);
     expect(result.turnResults[6].results[1].desc[1].includes("Friend Guards")).toEqual(false);
-    expect(result.turnResults[6].results[0].state.raiders[1].ability).toEqual("Friend Guard");
-    expect(result.turnResults[6].state.raiders[1].ability).toEqual("Friend Guard");
-    expect(result.turnResults[6].state.raiders[4].ability).toEqual("Pure Power");
+    expect(result.turnResults[6].results[0].state.raiders[1].hasAbility("Friend Guard")).toEqual(true);
+    expect(result.turnResults[6].state.raiders[1].hasAbility("Friend Guard")).toEqual(true);
+    expect(result.turnResults[6].state.raiders[4].hasAbility("Pure Power")).toEqual(true);
     // T8: Jigglypuff now benefits from Friend Guard (only Medi)
     expect(result.turnResults[7].results[1].state.raiders[4].field.attackerSide.friendGuards).toEqual(1);
     expect(result.turnResults[7].results[1].desc[4].includes("1 ally's Friend Guards")).toEqual(true);
     // T9: Delphox copies Friend Guard from Jigglypuff, benfits from it (only Medi)
     expect(result.turnResults[8].results[1].state.raiders[3].field.attackerSide.friendGuards).toEqual(1);
     expect(result.turnResults[8].results[1].desc[3].includes("1 ally's Friend Guards")).toEqual(true);
-    expect(result.turnResults[8].results[0].state.raiders[3].ability).toEqual("Friend Guard");
-    expect(result.turnResults[8].state.raiders[3].ability).toEqual("Friend Guard");
+    expect(result.turnResults[8].results[0].state.raiders[3].hasAbility("Friend Guard")).toEqual(true);
+    expect(result.turnResults[8].state.raiders[3].hasAbility("Friend Guard")).toEqual(true);
     // T10: Jigglypuff benefits from 2 Friend Guards (Medi & Delphox)
     expect(result.turnResults[9].results[1].state.raiders[4].field.attackerSide.friendGuards).toEqual(2);
     expect(result.turnResults[9].results[1].desc[4].includes("2 allies' Friend Guards")).toEqual(true);
     // T11: Swalot nullifies Delphox's Friend Guard, benefits from it (only Medi)
     expect(result.turnResults[10].results[1].state.raiders[2].field.attackerSide.friendGuards).toEqual(1);
     expect(result.turnResults[10].results[1].desc[2].includes("1 ally's Friend Guards")).toEqual(true);
-    expect(result.turnResults[10].results[0].state.raiders[2].ability).toEqual("(No Ability)");
+    expect(result.turnResults[10].results[0].state.raiders[2].hasAbility("Friend Guard")).toEqual(false);
     // T12: Medicham doesn't benefit from Friend Guard, since it is the only one with it
     expect(result.turnResults[11].results[1].state.raiders[1].field.attackerSide.friendGuards).toEqual(0);
     expect(result.turnResults[11].results[1].desc[1].includes("Friend Guards")).toEqual(false);

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -701,6 +701,27 @@ describe('Specific Test Cases', () => {
     expect(result.turnResults[3].state.raiders[1].status).toEqual("");
     expect(result.turnResults[3].state.raiders[1].boosts.atk).toEqual(1);
   })
+  test('ability-nullification', async() => {
+    const hash = "#H4sIAAAAAAAAA91WUU/bMBD+K5GfQMq00rRj8EYLEkgUIdpp0qo8HMk18erame0UEOK/785JKGUbGpu2SVNSxz6f7+777nLpvViIQ5F9dkaLWHhxOJ/3YqFhhSKNeSpznuzFonZoz45ZCWyBPkxN5aXRjjX6sSisqSuSrswaz/TC0PTaODfplo3BzEpPOw4zo3OwdyeLBWbekcgapehRSu9a3ZLNgV/SmOOCT1UQxjyM+Kg2s7Io0HJ0coWblSslqnwMOkN1DCso8FHYLK/Af080Qws/EI9L0AW2pGjjkUPPLOYygKjMElcNmbXVLAm0BHxYIQQlV187L33NhxvuCDvHEYgPfvUdPaU70nfnuEbmBa6lkj6IPa6CMrlgdVyzURlG1WoXqPOGEIp5dldhmxjXZaVWXlZKBh289RYm7W4H2oNI01isxeG9oLp4HwvR3vMgOIiJ+iuQeTQie7QxzZDqgXEsQDlsR/FBX9c2R6JE10rF4hQcowg23pGNxyt96ITJ3rObtvZ65O6C3BxbKJjguThHWEQjBTmDG1mEpdRFNL2RAW2jFx1z8mk5K2tmJLqsdVYS68mQDLY2pt5YZvQErC+/1LDk/IZY9uP9Xrw/jIe9uN/jeUJhdoEexFQCE8p8VgIf30y3CLikLEWX5oap7iiw+W9QEIzMCbHMllHAzewvpVIEHiqKnTXnaVDcBNvnCM2Ny8BCDuLZaivknQsTHTX1tsu2pbe1i0ZoLdffTK6oLXSR9od9Cr0ZXwthBrXmbnCKquLcnYLmV3tcEhZef6SXjgt0FqBeGbPagGvzs8XeBmxC8GrmJYwvgftEVqNzDO/qFSq4xefYfiU5U2oJSIX2DbbzWocuNKnzN1P1NFsvAxr8L4DStn8MgihMk63ypbcqaeTDbZywLmhzQwod25kY56PQoSkkQt+j0y+f7U4P4sET/y2KpBP9Ydd7nW7SpI+b7y67/2nkY4VgqfVSEC562+Zfcgd/TRx9uv4RBY9Y/55rKj36vzDgbzd/dumXpOFDHi7eTePuTtOHh68Mz9ngHgkAAA==";
+    const result = await resultsFromHash(hash);
+    // T0: Skill Swap, Muk Recieves Pure Power
+    expect(result.turnResults[0].state.raiders[3].ability).toEqual("Pure Power");
+    expect(result.turnResults[1].state.raiders[3].hasAbility("Pure Power")).toEqual(true);
+    // T1: Muk's attack is boosted by Pure Power
+    expect(result.turnResults[1].results[1].desc[0].includes("Pure Power")).toEqual(true);
+    // T2: Abilities Nullified
+    expect(result.turnResults[2].state.raiders[3].ability).toEqual("Pure Power");
+    expect(result.turnResults[2].state.raiders[3].abilityNullified).toEqual(1);
+    expect(result.turnResults[2].state.raiders[3].hasAbility("Pure Power")).toEqual(false);
+    // T3: Muk's attack is NOT boosted by Pure Power, nullification ends after turn
+    expect(result.turnResults[3].results[1].desc[0].includes("Pure Power")).toEqual(false);
+    expect(result.turnResults[3].results[1].state.raiders[3].abilityNullified).toEqual(1);
+    expect(result.turnResults[3].results[1].state.raiders[3].hasAbility("Pure Power")).toEqual(false);
+    expect(result.turnResults[3].state.raiders[3].abilityNullified).toEqual(undefined);
+    expect(result.turnResults[3].state.raiders[3].hasAbility("Pure Power")).toEqual(true);
+    // T4: Muk's attack is boosted by Pure Power
+    expect(result.turnResults[4].results[1].desc[0].includes("Pure Power")).toEqual(true);
+  })
 })
 
 

--- a/src/calc/pokemon.ts
+++ b/src/calc/pokemon.ts
@@ -170,7 +170,7 @@ export class Pokemon implements State.Pokemon {
   }
 
   hasAbility(...abilities: string[]) {
-    return this.abilityNullified !== 0 && !!(this.ability && abilities.includes(this.ability));
+    return (this.abilityNullified || 0) === 0 && !!(this.ability && abilities.includes(this.ability));
   }
 
   hasItem(...items: string[]) {

--- a/src/calc/pokemon.ts
+++ b/src/calc/pokemon.ts
@@ -58,6 +58,7 @@ export class Pokemon implements State.Pokemon {
 
   moves: I.MoveName[];
 
+  abilityNullified: number | undefined;
   permanentAtkCheers: number;
   permanentDefCheers: number;
 
@@ -145,6 +146,7 @@ export class Pokemon implements State.Pokemon {
     this.changedTypes = options.changedTypes;
     this.lastMoveFailed = !!options.lastMoveFailed;
     this.moves = options.moves || [];
+    this.abilityNullified = options.abilityNullified;
     this.permanentAtkCheers = options.permanentAtkCheers || 0;
     this.permanentDefCheers = options.permanentDefCheers || 0;
   }
@@ -168,7 +170,7 @@ export class Pokemon implements State.Pokemon {
   }
 
   hasAbility(...abilities: string[]) {
-    return !!(this.ability && abilities.includes(this.ability));
+    return this.abilityNullified !== 0 && !!(this.ability && abilities.includes(this.ability));
   }
 
   hasItem(...items: string[]) {
@@ -235,6 +237,7 @@ export class Pokemon implements State.Pokemon {
       changedTypes: this.changedTypes,
       lastMoveFailed: this.lastMoveFailed,
       moves: this.moves.slice(),
+      abilityNullified: this.abilityNullified,
       permanentAtkCheers: this.permanentAtkCheers,
       permanentDefCheers: this.permanentDefCheers,
       overrides: this.species,

--- a/src/calc/state.ts
+++ b/src/calc/state.ts
@@ -50,6 +50,7 @@ export namespace State {
     changedTypes?: [I.TypeName] | [I.TypeName, I.TypeName] | [I.TypeName, I.TypeName, I.TypeName];
     lastMoveFailed?: boolean;
     moves?: I.MoveName[];
+    abilityNullified?: number;
     permanentAtkCheers?: number;
     permanentDefCheers?: number,
     overrides?: Partial<I.Specie>;

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -1155,8 +1155,8 @@ export class RaidMove {
                     //     this._raidState.changeAbility(i, "(No Ability)");
                     // }
                     if (!pokemon.hasItem("Ability Shield") && !pokemon.hasAbility("Disguise", "Ice Face")) {
+                        this._raidState.removeAbilityFieldEffect(i, pokemon.ability);
                         pokemon.abilityNullified = 1;
-                        pokemon.nullifyAbilityOn = pokemon.abilityOn;
                         pokemon.abilityOn = false; // boosts from abilities (i.e. Flash Fire) are removed temporarily without Ability Shield
                     }
                     pokemon.field.attackerSide.isAtkCheered = 0; // clear active cheers
@@ -1229,7 +1229,8 @@ export class RaidMove {
                     !persistentAbilities["unsuppressable"].includes(target_ability) &&
                     !target.hasItem("Ability Shield")
                 ) {
-                    this._raidState.changeAbility(this._targetID, "(No Ability)");
+                    this._raidState.removeAbilityFieldEffect(target.id, target.ability);
+                    target.abilityNullified = -1;
                 } else {
                     this._desc[this._targetID] = this._user.name + " " + this.move.name + " vs. " + target.name + " — " + this.move.name + " failed!";
                 }

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -1769,10 +1769,19 @@ export class RaidMove {
             if (fainted[i]) { continue; }
             if (initialAbilities[i] !== finalAbilities[i])  {
                 if (finalAbilities[i] === "(No Ability)" || finalAbilities[i] === undefined) {
-                    this._flags[i].push(initialAbilities[i] + " nullified")
+                    this._flags[i].push(initialAbilities[i] + " removed")
                 } else {
                     this._flags[i].push("ability changed to " + finalAbilities[i])
                 }
+            }
+        }
+        // check for Ability Nullification
+        const initialNullified = this.raidState.raiders.map(p => p.abilityNullified)
+        const finalNullified = this._raidState.raiders.map(p => p.abilityNullified)
+        for (let i=0; i<5; i++) {
+            if (fainted[i] || (finalAbilities[i] === "(No Ability)")) { continue; }
+            if (!initialNullified[i] && !!finalNullified[i])  {
+                this._flags[i].push(finalAbilities[i] + " nullified")
             }
         }
         // check for ability triggers

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -1359,7 +1359,7 @@ export class RaidState implements State.RaidState{
         pokemon.isTaunt = 0;
         pokemon.isCharging = false;
         pokemon.isRecharging = false;
-        pokemon.abilityNullified = 0;
+        pokemon.abilityNullified = undefined;
         pokemon.moveRepeated = undefined;
         pokemon.isChoiceLocked = false;
         pokemon.isEncore = 0;

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -54,7 +54,7 @@ export class RaidState implements State.RaidState{
         let unnerve = false;
         let fainted = pokemon.originalCurHP <= 0;
         for (let i of opponents) {
-            if (this.getPokemon(i).ability === "Unnerve") { unnerve = true; break; }
+            if (this.getPokemon(i).hasAbility("Unnerve")) { unnerve = true; break; }
         }
         if (nHits > 0 && damage > 0) { // checks that the pokemon was attacked, and that the damage was not due to recoil or chip damage
             if (damage > 0) {
@@ -62,7 +62,7 @@ export class RaidState implements State.RaidState{
             }
             // Item consumption / Ability Activation triggered by damage
             // Ice Face
-            if (pokemon.ability === "Ice Face" && !pokemon.abilityOn && pokemon.name.includes("Eiscue") && moveCategory === "Physical") {
+            if (pokemon.hasAbility("Ice Face") && !pokemon.abilityOn && pokemon.name.includes("Eiscue") && moveCategory === "Physical") {
                 pokemon.changeForm("Eiscue-Noice" as SpeciesName);
                 pokemon.abilityOn = true;
                 pokemon.originalCurHP = originalHP; // no damage is done
@@ -71,7 +71,7 @@ export class RaidState implements State.RaidState{
                 return; // don't trigger item use
             }
             // Disguise
-            if (pokemon.ability === "Disguise" && !pokemon.abilityOn && pokemon.name.includes("Mimikyu")) {
+            if (pokemon.hasAbility("Disguise") && !pokemon.abilityOn && pokemon.name.includes("Mimikyu")) {
                 pokemon.abilityOn = true;
                 pokemon.originalCurHP = originalHP; // negate damage from attack
                 pokemon.cumDamageRolls = originalDamageRolls;
@@ -82,7 +82,7 @@ export class RaidState implements State.RaidState{
                 return; // don't trigger item use (except for Air Balloon)
             }
             // Focus Sash
-            if (pokemon.item === "Focus Sash" || pokemon.ability === "Sturdy") {
+            if (pokemon.item === "Focus Sash" || pokemon.hasAbility("Sturdy")) {
                 if (pokemon.originalCurHP <= 0 && originalHP === maxHP) { 
                     pokemon.originalCurHP = 1;
                     pokemon.cumDamageRolls = originalDamageRolls;
@@ -174,74 +174,74 @@ export class RaidState implements State.RaidState{
  
             /// abilities triggered by damage even if the target faints
             // Seed Sower
-            if (pokemon.ability === "Seed Sower") {
+            if (pokemon.hasAbility("Seed Sower")) {
                 this.applyTerrain("Grassy");
             }
             /// the rest can be skipped if the target faints
             if (fainted) { this.faint(id); return; }
             /// abilities triggered by damage if the target survives
             // Anger Point
-            if (isCrit && pokemon.ability === "Anger Point") { 
+            if (isCrit && pokemon.hasAbility("Anger Point")) { 
                 const boost = {atk: 12};
                 this.applyStatChange(id, boost, true, id);
             };
             // Steam Engine
-            if ((moveType === "Fire" || moveType === "Water" ) && pokemon.ability === "Steam Engine") {
+            if ((moveType === "Fire" || moveType === "Water" ) && pokemon.hasAbility("Steam Engine")) {
                 const boost = {spe: 6};
                 this.applyStatChange(id, boost, true, id);
             }
             // Water Compaction
-            if (moveType === "Water" && pokemon.ability === "Water Compaction") {
+            if (moveType === "Water" && pokemon.hasAbility("Water Compaction")) {
                 const boost = {def: 2 * nHits};
                 this.applyStatChange(id, boost, true, id);
             }
             // Justified
-            if (moveType === "Dark" && pokemon.ability === "Justified") {
+            if (moveType === "Dark" && pokemon.hasAbility("Justified")) {
                 const boost = {atk: nHits};
                 this.applyStatChange(id, boost, true, id);
             }
             // Thermal Exchange
-            if (moveType === "Fire" && pokemon.ability === "Thermal Exchange") {
+            if (moveType === "Fire" && pokemon.hasAbility("Thermal Exchange")) {
                 const boost = {atk: nHits};
                 this.applyStatChange(id, boost, true, id);
             } 
             // Weak Armor
-            if (moveCategory === "Physical" && pokemon.ability === "Weak Armor") {
+            if (moveCategory === "Physical" && pokemon.hasAbility("Weak Armor")) {
                 const boost = {def: -1 * nHits, spe: 2 * nHits};
                 this.applyStatChange(id, boost, true, id);
             }
             // Stamina
-            if (pokemon.ability === "Stamina") {
+            if (pokemon.hasAbility("Stamina")) {
                 const boost = {def: nHits};
                 this.applyStatChange(id, boost, true, id);
             }
             // Anger Shell
-            if (pokemon.ability === "Anger Shell" && !isSheerForceBoosted && originalHP > maxHP/2 && pokemon.originalCurHP <= maxHP/2) {
+            if (pokemon.hasAbility("Anger Shell") && !isSheerForceBoosted && originalHP > maxHP/2 && pokemon.originalCurHP <= maxHP/2) {
                 const boost = {atk: 1, spa: 1, spe: 1};
                 this.applyStatChange(id, boost, true, id);
             }
             // Berserk
-            if (pokemon.ability === "Berserk" && !isSheerForceBoosted && originalHP > maxHP/2 && pokemon.originalCurHP <= maxHP/2) {
+            if (pokemon.hasAbility("Berserk") && !isSheerForceBoosted && originalHP > maxHP/2 && pokemon.originalCurHP <= maxHP/2) {
                 const boost = {spa: 1};
                 this.applyStatChange(id, boost, true, id);
             }
             // Electromorphosis
-            if (pokemon.ability ===  "Electromorphosis") {
+            if (pokemon.hasAbility( "Electromorphosis")) {
                 pokemon.field.attackerSide.isCharged = true;
             }
             // Rattled
-            if (pokemon.ability === "Rattled" && ["Dark", "Ghost", "Bug"].includes(moveType || "")) {
+            if (pokemon.hasAbility("Rattled") && ["Dark", "Ghost", "Bug"].includes(moveType || "")) {
                 const boost = {spe: 1};
                 this.applyStatChange(id, boost, true, id);
             }
             // Wind Power
-            if (pokemon.ability === "Wind Power" && isWind){
+            if (pokemon.hasAbility("Wind Power") && isWind){
                 pokemon.field.attackerSide.isCharged = true;
             }
         }
         /// Abilities activated by HP %
         // Shields Down
-        if (pokemon.ability === "Shields Down" && pokemon.name.includes("Minior")) {
+        if (pokemon.hasAbility("Shields Down") && pokemon.name.includes("Minior")) {
             if (pokemon.originalCurHP < maxHP/2 && pokemon.species.name === "Minior-Meteor") {
                 pokemon.changeForm("Minior" as SpeciesName);
             } else if (pokemon.originalCurHP >= maxHP/2 && pokemon.species.name === "Minior") {
@@ -487,7 +487,7 @@ export class RaidState implements State.RaidState{
         const fromEnemy = (id === 0) ? (sourceID !== 0) : (sourceID === 0)
         const boostCoef = pokemon.boostCoefficient;
         // Mirror Armor
-        if (!fromSelf && !fromMirrorArmor && !ignoreAbility && pokemon.ability === "Mirror Armor") {
+        if (!fromSelf && !fromMirrorArmor && !ignoreAbility && pokemon.hasAbility("Mirror Armor")) {
             for (const stat in boosts) {
                 const mirroredBoosts: Partial<StatsTable> = {};
                 const statId = stat as StatIDExceptHP;
@@ -529,10 +529,10 @@ export class RaidState implements State.RaidState{
         // Apply stat changes
         const diff = pokemon.applyStatChange(boosts, ignoreAbility);
         // Defiant and Competitive
-        if (!fromSelf && fromEnemy && !ignoreAbility && (pokemon.ability === "Defiant" || pokemon.ability === "Competitive")) {
+        if (!fromSelf && fromEnemy && !ignoreAbility && (pokemon.hasAbility("Defiant", "Competitive"))) {
             const numNegativeBoosts = Object.values(diff).reduce((p, c) => p + (c < 0 ? 1 : 0), 0);
             if (numNegativeBoosts > 0) {
-                const boost = pokemon.ability === "Defiant" ? {atk: 2 * numNegativeBoosts} : {spa: 2 * numNegativeBoosts};
+                const boost = pokemon.hasAbility("Defiant") ? {atk: 2 * numNegativeBoosts} : {spa: 2 * numNegativeBoosts};
                 this.applyStatChange(id, boost, true, id);
             }
         }
@@ -542,7 +542,7 @@ export class RaidState implements State.RaidState{
             for (const opponentId of opponentIds) {
                 const opponent = this.getPokemon(opponentId);
                 const mirrorHerb = opponent.item === "Mirror Herb";
-                const opportunist = opponent.ability === "Opportunist";
+                const opportunist = opponent.hasAbility("Opportunist");
                 if (mirrorHerb || opportunist)  {
                     const both = mirrorHerb && opportunist;
                     const positiveDiff = {...diff};
@@ -579,13 +579,13 @@ export class RaidState implements State.RaidState{
         const pokemon = this.getPokemon(id);
         const field = pokemon.field;
         const sourceAbility = this.getPokemon(source).ability;
-        const attackerIgnoresAbility = ["Mold Breaker", "Teravolt", "Turboblaze"].includes(sourceAbility || "") && !pokemon.hasItem("Ability Shield");
+        const attackerIgnoresAbility = !this.getPokemon(source).abilityNullified && !this.getPokemon(source).abilityNullified && ["Mold Breaker", "Teravolt", "Turboblaze"].includes(sourceAbility || "") && !pokemon.hasItem("Ability Shield");
         const selfInflicted = id === source;
 
         if (hasNoStatus(pokemon)) {
             let success = true;
             // Secondary effect blockers
-            if (!selfInflicted && isSecondaryEffect && (pokemon.item === "Covert Cloak" || pokemon.ability === "Shield Dust")) { success = false; }
+            if (!selfInflicted && isSecondaryEffect && (pokemon.item === "Covert Cloak" || pokemon.hasAbility("Shield Dust"))) { success = false; }
             // Purifying Salt blocks all non-volatile statuses
             if (pokemon.hasAbility("Purifying Salt")) { success = false; }
             // field-based immunities
@@ -597,14 +597,14 @@ export class RaidState implements State.RaidState{
             if (status === "slp" && (field.hasTerrain("Electric") && pokemonIsGrounded(pokemon, field))) { success = false; }
             // type-based and ability-based immunities
             if (status === "brn" && (pokemon.hasType("Fire") || pokemon.hasAbility("Water Veil") || pokemon.hasAbility("Thermal Exchange") || pokemon.hasAbility("Water Bubble"))) { success = false; }
-            if (status === "frz" && (pokemon.field.hasWeather("Sun") || pokemon.hasType("Ice") || (!attackerIgnoresAbility && pokemon.ability === "Magma Armor"))) { success = false; }
-            if ((status === "psn" || status === "tox") && ((!attackerIgnoresAbility && pokemon.ability === "Immunity") || (sourceAbility !== "Corrosion" && pokemon.hasType("Poison", "Steel")))) { success = false; }
-            if ((status === "par" && (pokemon.hasType("Electric") || (!attackerIgnoresAbility && pokemon.ability === "Limber")))) { success = false; }
+            if (status === "frz" && (pokemon.field.hasWeather("Sun") || pokemon.hasType("Ice") || (!attackerIgnoresAbility && pokemon.hasAbility("Magma Armor")))) { success = false; }
+            if ((status === "psn" || status === "tox") && ((!attackerIgnoresAbility && pokemon.hasAbility("Immunity")) || (sourceAbility !== "Corrosion" && pokemon.hasType("Poison", "Steel")))) { success = false; }
+            if ((status === "par" && (pokemon.hasType("Electric") || (!attackerIgnoresAbility && pokemon.hasAbility("Limber"))))) { success = false; }
             if (status === "slp" && !attackerIgnoresAbility && (
                 ["Insomnia", "Vital Spirit"].includes(pokemon.ability as string) || 
                 (id === 0 ? [0] : [1,2,3,4]).map(i => this.getPokemon(i)).some(poke => poke.hasAbility("Sweet Veil"))
             )) { success = false; }
-            if (pokemon.field.hasWeather("Sun") && !attackerIgnoresAbility && pokemon.ability === "Leaf Guard") { success = false; }
+            if (pokemon.field.hasWeather("Sun") && !attackerIgnoresAbility && pokemon.hasAbility("Leaf Guard")) { success = false; }
             
             if (success) {
                 pokemon.status = status;
@@ -644,10 +644,10 @@ export class RaidState implements State.RaidState{
             if (field.attackerSide.isAromaVeil && ["confusion", "taunt", "encore", "disable", "infatuation", "yawn"].includes(ailment)) {
                 success = false;
             // Own Tempo
-            } else if (!attackerIgnoresAbility && pokemon.ability === "Own Tempo" && ailment === "confusion") {
+            } else if (!attackerIgnoresAbility && pokemon.hasAbility("Own Tempo") && ailment === "confusion") {
                 success = false;
             // Oblivious
-            } else if (!attackerIgnoresAbility && pokemon.ability === "Oblivious" && (ailment === "taunt" || ailment === "infatuation")) {
+            } else if (!attackerIgnoresAbility && pokemon.hasAbility("Oblivious") && (ailment === "taunt" || ailment === "infatuation")) {
                 success = false;
             // yawn immunity
             } else if (ailment === "yawn" && !attackerIgnoresAbility && (pokemon.hasAbility("Vital Spirit", "Insomnia") || (pokemon.hasAbility("Leaf Guard") && pokemon.field.hasWeather("Sun")))) {
@@ -688,7 +688,7 @@ export class RaidState implements State.RaidState{
         if (id > 0) {
             const symbiosisIds: number[] = []
             for (let sid=1; sid<5; sid++) {
-                if (sid !== id && this.getPokemon(sid).ability === "Symbiosis" && this.getPokemon(sid).item !== undefined) {
+                if (sid !== id && this.getPokemon(sid).hasAbility("Symbiosis") && this.getPokemon(sid).item !== undefined) {
                     symbiosisIds.push(sid);
                 }
             }
@@ -724,7 +724,7 @@ export class RaidState implements State.RaidState{
         pokemon.item = item;
         /// Items that activate upon reciept or switch in
         // Booster Energy
-        if (pokemon.item === "Booster Energy" && (pokemon.ability === "Protosynthesis" || pokemon.ability === "Quark Drive") && !pokemon.abilityOn) {
+        if (pokemon.item === "Booster Energy" && pokemon.hasAbility("Protosynthesis", "Quark Drive") && !pokemon.abilityOn) {
             pokemon.abilityOn = true;
             const statId = getQPBoostedStat(pokemon, gen) as StatIDExceptHP;
             pokemon.boostedStat = statId;
@@ -750,7 +750,7 @@ export class RaidState implements State.RaidState{
                 pokemon.field.terrainTurnsRemaining = turns;
             }
             // Quark Drive
-            if (pokemon.ability === "Quark Drive" && !pokemon.usedBoosterEnergy) {
+            if (pokemon.hasAbility("Quark Drive") && !pokemon.usedBoosterEnergy) {
                 if (pokemon.field.hasTerrain("Electric") && !pokemon.abilityOn) {
                     pokemon.abilityOn = true;
                     const statId = getQPBoostedStat(pokemon, gen) as StatIDExceptHP;
@@ -782,7 +782,7 @@ export class RaidState implements State.RaidState{
                 pokemon.field.weatherTurnsRemaining = turns;
             }
             // Protosynthesis
-            if (pokemon.ability === "Protosynthesis" && !pokemon.usedBoosterEnergy) {
+            if (pokemon.hasAbility("Protosynthesis") && !pokemon.usedBoosterEnergy) {
                 if (pokemon.field.hasWeather("Sun") && !pokemon.abilityOn) {
                     pokemon.abilityOn = true;
                     const statId = getQPBoostedStat(pokemon, gen) as StatIDExceptHP;
@@ -794,7 +794,7 @@ export class RaidState implements State.RaidState{
                 } 
             }
             // Ice Face
-            if ((weather === "Snow" || weather === "Hail") && pokemon.ability === "Ice Face" && pokemon.name.includes("Eiscue") && pokemon.abilityOn) {
+            if ((weather === "Snow" || weather === "Hail") && pokemon.hasAbility("Ice Face") && pokemon.name.includes("Eiscue") && pokemon.abilityOn) {
                 pokemon.changeForm("Eiscue" as SpeciesName);
                 pokemon.abilityOn = false;
             }
@@ -821,15 +821,28 @@ export class RaidState implements State.RaidState{
         const oldAbility = pokemon.ability;
         pokemon.ability = ability as AbilityName;
         pokemon.abilityOn = false;
+        pokemon.abilityNullified = undefined;
+        pokemon.nullifyAbilityOn = undefined;
         // lost field effects
         this.removeAbilityFieldEffect(id, oldAbility);
         // gained field effects
         this.addAbilityFieldEffect(id, ability, true, restore);
     }
 
+    public nullifyAbility(id: number)  {
+        const pokemon = this.getPokemon(id);
+        if (pokemon.hasItem("Ability Shield")) { return; }
+        const oldAbility = pokemon.ability;
+        // pokemon.ability = undefined;
+        pokemon.abilityOn = false;
+        // lost field effects
+        this.removeAbilityFieldEffect(id, oldAbility);
+    }
+
     public addAbilityFieldEffect(id: number, ability: AbilityName | "(No Ability)" | undefined, switchInOrChange: boolean = false, restore: boolean = false): string[][] {
         const pokemon = this.getPokemon(id);
         const flags: string[][] = [[],[],[],[],[]];
+        if (pokemon.abilityNullified) { return flags; }
         /// Imposter
         if (ability === "Imposter") {
             const target = id === 0 ? this.raiders[1] : this.raiders[0];
@@ -847,7 +860,7 @@ export class RaidState implements State.RaidState{
             const opponentIds = id === 0 ? [1,2,3,4] : [0];
             for (let oid of opponentIds) { // Trace might be random for bosses, but we'll check abilities in order
                 const copiedAbility = this.raiders[oid].ability;
-                if (copiedAbility && !persistentAbilities["uncopyable"].includes(copiedAbility)) {
+                if (copiedAbility && !this.raiders[oid].abilityNullified && !persistentAbilities["uncopyable"].includes(copiedAbility)) {
                     pokemon.ability = copiedAbility;
                     ability = copiedAbility;
                     flags[id].push("Trace copies " + copiedAbility);
@@ -978,7 +991,7 @@ export class RaidState implements State.RaidState{
                     const origAtk = opponent.boosts.atk ||  0;
                     this.applyStatChange(opponent.id, {atk: 1}, true, id);
                     flags[opponent.id].push("Atk: " + origAtk + " → " + opponent.boosts.atk + " (Guard Dog)");
-                } else if (!["Oblivious", "Own Tempo", "Inner Focus", "Scrappy"].includes(opponent.ability || "")) {
+                } else if (opponent.abilityNullified || !["Oblivious", "Own Tempo", "Inner Focus", "Scrappy"].includes(opponent.ability || "")) {
                     const origAtk = opponent.boosts.atk ||  0;
                     const origSourceAtk = pokemon.boosts.atk || 0;
                     this.applyStatChange(opponent.id, {atk: -1}, true, id);
@@ -1099,8 +1112,9 @@ export class RaidState implements State.RaidState{
     }
 
     public removeAbilityFieldEffect(id: number, ability: AbilityName | "(No Ability)" | undefined) {
+        const poke = this.getPokemon(id);
         // on/off field-based abilties
-        if (ability === undefined || ability === "(No Ability)") { return; }
+        if (ability === undefined || ability === "(No Ability)" || poke.abilityNullified) { return; }
         if (ability === "Neutralizing Gas") {
             if (
                 !this.raiders
@@ -1111,7 +1125,6 @@ export class RaidState implements State.RaidState{
                     if (i !== id ) {
                         const target = this.raiders[i];
                         if ((target.abilityNullified || 0) < 0 && target.originalAbility !== "(No Ability)") {
-                            this.changeAbility(i, target.originalAbility, true);
                             target.abilityNullified = undefined;
                             target.abilityOn = target.nullifyAbilityOn;
                             target.nullifyAbilityOn = undefined;

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -825,10 +825,11 @@ export class RaidState implements State.RaidState{
         const oldAbility = pokemon.ability;
         pokemon.ability = ability as AbilityName;
         pokemon.abilityOn = false;
-        pokemon.abilityNullified = undefined;
-        pokemon.nullifyAbilityOn = undefined;
         // lost field effects
-        this.removeAbilityFieldEffect(id, oldAbility);
+        if (!pokemon.abilityNullified) {
+            this.removeAbilityFieldEffect(id, oldAbility);
+        }
+        pokemon.abilityNullified = undefined;
         // gained field effects
         this.addAbilityFieldEffect(id, ability, true, restore);
     }
@@ -1025,9 +1026,8 @@ export class RaidState implements State.RaidState{
                     ) { 
                         continue; 
                     }
-                    this.changeAbility(i, "(No Ability)");
+                    this.removeAbilityFieldEffect(i, target.ability)
                     target.abilityNullified = -1;
-                    target.nullifyAbilityOn = target.abilityOn;
                     flags[i].push("Ability suppressed by Neutralizing Gas");
                 }
             }
@@ -1130,8 +1130,7 @@ export class RaidState implements State.RaidState{
                         const target = this.raiders[i];
                         if ((target.abilityNullified || 0) < 0 && target.originalAbility !== "(No Ability)") {
                             target.abilityNullified = undefined;
-                            target.abilityOn = target.nullifyAbilityOn;
-                            target.nullifyAbilityOn = undefined;
+                            this.addAbilityFieldEffect(i, target.ability, false, true);
                         }
                     }
                 }
@@ -1397,10 +1396,7 @@ export class RaidState implements State.RaidState{
         // check Neutralizing Gas
         const neutralizingGas = this.raiders.reduce((p, c) => p || c.ability === "Neutralizing Gas", false);
         if (neutralizingGas && !pokemon.hasItem("Ability Shield") && !persistentAbilities.unsuppressable.includes(ability || "") && ability !== "Neutralizing Gas") { 
-            ability = "(No Ability)" as AbilityName;
-            this.changeAbility(id, ability);
             pokemon.abilityNullified = -1;
-            pokemon.nullifyAbilityOn = pokemon.abilityOn;
         }
         // add abilites that Take Effect upon switch-in
         const flags = this.addAbilityFieldEffect(id, ability, true);

--- a/src/raidcalc/RaidTurn.ts
+++ b/src/raidcalc/RaidTurn.ts
@@ -508,25 +508,26 @@ export class RaidTurn {
 
     private modifyMovePriorityByAbility(moveData: MoveData, raider: Raider) {
         const ability = raider.ability;
-
-        switch (ability) {
-            case "Prankster": // do dark-type prankster failure elsewhere
-                if (moveData.priority !== undefined && pranksterMoves.includes(moveData.name)) {
-                    moveData.priority += 1;
-                }
-                break;
-            case "Gale Wings":
-                if (moveData.priority !== undefined && raider.curHP() === raider.maxHP() && moveData.type === "Flying") {
-                    moveData.priority += 1;
-                }
-                break;
-            case "Triage": // Comfey's signature ability
-                if (moveData.priority !== undefined && triageMoves.includes(moveData.name)) {
-                    moveData.priority += 3;
-                }
-                break;
-            default:
-                break;
+        if (!raider.abilityNullified) {
+            switch (ability) {
+                case "Prankster": // do dark-type prankster failure elsewhere
+                    if (moveData.priority !== undefined && pranksterMoves.includes(moveData.name)) {
+                        moveData.priority += 1;
+                    }
+                    break;
+                case "Gale Wings":
+                    if (moveData.priority !== undefined && raider.curHP() === raider.maxHP() && moveData.type === "Flying") {
+                        moveData.priority += 1;
+                    }
+                    break;
+                case "Triage": // Comfey's signature ability
+                    if (moveData.priority !== undefined && triageMoves.includes(moveData.name)) {
+                        moveData.priority += 3;
+                    }
+                    break;
+                default:
+                    break;
+            }
         }
     }
 
@@ -705,10 +706,8 @@ export class RaidTurn {
             let abilityRestored = false;
             let abilityReactivated = false;
             if (pokemon.abilityNullified === 0) { // restore ability after a full turn
-                if (pokemon.ability === "(No Ability)") { // if you overwrite the ability in the meantime, what happens?
-                    this._raidState.changeAbility(this.raiderID, pokemon.originalAbility, true);
-                    abilityRestored = pokemon.ability !== "(No Ability)";
-                }
+                this._raidState.changeAbility(this.raiderID, pokemon.originalAbility, true);
+                abilityRestored = pokemon.ability !== "(No Ability)";
                 if (pokemon.nullifyAbilityOn) {
                     abilityReactivated = pokemon.abilityOn !== true;
                     pokemon.nullifyAbilityOn = undefined;

--- a/src/raidcalc/RaidTurn.ts
+++ b/src/raidcalc/RaidTurn.ts
@@ -708,13 +708,10 @@ export class RaidTurn {
             let abilityRestored = false;
             let abilityReactivated = false;
             if (pokemon.abilityNullified === 0) { // restore ability after a full turn
-                this._raidState.changeAbility(this.raiderID, pokemon.originalAbility, true);
+                pokemon.abilityNullified = undefined;
+                this._raidState.addAbilityFieldEffect(pokemon.id, pokemon.ability, false, true);
                 abilityRestored = pokemon.ability !== "(No Ability)";
-                if (pokemon.nullifyAbilityOn) {
-                    abilityReactivated = pokemon.abilityOn !== true;
-                    pokemon.nullifyAbilityOn = undefined;
-                    pokemon.abilityOn = true;
-                }
+                abilityReactivated = !!pokemon.abilityOn;
                 // Not sure if we need to do anything special here to trigger ability reactivation
                 if (abilityRestored && abilityReactivated) {
                     this._endFlags.push(pokemon.role + " — " + pokemon.originalAbility + " restored and reactivated");

--- a/src/raidcalc/RaidTurn.ts
+++ b/src/raidcalc/RaidTurn.ts
@@ -713,12 +713,14 @@ export class RaidTurn {
                 abilityRestored = pokemon.ability !== "(No Ability)";
                 abilityReactivated = !!pokemon.abilityOn;
                 // Not sure if we need to do anything special here to trigger ability reactivation
-                if (abilityRestored && abilityReactivated) {
-                    this._endFlags.push(pokemon.role + " — " + pokemon.originalAbility + " restored and reactivated");
-                } else if (abilityRestored) {
-                    this._endFlags.push(pokemon.role + " — " + pokemon.originalAbility + " restored");
-                } else if (abilityReactivated) {
-                    this._endFlags.push(pokemon.role + " — " + pokemon.originalAbility + " reactivated");
+                if (pokemon.ability && (pokemon.ability !== "(No Ability)")) {
+                    if (abilityRestored && abilityReactivated) {
+                        this._endFlags.push(pokemon.role + " — " + pokemon.ability + " restored and reactivated");
+                    } else if (abilityRestored) {
+                        this._endFlags.push(pokemon.role + " — " + pokemon.ability + " restored");
+                    } else if (abilityReactivated) {
+                        this._endFlags.push(pokemon.role + " — " + pokemon.ability + " reactivated");
+                    }
                 }
             }
         }

--- a/src/raidcalc/Raider.ts
+++ b/src/raidcalc/Raider.ts
@@ -47,7 +47,6 @@ export class Raider extends Pokemon implements State.Raider {
     shieldBreakStun?: boolean[];
     substitute?: number;
 
-    abilityNullified?: number;  // indicates when the boss has nullified the ability of the Raider
     nullifyAbilityOn?: boolean; // indicates that the ability was active before nullification
     originalAbility: AbilityName | "(No Ability)";   // stores ability when nullified
 
@@ -104,7 +103,6 @@ export class Raider extends Pokemon implements State.Raider {
         shieldBroken: boolean | undefined = undefined, 
         shieldBreakStun: boolean[] | undefined = undefined,
         substitute: number | undefined = undefined,
-        abilityNullified: number | undefined = 0, 
         nullifyAbilityOn: boolean | undefined = undefined,
         originalAbility: AbilityName | "(No Ability)" | undefined = undefined,
         syrupBombDrops: number | undefined = 0,
@@ -155,7 +153,6 @@ export class Raider extends Pokemon implements State.Raider {
         this.shieldBroken = shieldBroken;
         this.shieldBreakStun = shieldBreakStun;
         this.substitute = substitute;
-        this.abilityNullified = abilityNullified;
         this.nullifyAbilityOn = nullifyAbilityOn;
         this.originalAbility = originalAbility || pokemon.ability || "(No Ability)";
         this.syrupBombDrops = syrupBombDrops;
@@ -218,6 +215,7 @@ export class Raider extends Pokemon implements State.Raider {
                 changedTypes: this.changedTypes ? [...this.changedTypes] : undefined,
                 lastMoveFailed: this.lastMoveFailed,
                 moves: this.moves.slice(),
+                abilityNullified: this.abilityNullified,
                 permanentAtkCheers: this.permanentAtkCheers,
                 permanentDefCheers: this.permanentDefCheers,
                 overrides: this.species,
@@ -249,7 +247,6 @@ export class Raider extends Pokemon implements State.Raider {
             this.shieldBroken,
             this.shieldBreakStun,
             this.substitute,
-            this.abilityNullified,
             this.nullifyAbilityOn,
             this.originalAbility,
             this.syrupBombDrops,
@@ -270,8 +267,8 @@ export class Raider extends Pokemon implements State.Raider {
     }
 
     public get boostCoefficient(): number {
-        const hasSimple = this.ability === "Simple";
-        const hasContrary = this.ability === "Contrary";
+        const hasSimple = this.hasAbility("Simple");
+        const hasContrary = this.hasAbility("Contrary");
         return hasSimple ? 2 : hasContrary ? -1 : 1;
     }
 
@@ -321,7 +318,7 @@ export class Raider extends Pokemon implements State.Raider {
 
     public loseItem() {
         // Unburden
-        if (this.ability === "Unburden" && this.item !== undefined) {
+        if (this.hasAbility("Unburden") && this.item !== undefined) {
             this.abilityOn = true;
         }
         if (this.hasItem("Choice Band", "Choice Specs", "Choice Scarf")) {

--- a/src/raidcalc/Raider.ts
+++ b/src/raidcalc/Raider.ts
@@ -47,7 +47,6 @@ export class Raider extends Pokemon implements State.Raider {
     shieldBreakStun?: boolean[];
     substitute?: number;
 
-    nullifyAbilityOn?: boolean; // indicates that the ability was active before nullification
     originalAbility: AbilityName | "(No Ability)";   // stores ability when nullified
 
     syrupBombDrops?: number;  // stores the number of speed drops left to be applied from Syrup Bomb
@@ -103,7 +102,6 @@ export class Raider extends Pokemon implements State.Raider {
         shieldBroken: boolean | undefined = undefined, 
         shieldBreakStun: boolean[] | undefined = undefined,
         substitute: number | undefined = undefined,
-        nullifyAbilityOn: boolean | undefined = undefined,
         originalAbility: AbilityName | "(No Ability)" | undefined = undefined,
         syrupBombDrops: number | undefined = 0,
         syrupBombSource: number | undefined = undefined,
@@ -153,7 +151,6 @@ export class Raider extends Pokemon implements State.Raider {
         this.shieldBroken = shieldBroken;
         this.shieldBreakStun = shieldBreakStun;
         this.substitute = substitute;
-        this.nullifyAbilityOn = nullifyAbilityOn;
         this.originalAbility = originalAbility || pokemon.ability || "(No Ability)";
         this.syrupBombDrops = syrupBombDrops;
         this.syrupBombSource = syrupBombSource;
@@ -247,7 +244,6 @@ export class Raider extends Pokemon implements State.Raider {
             this.shieldBroken,
             this.shieldBreakStun,
             this.substitute,
-            this.nullifyAbilityOn,
             this.originalAbility,
             this.syrupBombDrops,
             this.syrupBombSource,

--- a/src/raidcalc/interface.ts
+++ b/src/raidcalc/interface.ts
@@ -141,8 +141,6 @@ export interface Raider extends Pokemon {
     shieldBroken?: boolean;
     shieldBreakStun?: boolean[];
     substitute?: number; // store substitute's HP
-    abilityNullified?: number;  // indicates when the boss has nullified the ability of the Raider
-    nullifyAbilityOn?: boolean; // indicates that the ability was active before nullification
     originalAbility?: AbilityName | "(No Ability)"; // stores ability when nullified
     syrupBombDrops?: number;
     syrupBombSource?: number;


### PR DESCRIPTION
The overall goal was to fix behavior when ability nullification ends. A Pokemon's ability should *not* change back to its original ability as was done with the previous implementation, but instead the ability should not be totally removed by nullification, just disabled.

Most of the changes are just switching to use the `hasAbility()` method for Pokemon, which was modified to take ability nullification into account.

