### PR TITLE
Rework UI for scripted boss actions and raiders waiting

### DIFF
--- a/src/data/strats/default.json
+++ b/src/data/strats/default.json
@@ -183,8 +183,8 @@
             "id": 0,
             "group": 0,
             "moveInfo": {
-                "name": "(No Move)",
-                "userID": 1,
+                "name": "Ruination",
+                "userID": 0,
                 "targetID": 1,
                 "options": {
                     "crit": false,
@@ -195,9 +195,9 @@
                 }
             },
             "bossMoveInfo": {
-                "name": "Ruination",
+                "name": "(No Move)",
                 "userID": 0,
-                "targetID": 1,
+                "targetID": 0,
                 "options": {
                     "crit": false,
                     "secondaryEffects": false,

--- a/src/data/strats/wo-chien/bull_duo.json
+++ b/src/data/strats/wo-chien/bull_duo.json
@@ -174,18 +174,6 @@
             "id": 0,
             "group": 0,
             "moveInfo": {
-                "name": "(No Move)",
-                "userID": 1,
-                "targetID": 1,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "allowMiss": true,
-                    "roll": "min",
-                    "hits": 1
-                }
-            },
-            "bossMoveInfo": {
                 "name": "Ruination",
                 "userID": 0,
                 "targetID": 1,
@@ -195,6 +183,18 @@
                     "allowMiss": false,
                     "roll": "max",
                     "hits": 10
+                }
+            },
+            "bossMoveInfo": {
+                "name": "(No Move)",
+                "userID": 0,
+                "targetID": 0,
+                "options": {
+                    "crit": false,
+                    "secondaryEffects": false,
+                    "allowMiss": true,
+                    "roll": "min",
+                    "hits": 1
                 }
             }
         },

--- a/src/data/strats/wo-chien/bulls_trio.json
+++ b/src/data/strats/wo-chien/bulls_trio.json
@@ -179,18 +179,6 @@
             "id": 0,
             "group": 0,
             "moveInfo": {
-                "name": "(No Move)",
-                "userID": 1,
-                "targetID": 1,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "allowMiss": true,
-                    "roll": "min",
-                    "hits": 1
-                }
-            },
-            "bossMoveInfo": {
                 "name": "Ruination",
                 "userID": 0,
                 "targetID": 1,
@@ -200,6 +188,18 @@
                     "allowMiss": false,
                     "roll": "max",
                     "hits": 10
+                }
+            },
+            "bossMoveInfo": {
+                "name": "(No Move)",
+                "userID": 0,
+                "targetID": 0,
+                "options": {
+                    "crit": false,
+                    "secondaryEffects": false,
+                    "allowMiss": true,
+                    "roll": "min",
+                    "hits": 1
                 }
             }
         },

--- a/src/data/strats/wo-chien/charizard.json
+++ b/src/data/strats/wo-chien/charizard.json
@@ -173,8 +173,8 @@
             "id": 0,
             "group": 0,
             "moveInfo": {
-                "name": "(No Move)",
-                "userID": 1,
+                "name": "Ruination",
+                "userID": 0,
                 "targetID": 1,
                 "options": {
                     "crit": false,
@@ -185,9 +185,9 @@
                 }
             },
             "bossMoveInfo": {
-                "name": "Ruination",
+                "name": "(No Move)",
                 "userID": 0,
-                "targetID": 1,
+                "targetID": 0,
                 "options": {
                     "crit": false,
                     "secondaryEffects": false,

--- a/src/data/strats/wo-chien/main.json
+++ b/src/data/strats/wo-chien/main.json
@@ -183,18 +183,6 @@
             "id": 0,
             "group": 0,
             "moveInfo": {
-                "name": "(No Move)",
-                "userID": 1,
-                "targetID": 1,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "allowMiss": true,
-                    "roll": "min",
-                    "hits": 1
-                }
-            },
-            "bossMoveInfo": {
                 "name": "Ruination",
                 "userID": 0,
                 "targetID": 1,
@@ -204,6 +192,18 @@
                     "allowMiss": false,
                     "roll": "max",
                     "hits": 10
+                }
+            },
+            "bossMoveInfo": {
+                "name": "(No Move)",
+                "userID": 0,
+                "targetID": 0,
+                "options": {
+                    "crit": false,
+                    "secondaryEffects": false,
+                    "allowMiss": true,
+                    "roll": "min",
+                    "hits": 1
                 }
             }
         },

--- a/src/data/strats/wo-chien/simple_duo.json
+++ b/src/data/strats/wo-chien/simple_duo.json
@@ -172,18 +172,6 @@
             "id": 0,
             "group": 0,
             "moveInfo": {
-                "name": "(No Move)",
-                "userID": 1,
-                "targetID": 1,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "allowMiss": true,
-                    "roll": "min",
-                    "hits": 1
-                }
-            },
-            "bossMoveInfo": {
                 "name": "Ruination",
                 "userID": 0,
                 "targetID": 1,
@@ -193,6 +181,18 @@
                     "allowMiss": false,
                     "roll": "max",
                     "hits": 10
+                }
+            },
+            "bossMoveInfo": {
+                "name": "(No Move)",
+                "userID": 0,
+                "targetID": 0,
+                "options": {
+                    "crit": false,
+                    "secondaryEffects": false,
+                    "allowMiss": true,
+                    "roll": "min",
+                    "hits": 1
                 }
             }
         },

