### PR TITLE
Add UI for swapping raider positions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import { getTranslation } from './utils.ts';
 import DEFAULT_STRAT from './data/strats/default.json';
 import { LightBuildInfo } from './raidcalc/hashData.ts';
 import { deepEqual } from './utils.ts';
+import RaiderSummaries from './uicomponents/RaiderSummaries.tsx';
 
 type LanguageOption = 'en' | 'ja' | 'fr' | 'es' | 'de' | 'it' | 'ko' | 'zh-Hant' | 'zh-Hans';
 
@@ -407,7 +408,20 @@ function App() {
           </Grid>
         </Grid>
         <Grid container component='main' justifyContent="center" sx={{ my: 1 }}>
-          <Grid item>
+          <RaiderSummaries
+            raidInputProps={raidInputProps}
+            substitutes={[substitutes1, substitutes2, substitutes3, substitutes4]}
+            setSubstitutes={[setSubstitutes1, setSubstitutes2, setSubstitutes3, setSubstitutes4]}
+            groupsCounter={groupsCounter}
+            setGroupsCounter={setGroupsCounter}
+            allSpecies={allSpecies}
+            allMoves={allMoves}
+            setAllSpecies={setAllSpecies}
+            setAllMoves={setAllMoves}
+            prettyMode={prettyMode}
+            translationKey={translationKey}
+          />
+          {/* <Grid item>
             <Stack direction="row">
               <PokemonSummary pokemon={raider1} setPokemon={setRaider1} groups={groups} setGroups={setGroups} groupsCounter={groupsCounter} substitutes={substitutes1} setSubstitutes={setSubstitutes1} allSpecies={allSpecies} allMoves={allMoves} setAllSpecies={setAllSpecies} setAllMoves={setAllMoves} prettyMode={prettyMode} translationKey={translationKey} />
               <PokemonSummary pokemon={raider2} setPokemon={setRaider2} groups={groups} setGroups={setGroups} groupsCounter={groupsCounter} substitutes={substitutes2} setSubstitutes={setSubstitutes2} allSpecies={allSpecies} allMoves={allMoves} setAllSpecies={setAllSpecies} setAllMoves={setAllMoves} prettyMode={prettyMode} translationKey={translationKey}/>
@@ -418,7 +432,7 @@ function App() {
               <PokemonSummary pokemon={raider3} setPokemon={setRaider3} groups={groups} setGroups={setGroups} groupsCounter={groupsCounter} substitutes={substitutes3} setSubstitutes={setSubstitutes3} allSpecies={allSpecies} allMoves={allMoves} setAllSpecies={setAllSpecies} setAllMoves={setAllMoves} prettyMode={prettyMode} translationKey={translationKey} />
               <PokemonSummary pokemon={raider4} setPokemon={setRaider4} groups={groups} setGroups={setGroups} groupsCounter={groupsCounter} substitutes={substitutes4} setSubstitutes={setSubstitutes4} allSpecies={allSpecies} allMoves={allMoves} setAllSpecies={setAllSpecies} setAllMoves={setAllMoves} prettyMode={prettyMode} translationKey={translationKey} />
             </Stack>
-          </Grid>
+          </Grid> */}
           <Grid item>
             <BossSummary pokemon={raidBoss} setPokemon={setRaidBoss} allSpecies={allSpecies} allMoves={allMoves} setAllSpecies={setAllSpecies} setAllMoves={setAllMoves} prettyMode={prettyMode} translationKey={translationKey} />
           </Grid>

--- a/src/uicomponents/MoveSelection.tsx
+++ b/src/uicomponents/MoveSelection.tsx
@@ -385,6 +385,25 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [moveSet, moveInfo.moveData.target])
 
