### PR TITLE
Add NPC species without automatic Def cheer

### DIFF
--- a/src/calc/data/species.ts
+++ b/src/calc/data/species.ts
@@ -9977,12 +9977,18 @@ const SV_PATCH: {[name: string]: DeepPartial<SpeciesData>} = {
     weightkg: 5.4,
     abilities: {0: 'Gooey'},
   },
-  // Not a real species
+  // Not real species
   'Carry Slot': {
     types: ['???'],
     bs: {hp: 5, at: 5, df: 5, sa: 5, sd: 5, sp: 5},
     weightkg: 1.0,
     abilities: {0: '(No Ability)'},
+  },
+  'NPC': {
+    types: ['???'],
+    bs: {hp: 5, at: 5, df: 5, sa: 5, sd: 5, sp: 5},
+    weightkg: 1.0,
+    abilities: {0: '(No Ability)'}, 
   }
 };
 

--- a/src/raidcalc/RaidTurn.ts
+++ b/src/raidcalc/RaidTurn.ts
@@ -29,16 +29,17 @@ export type RaidTurnResult = {
 }
 
 export class RaidTurn {
-    raidState:      RaidState; // We shouldn't mutate this state; it is the result from the previous turn
-    raiderID:       number;
-    targetID:       number;
-    raiderMoveData!: MoveData;
-    bossMoveData!:   MoveData;
-    raiderOptions:  RaidMoveOptions;
-    bossOptions:    RaidMoveOptions;
-    id:        number;
-    group?:     number;
-    turnNumber: number;
+    raidState:          RaidState; // We shouldn't mutate this state; it is the result from the previous turn
+    raiderID:           number;
+    targetID:           number;
+    raiderMoveData!:    MoveData;
+    bossMoveData!:      MoveData;
+    raiderOptions:      RaidMoveOptions;
+    bossOptions:        RaidMoveOptions;
+    id:                 number;
+    group?:             number;
+    turnNumber:         number;
+    numNPCs:            number;
 
     _isBossAction!:     boolean;
     _isCheer!:          boolean;
@@ -58,19 +59,19 @@ export class RaidTurn {
     _bossMoveUsed!:     string;
     _instructed?:       boolean;
 
-    _raidMove1!:      RaidMove;
-    _raidMove2!:      RaidMove;
+    _raidMove1!:        RaidMove;
+    _raidMove2!:        RaidMove;
 
-    _result1!:        RaidMoveResult;
-    _result2!:        RaidMoveResult;
-    _delayedResults!: RaidMoveResult[];
-    _raidState!:      RaidState; // This tracks changes during this turn
+    _result1!:          RaidMoveResult;
+    _result2!:          RaidMoveResult;
+    _delayedResults!:   RaidMoveResult[];
+    _raidState!:        RaidState; // This tracks changes during this turn
 
-    _flags!:          string[][]; 
-    _endFlags!:       string[];
+    _flags!:            string[][]; 
+    _endFlags!:         string[];
 
 
-    constructor(raidState: RaidState, info: RaidTurnInfo, turnNumber: number) {
+    constructor(raidState: RaidState, info: RaidTurnInfo, turnNumber: number, numNPCs: number) {
         this.raidState = raidState;
         this.raiderID = info.moveInfo.userID;
         this.targetID = info.moveInfo.targetID;
@@ -85,6 +86,7 @@ export class RaidTurn {
         this.id = info.id;
         this.group = info.group;
         this.turnNumber = turnNumber;
+        this.numNPCs = numNPCs;
 
         this.raiderOptions = info.moveInfo.options || {};
         this.bossOptions = info.bossMoveInfo.options || {};
@@ -96,7 +98,11 @@ export class RaidTurn {
         this._isCheer = ["Attack Cheer", "Defense Cheer", "Heal Cheer"].includes(this.raiderMoveData.name);
         this._isEmptyTurn = this.raiderMoveData.name === "(No Move)" && this.bossMoveData.name === "(No Move)";
         // check if this marks the end of a 4-move "turn"
-        this._isEndOfFullTurn = !this._isBossAction && !this._isEmptyTurn && ((this.turnNumber % 4) === 3);
+        const turnMoveNumber = this.turnNumber % 4;
+        this._isEndOfFullTurn = !this._isBossAction && !this._isEmptyTurn && (
+            (turnMoveNumber === 3) || 
+            (this.raiderID === 1 && ((this.numNPCs + turnMoveNumber) >= 3))
+        );
         // set up moves
         this._raiderMove = new Move(9, this.raiderMoveData.name, this.raiderOptions);
         if (this.raiderOptions.crit) this._raiderMove.isCrit = true;

--- a/src/uicomponents/BuildControls.tsx
+++ b/src/uicomponents/BuildControls.tsx
@@ -1381,9 +1381,9 @@ function BuildControls({pokemon, abilities, moveSet, setPokemon, substitutes, se
             pokemon.field, 
             new Pokemon(gen, val, {
                 nature: "Hardy", 
-                level: val === "Carry Slot" ? 1 : 100,
+                level: (val === "Carry Slot" || val === "NPC") ? 1 : 100,
                 // ability: "(No Ability)",
-                ivs: val === "Carry Slot" ? {
+                ivs: (val === "Carry Slot" || val === "NPC") ? {
                     hp: 0,
                     atk: 0,
                     def: 0,

--- a/src/uicomponents/BuildControls.tsx
+++ b/src/uicomponents/BuildControls.tsx
@@ -1377,7 +1377,7 @@ function BuildControls({pokemon, abilities, moveSet, setPokemon, substitutes, se
             pokemon.id, 
             pokemon.role, 
             pokemon.shiny, 
-            false,
+            (val === "Carry Slot" || val === "NPC"),
             pokemon.field, 
             new Pokemon(gen, val, {
                 nature: "Hardy", 
@@ -1409,7 +1409,7 @@ function BuildControls({pokemon, abilities, moveSet, setPokemon, substitutes, se
             poke.id, 
             poke.role, 
             poke.shiny, 
-            false,
+            poke.isAnyLevel,
             poke.field, 
             new Pokemon(gen, val, {
                 nature: poke.nature, 

--- a/src/uicomponents/PokemonSummary.tsx
+++ b/src/uicomponents/PokemonSummary.tsx
@@ -3,8 +3,10 @@ import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Paper from '@mui/material/Paper';
 import TextField from '@mui/material/TextField';
+import IconButton from '@mui/material/IconButton';
+import CloseIcon from '@mui/icons-material/Close';
 
-import { ABILITIES, Generations } from '../calc';
+import { ABILITIES, Generations, Pokemon } from '../calc';
 import { toID } from '../calc/util';
 
 import StatRadarPlot from "./StatRadarPlot";
@@ -78,6 +80,30 @@ function PokemonSummary({pokemon, setPokemon, groups, setGroups, groupsCounter, 
 ) {
     const [moveSet, setMoveSet] = useState<(MoveSetItem)[]>([])
     const [abilities, setAbilities] = useState<{name: AbilityName, hidden: boolean}[]>([])
+
+    const handleDelete = () => {
+        setPokemon(new Raider(
+            pokemon.id, 
+            getTranslation("NPC", translationKey, "pokemon"),
+            false, 
+            true,
+            pokemon.field, 
+            new Pokemon(gen, "NPC", {
+                nature: "Hardy", 
+                level: 1,
+                // ability: "(No Ability)",
+                ivs: {
+                    hp: 0,
+                    atk: 0,
+                    def: 0,
+                    spa: 0,
+                    spd: 0,
+                    spe: 0
+                }
+            }), 
+            [],
+        ));
+    }
   
     useEffect(() => {
         if (!allSpecies) {
@@ -134,9 +160,18 @@ function PokemonSummary({pokemon, setPokemon, groups, setGroups, groupsCounter, 
 
     return (
         <Box>
-            <Paper elevation={3} sx={{ mx: 1, my: 1, width: 280, display: "flex", flexDirection: "column", padding: "0px"}}>                
+            <Paper elevation={3} sx={{ mx: 1, my: 1, width: 280, display: "flex", flexDirection: "column", padding: "0px"}}>     
+                {!prettyMode &&   
+                    <Box sx={{position: "absolute", transform: "translate(248px, 2px)"}} >
+                        <Paper elevation={3} sx={{borderRadius: 100, justifyContent: "center", alignItems: "center", boxShadow: "none"}}>
+                            <IconButton size="small" onClick={handleDelete}>
+                                <CloseIcon />
+                            </IconButton>
+                        </Paper>
+                    </Box>         
+                }
                 <Stack direction="column" spacing={0} alignItems="center" justifyContent="top" minHeight= {prettyMode ? "666px" : "800px"} sx={{ marginTop: 1 }} >
-                    <Box paddingBottom={0} width="90%">
+                    <Box paddingBottom={0} paddingLeft={1.5} width="88%" alignSelf="start">
                         <RoleField pokemon={pokemon} setPokemon={setPokemon} translationKey={translationKey} />
                     </Box>
                     <Box width="100%" marginTop="10px" display="flex" justifyContent="center">

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,7 +62,7 @@ const methodIconProlog = "https://raw.githubusercontent.com/theastrogoth/tera-ra
 
 // use the Serebii item dex for item sprites
 export function prepareImageAssetName(name: string) {
-    if (name === "Carry Slot") { return "substitute"; }
+    if (name === "Carry Slot" || name === "NPC") { return "substitute"; }
     if (name === "Flabébé") { return "flabebe"; } // ugh
     if (name.includes("Arceus")) { return "arceus"; }
     return name.replaceAll(' ','_').replaceAll('.','').replaceAll("’", '').replaceAll("'", '').replaceAll(':','').replaceAll('é','e').toLowerCase();


### PR DESCRIPTION
Add the option for "NPC" slots, which handle the T1 Def cheer after the host moves and add to the move counter when the host moves. The host is assumed to be in the first slot.