### PR TITLE
Fix Flabébé key in species map

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,7 +68,7 @@ const speciesData = recursiveEmptiesToNull(deserialize(speciesText));
 const _allSpecies = new Map<SpeciesName,PokemonData>();
 for (let [specie, data] of Object.entries(speciesData)) {
   if (specie.includes("Flab")) {
-    const flab_species = "Flabebe";
+    const flab_species = "Flabébé";
     const flab_data = {...data as PokemonData, name: "Flabébé" as SpeciesName};
     _allSpecies.set(flab_species as SpeciesName, flab_data as PokemonData);
   } else {


### PR DESCRIPTION
Closes #249 

The original smogon calc data uses U+0301 for accents, while our reformatted showdown data uses U+00E9. We could probably unify these to whatever is consistent with PokePaste, but this is just a hardcoded fix when the data gets loaded for now.