--- a/src/uicomponents/LinkButton.tsx
+++ b/src/uicomponents/LinkButton.tsx
@@ -145,6 +145,8 @@ export async function lightToFullBuildInfo(obj: LightBuildInfo, allMoves?: Map<M
                 mdata = {name: name, priority: 10, category: "field-effect", target: "user-and-allies"};
             } else if (name === "Heal Cheer") {
                 mdata = {name: name, priority: 10, category: "heal", target: "user-and-allies"};
+            } else if (t.moveInfo.userID === 0) {
+                mdata = [...pokemon[0].moveData, ...pokemon[0].extraMoveData!].find((m) => m && m.name === t.moveInfo.name) || {name: name};
             } else {
                 mdata = pokemon[t.moveInfo.userID].moveData.find((m) => m && m.name === t.moveInfo.name) || {name: name};
             }

--- a/src/uicomponents/MoveSelection.tsx
+++ b/src/uicomponents/MoveSelection.tsx
@@ -334,21 +334,27 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
     const moveInfo = groups[groupIndex].turns[turnIndex].moveInfo;
     const moveName = moveInfo.moveData.name;
 
+    const userIDRef = useRef(moveInfo.userID);
     const targetRef = useRef(moveInfo.moveData.target);
 
     // const moves = getSelectableMoves(raiders[moveInfo.userID]); // raiders[moveInfo.userID].moves;
     const raider = raiders[groups[groupIndex].turns[turnIndex].moveInfo.userID];