+    useEffect(() => {
+        const newDisableTarget = (
+            moveInfo.moveData.name === "(No Move)" ||
+            moveInfo.moveData.target === undefined ||
+            moveInfo.moveData.target === "user" ||
+            moveInfo.moveData.target === "user-and-allies" ||
+            moveInfo.moveData.target === "all-allies" ||
+            // moveInfo.moveData.target === "all-opponents" ||
+            // moveInfo.moveData.target === "all-other-pokemon" ||
+            // moveInfo.moveData.target === "all-pokemon" ||
+            moveInfo.moveData.target === "users-field" ||
+            moveInfo.moveData.target === "opponents-field" ||
+            moveInfo.moveData.target === "entire-field"
+        );
+        const newValidTargets = newDisableTarget ? [moveInfo.userID] : getSelectableTargets(moveInfo.moveData.target).filter((id) => id !== moveInfo.userID)
+        setDisableTarget(newDisableTarget);
+        setValidTargets(newValidTargets);
+    }, [moveInfo.userID])
+
     return (
         <Stack direction="row" spacing={-0.5} alignItems="center" justifyContent="right">
             <Stack width="450px" direction="row" spacing={0.5} alignItems="center" justifyContent="center">

--- a/src/uicomponents/PokemonSummary.tsx
+++ b/src/uicomponents/PokemonSummary.tsx
@@ -5,6 +5,8 @@ import Paper from '@mui/material/Paper';
 import TextField from '@mui/material/TextField';
 import IconButton from '@mui/material/IconButton';
 import CloseIcon from '@mui/icons-material/Close';
+import ChevronLeft from '@mui/icons-material/ChevronLeft';
+import ChevronRight from '@mui/icons-material/ChevronRight';
 
 import { ABILITIES, Generations, Pokemon } from '../calc';
 import { toID } from '../calc/util';
@@ -73,10 +75,10 @@ export function RoleField({pokemon, setPokemon, translationKey}: {pokemon: Raide
     )
 }
 
-function PokemonSummary({pokemon, setPokemon, groups, setGroups, groupsCounter, substitutes, setSubstitutes, allSpecies, allMoves, setAllSpecies, setAllMoves, prettyMode, translationKey}: 
+function PokemonSummary({pokemon, setPokemon, groups, setGroups, groupsCounter, substitutes, setSubstitutes, swapIDs, setSwapIDs, allSpecies, allMoves, setAllSpecies, setAllMoves, prettyMode, translationKey}: 
     {pokemon: Raider, setPokemon: (r: Raider) => void, groups: TurnGroupInfo[], setGroups: (g: TurnGroupInfo[]) => void, groupsCounter: number,
-     substitutes: SubstituteBuildInfo[], setSubstitutes: (s: SubstituteBuildInfo[]) => void, allSpecies: Map<SpeciesName,PokemonData> | null, allMoves: Map<MoveName,MoveData> | null, 
-     setAllSpecies: (m: Map<SpeciesName,PokemonData> | null) => void, setAllMoves: (m: Map<MoveName,MoveData> | null) => void, prettyMode: boolean, translationKey: any}
+     substitutes: SubstituteBuildInfo[], setSubstitutes: (s: SubstituteBuildInfo[]) => void,  swapIDs: [number, number] | undefined, setSwapIDs: (i: [number, number] | undefined) => void,
+     allSpecies: Map<SpeciesName,PokemonData> | null, allMoves: Map<MoveName,MoveData> | null, setAllSpecies: (m: Map<SpeciesName,PokemonData> | null) => void, setAllMoves: (m: Map<MoveName,MoveData> | null) => void, prettyMode: boolean, translationKey: any}
 ) {
     const [moveSet, setMoveSet] = useState<(MoveSetItem)[]>([])
     const [abilities, setAbilities] = useState<{name: AbilityName, hidden: boolean}[]>([])
@@ -169,6 +171,24 @@ function PokemonSummary({pokemon, setPokemon, groups, setGroups, groupsCounter, 
                             </IconButton>
                         </Paper>
                     </Box>         
+                }
+                {!prettyMode && 
+                    <Box sx={{position: "absolute", transform: "translate(0px, 132px)"}} >
+                        <Paper elevation={3} sx={{borderRadius: 100, justifyContent: "center", alignItems: "center", boxShadow: "none"}}>
+                            <IconButton size="small" disabled={pokemon.id < 2} onClick={() => setSwapIDs([pokemon.id-1, pokemon.id])}>
+                                <ChevronLeft fontSize="large"/>
+                            </IconButton>
+                        </Paper>
+                    </Box>
+                }
+                {!prettyMode && 
+                    <Box sx={{position: "absolute", transform: "translate(242px, 132px)"}} >
+                        <Paper elevation={3} sx={{borderRadius: 100, justifyContent: "center", alignItems: "center", boxShadow: "none"}}>
+                            <IconButton size="small" disabled={pokemon.id > 3} onClick={() => setSwapIDs([pokemon.id, pokemon.id+1])}>
+                                <ChevronRight fontSize="large"/>
+                            </IconButton>
+                        </Paper>
+                    </Box>
                 }
                 <Stack direction="column" spacing={0} alignItems="center" justifyContent="top" minHeight= {prettyMode ? "666px" : "800px"} sx={{ marginTop: 1 }} >
                     <Box paddingBottom={0} paddingLeft={1.5} width="88%" alignSelf="start">
@@ -279,6 +299,13 @@ export default React.memo(PokemonSummary,
         (!!prevProps.allMoves === !!nextProps.allMoves) &&
         (!!prevProps.allSpecies === !!nextProps.allSpecies) &&
         prevProps.groupsCounter === nextProps.groupsCounter &&
+        (
+            prevProps.swapIDs === nextProps.swapIDs || (
+                prevProps.swapIDs !== undefined && nextProps.swapIDs !== undefined &&
+                prevProps.swapIDs[0] === nextProps.swapIDs[0] &&
+                prevProps.swapIDs[1] === nextProps.swapIDs[1]
+            ) 
+        ) &&
         prevProps.prettyMode === nextProps.prettyMode &&
         prevProps.translationKey === nextProps.translationKey
     )

--- a/src/uicomponents/RaiderSummaries.tsx
+++ b/src/uicomponents/RaiderSummaries.tsx
@@ -1,0 +1,109 @@
+import React, { useState, useEffect, useRef } from "react";
+import Grid from '@mui/material/Grid';
+import Stack from '@mui/material/Stack';
+
+import PokemonSummary from "./PokemonSummary";
+import { RaidInputProps } from "../raidcalc/inputs";
+import { SubstituteBuildInfo, TurnGroupInfo} from "../raidcalc/interface";
+import { Raider } from "../raidcalc/Raider";
+
+function swapGroupRaiderIds(groups: TurnGroupInfo[], firstId: number, secondId: number) {
+    return groups.map(group => { 
+        const newTurns = group.turns.map(turn => { return (
+            {
+                id: turn.id,
+                group: turn.group,
+                moveInfo: {
+                    userID: turn.moveInfo.userID === firstId ? secondId : (turn.moveInfo.userID === secondId ? firstId : turn.moveInfo.userID),
+                    targetID: turn.moveInfo.targetID === firstId ? secondId : (turn.moveInfo.targetID === secondId ? firstId : turn.moveInfo.targetID),
+                    moveData: {...turn.moveInfo.moveData},
+                    options: {...turn.moveInfo.options}
+                },
+                bossMoveInfo: {
+                    userID: turn.bossMoveInfo.userID,
+                    targetID: turn.bossMoveInfo.targetID === firstId ? secondId : (turn.bossMoveInfo.targetID === secondId ? firstId : turn.bossMoveInfo.targetID),
+                    moveData: {...turn.bossMoveInfo.moveData},
+                    options: {...turn.bossMoveInfo.options}
+                },
+            }
+        )});
+        return ({
+            id: group.id,
+            turns: newTurns,
+            repeats: group.repeats
+        })
+    });
+}
+
+function replaceSubstituteIds(substitutes: SubstituteBuildInfo[], firstId: number, secondId: number) {
+    return substitutes.map(substitute => { 
+        const newRaider = substitute.raider.clone() as Raider;
+        newRaider.id = substitute.raider.id === firstId ? secondId : (substitute.raider.id === secondId ? firstId : substitute.raider.id);
+        return ({
+            raider: newRaider,
+            substituteMoves: substitute.substituteMoves,
+            substituteTargets: substitute.substituteTargets.map(target => target === firstId ? secondId : (target === secondId ? firstId : target))
+    })});            
+}
+
+function RaiderSummaries(
+    {raidInputProps, substitutes, groupsCounter, setGroupsCounter, setSubstitutes, allSpecies, allMoves, setAllSpecies, setAllMoves, prettyMode, translationKey}: 
+    {raidInputProps: RaidInputProps, substitutes: SubstituteBuildInfo[][], setSubstitutes: ((s: SubstituteBuildInfo[]) => void)[], groupsCounter: number, setGroupsCounter: (c: number) => void, allSpecies: any, allMoves: any, setAllSpecies: any, setAllMoves: any, prettyMode: boolean, translationKey: any}
+) {
+    const [swapIDs, setSwapIDs] = useState<[number, number] | undefined>(undefined);
+
+    useEffect(() => {
+        if (swapIDs !== undefined) {
+            const newRaider1 = raidInputProps.pokemon[swapIDs[0]].clone();
+            const newRaider2 = raidInputProps.pokemon[swapIDs[1]].clone();
+            newRaider1.id = swapIDs[1];
+            newRaider2.id = swapIDs[0];
+
+            const newGroups = swapGroupRaiderIds(raidInputProps.groups, swapIDs[0], swapIDs[1]);
+            const newSubstitutes1 = replaceSubstituteIds(substitutes[swapIDs[0]-1], swapIDs[0], swapIDs[1]);
+            const newSubstitutes2 = replaceSubstituteIds(substitutes[swapIDs[1]-1], swapIDs[1], swapIDs[0]);
+
+            raidInputProps.setPokemon[swapIDs[0]](newRaider2);
+            raidInputProps.setPokemon[swapIDs[1]](newRaider1);
+            raidInputProps.setGroups(newGroups);
+            setSubstitutes[swapIDs[0]-1](newSubstitutes2);
+            setSubstitutes[swapIDs[1]-1](newSubstitutes1);
+
+            setSwapIDs(undefined);
+            setGroupsCounter(groupsCounter+1);
+        }
+    }, [swapIDs]);
+
+    return (
+    <>
+        <Grid item>
+            <Stack direction="row">
+                <PokemonSummary pokemon={raidInputProps.pokemon[1]} setPokemon={raidInputProps.setPokemon[1]} groups={raidInputProps.groups} setGroups={raidInputProps.setGroups} groupsCounter={groupsCounter} substitutes={substitutes[0]} setSubstitutes={setSubstitutes[0]} allSpecies={allSpecies} allMoves={allMoves} swapIDs={swapIDs} setSwapIDs={setSwapIDs} setAllSpecies={setAllSpecies} setAllMoves={setAllMoves} prettyMode={prettyMode} translationKey={translationKey} />
+                <PokemonSummary pokemon={raidInputProps.pokemon[2]} setPokemon={raidInputProps.setPokemon[2]} groups={raidInputProps.groups} setGroups={raidInputProps.setGroups} groupsCounter={groupsCounter} substitutes={substitutes[1]} setSubstitutes={setSubstitutes[1]} allSpecies={allSpecies} allMoves={allMoves} swapIDs={swapIDs} setSwapIDs={setSwapIDs} setAllSpecies={setAllSpecies} setAllMoves={setAllMoves} prettyMode={prettyMode} translationKey={translationKey} />
+            </Stack>
+        </Grid>
+        <Grid item>
+            <Stack direction="row">
+                <PokemonSummary pokemon={raidInputProps.pokemon[3]} setPokemon={raidInputProps.setPokemon[3]} groups={raidInputProps.groups} setGroups={raidInputProps.setGroups} groupsCounter={groupsCounter} substitutes={substitutes[2]} setSubstitutes={setSubstitutes[2]} allSpecies={allSpecies} allMoves={allMoves} swapIDs={swapIDs} setSwapIDs={setSwapIDs} setAllSpecies={setAllSpecies} setAllMoves={setAllMoves} prettyMode={prettyMode} translationKey={translationKey} />
+                <PokemonSummary pokemon={raidInputProps.pokemon[4]} setPokemon={raidInputProps.setPokemon[4]} groups={raidInputProps.groups} setGroups={raidInputProps.setGroups} groupsCounter={groupsCounter} substitutes={substitutes[3]} setSubstitutes={setSubstitutes[3]} allSpecies={allSpecies} allMoves={allMoves} swapIDs={swapIDs} setSwapIDs={setSwapIDs} setAllSpecies={setAllSpecies} setAllMoves={setAllMoves} prettyMode={prettyMode} translationKey={translationKey} />
+            </Stack>
+        </Grid> 
+    </>
+    )
+}
+
+export default React.memo(RaiderSummaries,
+    (prevProps, nextProps) => {
+        return prevProps.raidInputProps === nextProps.raidInputProps &&
+               prevProps.substitutes === nextProps.substitutes &&
+               prevProps.groupsCounter === nextProps.groupsCounter &&
+               prevProps.setGroupsCounter === nextProps.setGroupsCounter &&
+               prevProps.setSubstitutes === nextProps.setSubstitutes &&
+               prevProps.allSpecies === nextProps.allSpecies &&
+               prevProps.allMoves === nextProps.allMoves &&
+               prevProps.setAllSpecies === nextProps.setAllSpecies &&
+               prevProps.setAllMoves === nextProps.setAllMoves &&
+               prevProps.prettyMode === nextProps.prettyMode &&
+               prevProps.translationKey === nextProps.translationKey;
+    }
+);


### PR DESCRIPTION
Adds a way to move builds within the 4 raider slots while making the appropriate modifications to the substitutes and turn groups lists.

Other than moving raiders around for aesthetic reasons, this is mostly useful when dealing with NPCs, since it might matter which role is in the first position as the host.

As a first pass, buttons are used to shift raiders left and right:
<img width="296" alt="swap_buttons" src="https://github.com/user-attachments/assets/b3fe3222-0263-4e2d-9c8d-10888ed0c501">



Drag and drop would be nice, but I don't think react-beautiful-dnd handles grid layouts very well. [react-dnd](https://github.com/react-dnd/react-dnd) looks like it might work, but I'm not inclined to switch over to it just yet.