-    const moveSet = ["(No Move)", "(Most Damaging)", ...(selectableMoves.length > 0 ? selectableMoves : ["Struggle"]), ...(raider.cheersLeft || 0 > 0 ? ["Attack Cheer", "Defense Cheer", "Heal Cheer"] : [])];
-
+    const moveSet = raider.id > 0 ? ["(No Move)", "(Most Damaging)", "(Wait)", ...(selectableMoves.length > 0 ? selectableMoves : ["Struggle"]), ...(raider.cheersLeft || 0 > 0 ? ["Attack Cheer", "Defense Cheer", "Heal Cheer"] : [])]
+                                  : ["(No Move)", ...raider.moves, ...(raider.extraMoves || []), "Remove Negative Effects", "Clear Boosts / Abilities", "Steal Tera Charge", "Activate Shield"];
     const [disableTarget, setDisableTarget] = useState<boolean>(
             moveInfo.moveData.name === "(No Move)" ||
+            moveInfo.moveData.name === "(Wait)" ||
             moveInfo.moveData.target === undefined ||
             moveInfo.moveData.target === "user" ||
             moveInfo.moveData.target === "user-and-allies" ||
             moveInfo.moveData.target === "all-allies" ||
-            // moveInfo.moveData.target === "all-opponents" ||
-            // moveInfo.moveData.target === "all-other-pokemon" ||
-            // moveInfo.moveData.target === "all-pokemon" ||
+            ( moveInfo.userID === 0 && 
+                (
+                    moveInfo.moveData.target === "all-opponents" ||
+                    moveInfo.moveData.target === "all-other-pokemon" ||
+                    moveInfo.moveData.target === "all-pokemon"
+                )
+            ) ||
             moveInfo.moveData.target === "users-field" ||
             moveInfo.moveData.target === "opponents-field" ||
             moveInfo.moveData.target === "entire-field"
@@ -359,15 +365,29 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
         let newGroups = [...groups];
         newGroups[groupIndex].turns[turnIndex].moveInfo = moveInfo;
 
+        if (moveInfo.userID === 0 || moveInfo.moveData.name === "(Wait)") {
+            newGroups[groupIndex].turns[turnIndex].bossMoveInfo = {
+                moveData: {name: "(No Move)" as MoveName},
+                userID: 0,
+                targetID: 0,
+                options: {...newGroups[groupIndex].turns[turnIndex].bossMoveInfo.options}
+            }
+        }
+
         const newDisableTarget = (
             moveInfo.moveData.name === "(No Move)" ||
+            moveInfo.moveData.name === "(Wait)" ||
             moveInfo.moveData.target === undefined ||
             moveInfo.moveData.target === "user" ||
             moveInfo.moveData.target === "user-and-allies" ||
             moveInfo.moveData.target === "all-allies" ||
-            // moveInfo.moveData.target === "all-opponents" ||
-            // moveInfo.moveData.target === "all-other-pokemon" ||
-            // moveInfo.moveData.target === "all-pokemon" ||
+            ( moveInfo.userID === 0 && 
+                (
+                    moveInfo.moveData.target === "all-opponents" ||
+                    moveInfo.moveData.target === "all-other-pokemon" ||
+                    moveInfo.moveData.target === "all-pokemon"
+                )
+            ) ||
             moveInfo.moveData.target === "users-field" ||
             moveInfo.moveData.target === "opponents-field" ||
             moveInfo.moveData.target === "entire-field"
@@ -398,15 +418,26 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
     }, [moveSet, moveInfo.moveData.target])
 
     useEffect(() => {
+        if (userIDRef.current !== moveInfo.userID) {
+            if (userIDRef.current === 0 || moveInfo.userID === 0) {
+                
+            }
+            userIDRef.current = moveInfo.userID;
+        }
         const newDisableTarget = (
             moveInfo.moveData.name === "(No Move)" ||
+            moveInfo.moveData.name === "(Wait)" ||
             moveInfo.moveData.target === undefined ||
             moveInfo.moveData.target === "user" ||
             moveInfo.moveData.target === "user-and-allies" ||
             moveInfo.moveData.target === "all-allies" ||
-            // moveInfo.moveData.target === "all-opponents" ||
-            // moveInfo.moveData.target === "all-other-pokemon" ||
-            // moveInfo.moveData.target === "all-pokemon" ||
+            ( moveInfo.userID === 0 && 
+                (
+                    moveInfo.moveData.target === "all-opponents" ||
+                    moveInfo.moveData.target === "all-other-pokemon" ||
+                    moveInfo.moveData.target === "all-pokemon"
+                )
+            ) ||
             moveInfo.moveData.target === "users-field" ||
             moveInfo.moveData.target === "opponents-field" ||
             moveInfo.moveData.target === "entire-field"
@@ -434,11 +465,12 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
                         }}
                         sx={{ maxWidth : "175px" }}
                     >
-                        {roles.slice(1).map((role, i) => {
-                            const raider = raiders[i+1];
+                        {[...roles.slice(1), roles[0]].map((role, i) => {
+                            const idx = i < 4 ? i + 1 : 0
+                            const raider = raiders[idx];
                             const name = raider.name;
                             return (
-                            <MenuItem key={i} value={i+1}>
+                            <MenuItem key={i} value={idx}>
                                 <Stack direction="row" spacing={0.5} justifyContent="center" alignItems="center">
                                     <Box
                                         sx={{
@@ -484,7 +516,7 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
                         onChange={(e) => {
                             const name = e.target.value as MoveName;
                             let mData: MoveData = {name: name};
-                            if (name === "(No Move)") {
+                            if (name === "(No Move)" || name === "(Wait)") {
                             } else if (name === "(Most Damaging)") {
                                 mData = {name: name, target: "selected-pokemon"};
                             } else if (name === "Attack Cheer" || name === "Defense Cheer") {
@@ -493,6 +525,10 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
                                 mData = {name: name, priority: 10, category: "heal", target: "user-and-allies"};
                             } else if (name === "Struggle") {
                                 mData = {...STRUGGLE_DATA};
+                            } else if (raiders[moveInfo.userID].id === 0) {
+                                if (isRegularMove(name)) {
+                                    mData = [...raiders[moveInfo.userID].moveData, ...raiders[moveInfo.userID].extraMoveData!].find((m) => m.name === name) as MoveData;
+                                }
                             } else {
                                 mData = raiders[moveInfo.userID].moveData.find((m) => m.name === name) as MoveData;
                             }
@@ -645,8 +681,14 @@ function MoveSelectionContainer({raiders, turnIndex, groupIndex, groups, setGrou
     const turnID = groups[groupIndex].turns[turnIndex].id;
     const collapseIn = transitionOut !== turnID && transitionIn !== turnID;
 
-    const raiderSelectableMoves = getSelectableMoves(raiders[groups[groupIndex].turns[turnIndex].moveInfo.userID]);
-    const bossSelectableMoves = getSelectableMoves(raiders[0], groups[groupIndex].turns[turnIndex].moveInfo.moveData.name === "(No Move)");
+    const bossSelectableMoves = getSelectableMoves(
+        raiders[0], 
+        (
+            groups[groupIndex].turns[turnIndex].moveInfo.moveData.name === "(No Move)" ||
+            groups[groupIndex].turns[turnIndex].moveInfo.userID === 0
+        )
+    );
+    const raiderSelectableMoves = getSelectableMoves(raiders[groups[groupIndex].turns[turnIndex].moveInfo.userID], groups[groupIndex].turns[turnIndex].moveInfo.userID === 0);
 
     useEffect(() => {
         if (transitionIn === turnID) {
@@ -769,7 +811,9 @@ function MoveSelectionCard({raiders, groupIndex, turnIndex, groups, setGroups, r
                         {/* <Box width="80%">
                             <Divider />
                         </Box> */}
-                        <BossMoveDropdown groupIndex={groupIndex} turnIndex={turnIndex} boss={raiders[0]} groups={groups} setGroups={setGroups} selectableMoves={bossSelectableMoves} translationKey={translationKey} />
+                        { (groups[groupIndex].turns[turnIndex].moveInfo.userID !== 0 && groups[groupIndex].turns[turnIndex].moveInfo.moveData.name !== "(Wait)") && 
+                            <BossMoveDropdown groupIndex={groupIndex} turnIndex={turnIndex} boss={raiders[0]} groups={groups} setGroups={setGroups} selectableMoves={bossSelectableMoves} translationKey={translationKey} />
+                        }
                     </Stack>
                     <Stack alignItems="center" justifyContent={"center"} paddingRight={0.5}>
                         <CloseButton onClick={handleRemoveTurn} visible={true} disabled={!buttonsVisible}/>

--- a/src/uicomponents/MoveSelection.tsx
+++ b/src/uicomponents/MoveSelection.tsx
@@ -192,7 +192,7 @@ function MoveOptionsControls({moveInfo, setMoveInfo, raider, isBoss = false, tra
                     <TableContainer>
                         <Table size="small">
                             <TableBody>
-                                { (!isBoss && raider.teraType && !raider.isTera && ((raider.teraCharge || 0) >= 3) && !isRaidAction(moveInfo.moveData.name) && moveInfo.moveData.name !== "(No Move)") &&
+                                { (!isBoss && raider.teraType && !raider.isTera && ((raider.teraCharge || 0) >= 3) && !isRaidAction(moveInfo.moveData.name) && moveInfo.moveData.name !== "(No Move)" && moveInfo.moveData.name !== "(Wait)") &&
                                     <TableRow>
                                         <TableCell>
                                             {getTranslation("Tera",translationKey)}
@@ -334,13 +334,12 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
     const moveInfo = groups[groupIndex].turns[turnIndex].moveInfo;
     const moveName = moveInfo.moveData.name;
 
-    const userIDRef = useRef(moveInfo.userID);
     const targetRef = useRef(moveInfo.moveData.target);
 
     // const moves = getSelectableMoves(raiders[moveInfo.userID]); // raiders[moveInfo.userID].moves;
     const raider = raiders[groups[groupIndex].turns[turnIndex].moveInfo.userID];
     const moveSet = raider.id > 0 ? ["(No Move)", "(Most Damaging)", "(Wait)", ...(selectableMoves.length > 0 ? selectableMoves : ["Struggle"]), ...(raider.cheersLeft || 0 > 0 ? ["Attack Cheer", "Defense Cheer", "Heal Cheer"] : [])]
-                                  : ["(No Move)", ...raider.moves, ...(raider.extraMoves || []), "Remove Negative Effects", "Clear Boosts / Abilities", "Steal Tera Charge", "Activate Shield"];
+                                  : [...(raider.extraMoves || []), "Remove Negative Effects", "Clear Boosts / Abilities", "Steal Tera Charge", "Activate Shield"];
     const [disableTarget, setDisableTarget] = useState<boolean>(
             moveInfo.moveData.name === "(No Move)" ||
             moveInfo.moveData.name === "(Wait)" ||
@@ -362,17 +361,8 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
     const [validTargets, setValidTargets] = useState<number[]>(disableTarget ? [moveInfo.userID] : getSelectableTargets(moveInfo.moveData.target).filter((id) => id !== moveInfo.userID));
     
     const setMoveInfo = (moveInfo: RaidMoveInfo) => {
-        let newGroups = [...groups];
+        const newGroups = [...groups];
         newGroups[groupIndex].turns[turnIndex].moveInfo = moveInfo;
-
-        if (moveInfo.userID === 0 || moveInfo.moveData.name === "(Wait)") {
-            newGroups[groupIndex].turns[turnIndex].bossMoveInfo = {
-                moveData: {name: "(No Move)" as MoveName},
-                userID: 0,
-                targetID: 0,
-                options: {...newGroups[groupIndex].turns[turnIndex].bossMoveInfo.options}
-            }
-        }
 
         const newDisableTarget = (
             moveInfo.moveData.name === "(No Move)" ||
@@ -405,6 +395,48 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
     const setInfoParam = (param: string) => (val: any) => {
         setMoveInfo({...moveInfo, [param]: val});
     }
+
+    const handleChangeUserID = (userID: number) => {
+        if (userID === moveInfo.userID) { return; }
+        const bossSwap = (userID * moveInfo.userID === 0);
+        const newMoveSet = userID > 0 ? ["(No Move)", "(Most Damaging)", "(Wait)", ...raiders[userID].moves, "Attack Cheer", "Defense Cheer", "Heal Cheer"]
+                                  : [...(raiders[0].extraMoves || []), "Remove Negative Effects", "Clear Boosts / Abilities", "Steal Tera Charge", "Activate Shield"];
+        // attempt to avoid mixing up boss options and raider options
+        const turn = groups[groupIndex].turns[turnIndex];
+        const tempOpts = {...moveInfo.options};
+        const newMoveInfo = {
+            moveData: moveInfo.moveData,
+            userID: userID,
+            targetID: moveInfo.targetID,
+            options: bossSwap ? turn.bossMoveInfo.options : moveInfo.options,
+        }
+        if (userID === 0) {
+            newMoveInfo.moveData = turn.bossMoveInfo.moveData;
+            if (!raiders[0].extraMoves?.includes(newMoveInfo.moveData.name)) {
+                newMoveInfo.moveData = raiders[0].extraMoveData ? raiders[0].extraMoveData[0] : {name: "Remove Negative Effects" as MoveName};
+            }
+        } else if (moveInfo.userID === 0) {
+            newMoveInfo.moveData = turn.bossMoveInfo.moveData;
+            newMoveInfo.moveData = {name: "(No Move)" as MoveName};
+            newMoveInfo.userID = userID;
+            newMoveInfo.targetID = userID;
+        } else {
+            if (!newMoveSet.includes(newMoveInfo.moveData.name)) {
+                newMoveInfo.moveData = {name: "(No Move)" as MoveName};
+                newMoveInfo.userID = userID;
+                newMoveInfo.targetID = userID;
+            } 
+        }
+        if (bossSwap) {
+            turn.bossMoveInfo = {
+                moveData: moveInfo.userID === 0 ? {...moveInfo.moveData} : {name: "(No Move)" as MoveName},
+                userID: 0,
+                targetID: userID,
+                options: tempOpts
+            };
+        }
+        setMoveInfo(newMoveInfo);
+    }
     
     useEffect(() => {
         if (!moveSet.includes(moveName)) {
@@ -418,12 +450,39 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
     }, [moveSet, moveInfo.moveData.target])
 
     useEffect(() => {
-        if (userIDRef.current !== moveInfo.userID) {
-            if (userIDRef.current === 0 || moveInfo.userID === 0) {
-                
-            }
-            userIDRef.current = moveInfo.userID;
-        }
+        // if (userIDRef.current !== moveInfo.userID && ((userIDRef.current * moveInfo.userID) === 0)) {
+        //     // attempt to avoid mixing up boss options and raider options
+        //     const turn = groups[groupIndex].turns[turnIndex];
+        //     const tempOpts = {...moveInfo.options};
+        //     const newMoveInfo = {
+        //         moveData: moveInfo.moveData,
+        //         userID: moveInfo.userID,
+        //         targetID: moveInfo.targetID,
+        //         options: turn.bossMoveInfo.options,
+        //     }
+        //     if (moveInfo.userID === 0) {
+        //         newMoveInfo.moveData = turn.bossMoveInfo.moveData;
+        //         if (!moveSet.includes(newMoveInfo.moveData.name)) {
+        //             newMoveInfo.moveData = raider.extraMoveData ? raider.extraMoveData[0] : {name: moveSet[0] as MoveName};
+        //         }
+        //     } else {
+        //         newMoveInfo.moveData = turn.bossMoveInfo.moveData;
+        //         if (!moveSet.includes(newMoveInfo.moveData.name)) {
+        //             newMoveInfo.moveData = {name: "(No Move)" as MoveName};
+        //             newMoveInfo.userID = raider.id;
+        //             newMoveInfo.targetID = raider.id;
+        //         } 
+        //     }
+        //     turn.bossMoveInfo = {
+        //         moveData: userIDRef.current === 0 ? {...moveInfo.moveData} : {name: "(No Move)" as MoveName},
+        //         userID: 0,
+        //         targetID: moveInfo.userID,
+        //         options: tempOpts
+        //     };
+
+        //     setMoveInfo(newMoveInfo);
+        // }
+        // userIDRef.current = moveInfo.userID;
         const newDisableTarget = (
             moveInfo.moveData.name === "(No Move)" ||
             moveInfo.moveData.name === "(Wait)" ||
@@ -456,7 +515,8 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
                         size="small"
                         variant="standard"
                         value = {moveInfo.userID}
-                        onChange={(e) => setInfoParam("userID")(e.target.value)}
+                        // onChange={(e) => setInfoParam("userID")(e.target.value)}
+                        onChange={(e) => handleChangeUserID(e.target.value as number)}
                         MenuProps={{
                             anchorOrigin: {
                                 vertical: "bottom",
@@ -597,7 +657,10 @@ function BossMoveDropdown({groupIndex, turnIndex, boss, groups, setGroups, selec
     {groupIndex: number, turnIndex: number, boss: Raider, groups: TurnGroupInfo[], setGroups: (t: TurnGroupInfo[]) => void, selectableMoves: MoveName[], translationKey: any}) 
 {
     const moveInfo = groups[groupIndex].turns[turnIndex].bossMoveInfo;
-    const moveSet = ["(No Move)", "(Most Damaging)", "(Optimal Move)", ...selectableMoves, "Remove Negative Effects", "Clear Boosts / Abilities", "Steal Tera Charge", "Activate Shield"];
+    const moveSet = [
+        "(No Move)", "(Most Damaging)", "(Optimal Move)", ...selectableMoves, 
+        ...(groups[groupIndex].turns[turnIndex].moveInfo.moveData.name === "(No Move)" ? ["Remove Negative Effects", "Clear Boosts / Abilities", "Steal Tera Charge", "Activate Shield"] : [])
+    ];
 
     const moveName = moveInfo.moveData.name;
     const [updateCount, setUpdateCount] = useState<number>(0); // just used to trigger rerender
@@ -611,7 +674,7 @@ function BossMoveDropdown({groupIndex, turnIndex, boss, groups, setGroups, selec
 
     useEffect(() => {
         if (!moveSet.includes(moveName)) {
-            setMoveInfo({...moveInfo, moveData: {name: "(No Move)" as MoveName}});
+            setMoveInfo({...moveInfo, moveData: {name: "(Most Damaging)" as MoveName}});
         } 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [moveSet])
@@ -678,17 +741,19 @@ function BossMoveDropdown({groupIndex, turnIndex, boss, groups, setGroups, selec
 function MoveSelectionContainer({raiders, turnIndex, groupIndex, groups, setGroups, buttonsVisible, transitionIn, setTransitionIn, transitionOut, setTransitionOut, translationKey}: 
     {raiders: Raider[], turnIndex: number, groupIndex: number, groups: TurnGroupInfo[], setGroups: (t: TurnGroupInfo[]) => void, buttonsVisible: boolean, transitionIn: number, setTransitionIn: (i: number) => void, transitionOut: number, setTransitionOut: (i: number) => void, translationKey: any}) 
 {
-    const turnID = groups[groupIndex].turns[turnIndex].id;
+    const turn = groups[groupIndex].turns[turnIndex];
+    const turnID = turn.id;
     const collapseIn = transitionOut !== turnID && transitionIn !== turnID;
 
     const bossSelectableMoves = getSelectableMoves(
         raiders[0], 
         (
-            groups[groupIndex].turns[turnIndex].moveInfo.moveData.name === "(No Move)" ||
-            groups[groupIndex].turns[turnIndex].moveInfo.userID === 0
+            turn.moveInfo.moveData.name === "(No Move)" ||
+            turn.moveInfo.userID === 0
         )
     );
-    const raiderSelectableMoves = getSelectableMoves(raiders[groups[groupIndex].turns[turnIndex].moveInfo.userID], groups[groupIndex].turns[turnIndex].moveInfo.userID === 0);
+    const raiderSelectableMoves = getSelectableMoves(raiders[turn.moveInfo.userID], turn.moveInfo.userID === 0);
+    const bossVisible = turn.moveInfo.userID !==0 && turn.moveInfo.moveData.name !== "(Wait)";
 
     useEffect(() => {
         if (transitionIn === turnID) {
@@ -720,6 +785,7 @@ function MoveSelectionContainer({raiders, turnIndex, groupIndex, groups, setGrou
                                 raiderSelectableMoves={raiderSelectableMoves}
                                 bossSelectableMoves={bossSelectableMoves}
                                 buttonsVisible={buttonsVisible} 
+                                bossVisible={bossVisible}
                                 setTransitionIn={setTransitionIn} 
                                 setTransitionOut={setTransitionOut} 
                                 translationKey={translationKey}
@@ -773,8 +839,8 @@ function CloseButton({onClick, visible, disabled=false}: {onClick: () => void, v
     )
 }
 
-function MoveSelectionCard({raiders, groupIndex, turnIndex, groups, setGroups, raiderSelectableMoves, bossSelectableMoves, buttonsVisible, setTransitionIn, setTransitionOut, translationKey}: 
-    {raiders: Raider[], groupIndex: number, turnIndex: number, groups: TurnGroupInfo[], setGroups: (t: TurnGroupInfo[]) => void, raiderSelectableMoves: MoveName[], bossSelectableMoves: MoveName[], buttonsVisible: boolean, setTransitionIn: (i: number) => void, setTransitionOut: (i: number) => void, translationKey: any}) 
+function MoveSelectionCard({raiders, groupIndex, turnIndex, groups, setGroups, raiderSelectableMoves, bossSelectableMoves, buttonsVisible, bossVisible, setTransitionIn, setTransitionOut, translationKey}: 
+    {raiders: Raider[], groupIndex: number, turnIndex: number, groups: TurnGroupInfo[], setGroups: (t: TurnGroupInfo[]) => void, raiderSelectableMoves: MoveName[], bossSelectableMoves: MoveName[], buttonsVisible: boolean, bossVisible: boolean, setTransitionIn: (i: number) => void, setTransitionOut: (i: number) => void, translationKey: any}) 
 {
     const timer = useRef<NodeJS.Timeout | null>(null);
     const handleRemoveTurn = () => {
@@ -811,7 +877,7 @@ function MoveSelectionCard({raiders, groupIndex, turnIndex, groups, setGroups, r
                         {/* <Box width="80%">
                             <Divider />
                         </Box> */}
-                        { (groups[groupIndex].turns[turnIndex].moveInfo.userID !== 0 && groups[groupIndex].turns[turnIndex].moveInfo.moveData.name !== "(Wait)") && 
+                        { bossVisible && 
                             <BossMoveDropdown groupIndex={groupIndex} turnIndex={turnIndex} boss={raiders[0]} groups={groups} setGroups={setGroups} selectableMoves={bossSelectableMoves} translationKey={translationKey} />
                         }
                     </Stack>
@@ -865,6 +931,7 @@ const MoveSelectionCardMemo = React.memo(MoveSelectionCard, (prevProps, nextProp
         arraysEqual(prevProps.raiderSelectableMoves, nextProps.raiderSelectableMoves) &&
         arraysEqual(prevProps.bossSelectableMoves, nextProps.bossSelectableMoves) &&
         prevProps.buttonsVisible === nextProps.buttonsVisible &&
+        prevProps.bossVisible === nextProps.bossVisible &&
         prevProps.groups.length === nextProps.groups.length &&
         prevProps.translationKey === nextProps.translationKey
     )
@@ -1163,7 +1230,7 @@ function MoveSelection({raidInputProps, results, rollCase, translationKey}: {rai
                                                 // number of regular moves
                                                 g.turns.length +
                                                 // ... plus the number of NPC moves (assumes NPC isn't in the first slot, so maybe we should enforce that)
-                                                g.turns.filter(t => t.moveInfo.userID === 1 && t.moveInfo.moveData.name !== "(No Move)").length * raidInputProps.pokemon.slice(1).filter(p => p.name === "NPC").length    
+                                                g.turns.filter(t => t.moveInfo.userID === 1 && t.moveInfo.moveData.name !== "(No Move)" && t.moveInfo.moveData.name !== "(Wait)").length * raidInputProps.pokemon.slice(1).filter(p => p.name === "NPC").length    
                                             ) * (g.repeats || 1), 0
                                         );
                                         return (

--- a/src/uicomponents/RaidControls.tsx
+++ b/src/uicomponents/RaidControls.tsx
@@ -1014,7 +1014,7 @@ function RollCaseButton({raidInputProps, rollCase, setRollCase, translationKey}:
     const handleClick = () => {
         const newGroups: TurnGroupInfo[] = raidInputProps.groups.map(g => {
             const newTurns: RaidTurnInfo[] = g.turns.map(t => {
-                const [raiderOptions, bossOptions] = getMoveOptionsForRollCase(rollCase, t.moveInfo.targetID, t.moveInfo.moveData, t.bossMoveInfo.moveData);
+                const [raiderOptions, bossOptions] = getMoveOptionsForRollCase(rollCase, t.moveInfo.userID, t.moveInfo.targetID, t.moveInfo.moveData, t.bossMoveInfo.moveData);
                 const newRaiderMoveInfo = {...t.moveInfo};
                 newRaiderMoveInfo.options = {...newRaiderMoveInfo.options, ...raiderOptions}
                 const newBossMoveInfo = {...t.bossMoveInfo};
@@ -1050,11 +1050,14 @@ function RollCaseButton({raidInputProps, rollCase, setRollCase, translationKey}:
     )
 }
 
-function getMoveOptionsForRollCase(rollCase: "max" | "min" | "avg", targetID: number, moveData: MoveData, bossMoveData: MoveData) {
+function getMoveOptionsForRollCase(rollCase: "max" | "min" | "avg", userID: number, targetID: number, moveData: MoveData, bossMoveData: MoveData) {
     const bossRollCase = rollCase === "max" ? "min" : (rollCase === "min" ? "max" : "avg")
-    const raiderRollCase = (targetID !== 0 && moveData.category?.includes("damage")) ? (
-        rollCase === "max" ? "sidemax" : (rollCase === "min" ? "sidemin" : "avg")
-    ) : rollCase;
+    const raiderRollCase = userID === 0 ? bossRollCase : 
+        (
+            (targetID !== 0 && moveData.category?.includes("damage")) ? (
+            rollCase === "max" ? "sidemax" : (rollCase === "min" ? "sidemin" : "avg")
+            ) : rollCase
+        );
     return [rollCaseToOptions(raiderRollCase, moveData), rollCaseToOptions(bossRollCase, bossMoveData)]
 }
 
@@ -1076,7 +1079,8 @@ function rollCaseCheck(rollCase: "max" | "min" | "avg", groups: TurnGroupInfo[])
     let matchesCase = true;
     for (let group of groups) {
         for (let turn of group.turns) {
-            const [raiderShouldMatch, bossShouldMatch] = getMoveOptionsForRollCase(rollCase, turn.moveInfo.targetID, turn.moveInfo.moveData, turn.bossMoveInfo.moveData);
+            let [raiderShouldMatch, bossShouldMatch] = getMoveOptionsForRollCase(rollCase, turn.moveInfo.userID, turn.moveInfo.targetID, turn.moveInfo.moveData, turn.bossMoveInfo.moveData);
+            if (turn.moveInfo.userID === 0) { raiderShouldMatch = bossShouldMatch };
             const raiderMatches = !!turn.moveInfo.options &&
                 turn.moveInfo.options.crit === raiderShouldMatch.crit &&
                 turn.moveInfo.options.secondaryEffects === raiderShouldMatch.secondaryEffects &&

--- a/src/uicomponents/RaidControls.tsx
+++ b/src/uicomponents/RaidControls.tsx
@@ -1079,6 +1079,9 @@ function rollCaseCheck(rollCase: "max" | "min" | "avg", groups: TurnGroupInfo[])
     let matchesCase = true;
     for (let group of groups) {
         for (let turn of group.turns) {
+            // if (turn.moveInfo.moveData.name === "(Wait)" || (turn.moveInfo.moveData.name === "(No Move)" && turn.bossMoveInfo.moveData.name === "(No Move)")) {
+            //     continue;
+            // }
             let [raiderShouldMatch, bossShouldMatch] = getMoveOptionsForRollCase(rollCase, turn.moveInfo.userID, turn.moveInfo.targetID, turn.moveInfo.moveData, turn.bossMoveInfo.moveData);
             if (turn.moveInfo.userID === 0) { raiderShouldMatch = bossShouldMatch };
             const raiderMatches = !!turn.moveInfo.options &&
@@ -1087,7 +1090,7 @@ function rollCaseCheck(rollCase: "max" | "min" | "avg", groups: TurnGroupInfo[])
                 ((turn.moveInfo.moveData.maxHits || 1) > 1 ? turn.moveInfo.options.hits === raiderShouldMatch.hits : true) &&
                 turn.moveInfo.options.allowMiss === raiderShouldMatch.allowMiss &&
                 turn.moveInfo.options.roll === raiderShouldMatch.roll;
-            const bossMatches = !!turn.bossMoveInfo.options &&
+            const bossMatches = turn.moveInfo.userID === 0 || !!turn.bossMoveInfo.options &&
                 turn.bossMoveInfo.options.crit === bossShouldMatch.crit &&
                 turn.bossMoveInfo.options.secondaryEffects === bossShouldMatch.secondaryEffects &&
                 ((turn.bossMoveInfo.moveData.maxHits || 1) > 1 ? turn.bossMoveInfo.options.hits === bossShouldMatch.hits : true) &&

--- a/src/workers/raidcalc.worker.ts
+++ b/src/workers/raidcalc.worker.ts
@@ -4,6 +4,7 @@ import { RaidState } from "../raidcalc/RaidState";
 import { Raider } from "../raidcalc/Raider";
 import { Field, Pokemon, Generations } from "../calc";
 import { optimizeBossMoves } from "../raidcalc/optmoves";
+import { MoveName } from "../calc/data/interface";
 
 declare var self: DedicatedWorkerGlobalScope;
 export {};
@@ -29,6 +30,22 @@ self.onmessage = (event: MessageEvent<{raiders: Raider[], groups: TurnGroupInfo[
     raiders[0].isTera = true; // ensure the boss is Tera'd on T0
     for (let i = 0; i < raiders.length; i++) {
         raiders[i].field.gameType = 'Doubles'; // affects Reflect/Light Screen/Aurora Veil 
+    }
+
+    // handle alt UI format for scripted boss moves...
+    // ... as well as (Wait) moves from the UI
+    for (const g of event.data.groups) {
+        for (const t of g.turns) {
+            if (t.moveInfo.userID === 0) {
+                const tempMoveInfo = t.moveInfo;
+                t.moveInfo = t.bossMoveInfo;
+                t.bossMoveInfo = tempMoveInfo;
+                t.moveInfo.userID = t.bossMoveInfo.targetID;
+                t.moveInfo.targetID = t.moveInfo.userID;
+            } else if (t.moveInfo.moveData.name === "(Wait)") {
+                t.moveInfo.moveData.name = "(No Move)" as MoveName;
+            }
+        }
     }
 
     const numBranches = (event.data.groups.map((g) => g.turns.map((t) => t.bossMoveInfo.moveData.name === "(Optimal Move)" ? 1 : 0)).flat() as number[]).reduce((acc, v) => acc + v, 0);

--- a/src/workers/raidcalc.worker.ts
+++ b/src/workers/raidcalc.worker.ts
@@ -44,6 +44,7 @@ self.onmessage = (event: MessageEvent<{raiders: Raider[], groups: TurnGroupInfo[
                 t.moveInfo.targetID = t.moveInfo.userID;
             } else if (t.moveInfo.moveData.name === "(Wait)") {
                 t.moveInfo.moveData.name = "(No Move)" as MoveName;
+                t.bossMoveInfo.moveData.name = "(No Move)" as MoveName;
             }
         }
     }


### PR DESCRIPTION
Reworking scripted boss moves and raiders "waiting" to hopefully make it more intuitive.

Thinking about adding something to allow bosses to target any raider for move optimization, but that might be a separate PR at some point.

### Additions
- In addition to raiders, the raid boss can now be selected in a `MoveDropdown`
   - this hides the associated `BossMoveDropdown`
   - this is handled the same way as a "(No Move)" action by a raider with a selected action for the boss
   - the roll case is attempted to be preserved when switching to/from the boss
- Raiders can now select the "(Wait)" action
   - this hides the associated 'BossMoveDropdown`
   - this is handled the same was a "(No Move)" action for both the raider and the boss

### Tweaks
- Scripted boss actions now only allow `extraMoves` and special raid actions to be chosen
- Non-scripted boss actions (i.e. when the raider performs an action) only allow the boss's `moves` to be selected
- Fewer rerenders when switching raiders in a `MoveDropdown`