### PR TITLE
Combine symmetric builds/moves in graphic

### DIFF
--- a/src/raidcalc/interface.ts
+++ b/src/raidcalc/interface.ts
@@ -243,7 +243,8 @@ export type ExtraBuildInfo = {
     moveTypes: TypeName[];
     optionalMove: boolean[];
     subFor?: string;
-    copies?: number;
+    copiesShiny?: boolean[];
+    copiesRole?: string,
 }
 
 export type GraphicBuildInfo = {

--- a/src/raidcalc/interface.ts
+++ b/src/raidcalc/interface.ts
@@ -243,6 +243,7 @@ export type ExtraBuildInfo = {
     moveTypes: TypeName[];
     optionalMove: boolean[];
     subFor?: string;
+    copies?: number;
 }
 
 export type GraphicBuildInfo = {

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -781,7 +781,7 @@ function generateGraphic(theme: any, buildsOnly: boolean, buildInfo: GraphicBuil
                                                     ))}
                                                     {info.raider.types.length === 1 && <BuildTypeIcon key={1} src={getTypeIconURL("none")}/>}
                                                 </BuildTypes>
-                                                <BuildRole>{copies > 1 ? `${info.raider.role}  ×${copies}` : info.raider.role}</BuildRole>
+                                                <BuildRole>{copies > 1 ? `${getTranslation(info.raider.name, translationKey, "pokemon")}  ×${copies}` : info.raider.role}</BuildRole>
                                                 { info.extraBuildInfo.subFor &&
                                                     <BuildSubstituteSubtitle>Substitute for {info.extraBuildInfo.subFor}</BuildSubstituteSubtitle>
                                                 }

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect } from "react";
 
 import Box from '@mui/material/Box';
 
-import { Generations, Move, toID } from "../calc";
+import { Generations, Move, SPECIES, toID } from "../calc";
 import { SpeciesName, TypeName, Nature, StatID } from "../calc/data/interface";
 import { getItemSpriteURL, getPokemonArtURL, getTypeIconURL, getTeraTypeIconURL, getMoveMethodIconURL, getReadableGender, getEVDescription, getIVDescription, getPokemonSpriteURL, getMiscImageURL, getTeraTypeBannerURL, getTranslation, sortGroupsIntoTurns, getTurnNumbersFromGroups } from "../utils";
 import { RaidMoveInfo, SubstituteBuildInfo, TurnGroupInfo, ExtraBuildInfo, GraphicBuildInfo } from "../raidcalc/interface";
@@ -219,11 +219,21 @@ const BuildHeader = styled(Box)({
     position: "relative"
 });
 
-const BuildArt = styled("img")({
+const BuildArtWrapper = styled(Stack)({
     width: "375px",
     position: "absolute",
     top: "-290px",
     right: "0px",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "left"
+});
+
+const BuildArt = styled("img")({
+    width: "375px",
+    // position: "absolute",
+    // top: "-290px",
+    // right: "0px",
     filter: "drop-shadow(0px 0px 15px rgba(0, 0, 0, 0.35))"
 });
 
@@ -658,10 +668,11 @@ function getMoveMethodIcon(moveMethod: string, moveType: TypeName) {
 }
 
 // TODO: move this to a more appropriate place (also used in MoveDisplay)
-function getTurnGroups(groups: TurnGroupInfo[], results: RaidBattleResults): [{id: number, move: string, info: RaidMoveInfo, isSpread: boolean, repeats: number, teraActivated: boolean}[][][], number[]] {
+function getTurnGroups(groups: TurnGroupInfo[], results: RaidBattleResults): [{id: number, move: string, info: RaidMoveInfo, isSpread: boolean, repeats: number, teraActivated: boolean, raiderIDs: number[]}[][][], number[]] {
+    const raiders = results.turnZeroState.raiders;
     const [turnGroups, turnNumbers] = sortGroupsIntoTurns(getTurnNumbersFromGroups(groups), groups);
-    const preparedTurnGroups = turnGroups.map(groups => groups.map((group, groupIndex) => 
-        group.turns.map((t) => { 
+    const tempTurnGroups = turnGroups.map(groups => groups.map((group, groupIndex) => 
+        group.turns.map((t, i) => { 
             const turnResult = results.turnResults.find((r) => t.id === r.id)!;
             let move = turnResult.raiderMoveUsed;
             const wait = move === "(No Move)" && turnResult.bossMoveUsed === "(No Move)";
@@ -677,14 +688,41 @@ function getTurnGroups(groups: TurnGroupInfo[], results: RaidBattleResults): [{i
                 isSpread,
                 repeats: group.repeats || 1,
                 teraActivated: !wait && !!(turnResult!.moveInfo.options!.activateTera && (results.turnZeroState.raiders[t.moveInfo.userID].teraType || "???")!== "???" &&
-                                turnResult.flags[turnResult.moveInfo.userID].includes("Tera activated"))
+                                turnResult.flags[turnResult.moveInfo.userID].includes("Tera activated")),
+                raiderIDs: [info.userID],
             } 
         })
     ));
+    const preparedTurnGroups = tempTurnGroups.map(tg => 
+        tg.map(g => {
+            const turns = [g[0]];
+            for (let i=1; i<g.length; i++) {
+                let duplicate = false;
+                for (let j=0; j<turns.length; j++) {
+                    if (
+                        raiders[g[i].info.userID].name === raiders[g[j].info.userID].name &&
+                        g[i].info.moveData.name === g[j].info.moveData.name &&
+                        (
+                            g[i].info.targetID === g[j].info.targetID ||
+                            ((g[i].info.targetID === g[i].info.userID) && (g[j].info.targetID === g[j].info.userID))
+                        )
+                    ) {
+                        duplicate = true;
+                        g[j].raiderIDs.push(g[i].info.userID); 
+                        break;
+                    }
+                }
+                if (!duplicate) {
+                    turns.push!(g[i])
+                }
+            }
+            return turns;
+        })
+    )
     return [preparedTurnGroups, turnNumbers];
 }
 
-function generateGraphic(theme: any, buildsOnly: boolean, buildInfo: GraphicBuildInfo[], results: RaidBattleResults, buildsCount: number, turnGroups: {id: number, move: string, info: RaidMoveInfo, isSpread: boolean, repeats: number, teraActivated: boolean}[][][], turnNumbers: number[], backgroundImageURL: string, title?: string, subtitle?: string, notes?: string, credits?: string, statDisplay?: (JSX.Element)[], translationKey?: any) {
+function generateGraphic(theme: any, buildsOnly: boolean, buildInfo: GraphicBuildInfo[], results: RaidBattleResults, buildsCount: number, turnGroups: {id: number, move: string, info: RaidMoveInfo, isSpread: boolean, repeats: number, teraActivated: boolean, raiderIDs: number[]}[][][], turnNumbers: number[], backgroundImageURL: string, title?: string, subtitle?: string, notes?: string, credits?: string, statDisplay?: (JSX.Element)[], translationKey?: any) {
     const graphicTop = document.createElement('graphic_top');
     graphicTop.setAttribute("style", "width: 3600px");
     const root = createRoot(graphicTop);
@@ -718,11 +756,21 @@ function generateGraphic(theme: any, buildsOnly: boolean, buildInfo: GraphicBuil
                         </Separator> 
                         <BuildsContainer>    
                             {
-                                buildInfo.slice(1, buildsCount + 1).map((info, index) => (
+                                buildInfo.slice(1, buildsCount + 1).map((info, index) => {
+                                  const copies = info.extraBuildInfo.copies || 1;
+                                  const hSpacing = -120 / (Math.max(copies,2) - 1) - 375;
+                                  const vSpacing = 42 / (Math.max(copies,2) - 1);
+                                  return (
                                     <BuildWrapper key={index}>
                                         <Build>
                                             <BuildHeader>
-                                                <BuildArt src={getPokemonArtURL(info.raider.species.name, info.raider.shiny)}/>
+                                                <BuildArtWrapper direction="row-reverse" spacing={`${hSpacing}px`}>
+                                                    {
+                                                        [...Array(copies || 1).keys()].map(i =>
+                                                            <BuildArt src={getPokemonArtURL(info.raider.species.name, info.raider.shiny)} sx={{ transform: `translate(0px, ${vSpacing * (i - (copies || 1))}px)` }}/>
+                                                        )
+                                                    }
+                                                </BuildArtWrapper>
                                                 {info.raider.item ? 
                                                     <BuildItemArt src={getItemSpriteURL(info.raider.item)} /> : null}
                                                 {(info.raider.teraType || "???") !== "???" ?
@@ -733,7 +781,7 @@ function generateGraphic(theme: any, buildsOnly: boolean, buildInfo: GraphicBuil
                                                     ))}
                                                     {info.raider.types.length === 1 && <BuildTypeIcon key={1} src={getTypeIconURL("none")}/>}
                                                 </BuildTypes>
-                                                <BuildRole>{info.raider.role}</BuildRole>
+                                                <BuildRole>{copies > 1 ? `${info.raider.role}  ×${copies}` : info.raider.role}</BuildRole>
                                                 { info.extraBuildInfo.subFor &&
                                                     <BuildSubstituteSubtitle>Substitute for {info.extraBuildInfo.subFor}</BuildSubstituteSubtitle>
                                                 }
@@ -754,7 +802,7 @@ function generateGraphic(theme: any, buildsOnly: boolean, buildInfo: GraphicBuil
                                                         : null
                                                     }
                                                 </Stack> : null}
-                                                {info.raider.gender && info.raider.gender !== "N" &&
+                                                {info.raider.gender && info.raider.gender !== "N" && (SPECIES[9][info.raider.name].gender === undefined || SPECIES[9][info.raider.name].gender === "N") &&
                                                     <BuildInfo>{ getTranslation("Gender", translationKey) + ": " + getTranslation(getReadableGender(info.raider.gender), translationKey) }</BuildInfo>
                                                 }
                                                 <BuildInfo>{ getTranslation("Nature", translationKey) + ": " + (info.raider.nature === "Hardy" ? getTranslation("Any", translationKey) : getTranslation(info.raider.nature, translationKey, "natures")) }</BuildInfo>
@@ -798,7 +846,7 @@ function generateGraphic(theme: any, buildsOnly: boolean, buildInfo: GraphicBuil
                                             </BuildMovesSection>
                                         </Build>
                                     </BuildWrapper>
-                                ))
+                                )})
                             }
                         </BuildsContainer>
                         { buildInfo.some(entry => entry.extraBuildInfo.optionalMove.some(move => move)) &&
@@ -871,9 +919,15 @@ function generateGraphic(theme: any, buildsOnly: boolean, buildInfo: GraphicBuil
                                                                                 </ExecutionMovePokemonIconWrapper>
                                                                             </ExecutionMovePokemonWrapperShifted> :
                                                                             <ExecutionMovePokemonWrapper>
-                                                                                <ExecutionMovePokemonName>{turnRaiders[move.info.userID].role}</ExecutionMovePokemonName>
+                                                                                <ExecutionMovePokemonName>{moveGroup[moveIndex].raiderIDs.length > 1 ? `${getTranslation(turnRaiders[move.info.userID].name, translationKey, "pokemon")} ×${moveGroup[moveIndex].raiderIDs.length}` : turnRaiders[move.info.userID].role}</ExecutionMovePokemonName>
                                                                                 <ExecutionMovePokemonIconWrapper>
-                                                                                    <ExecutionMovePokemonIcon src={getPokemonSpriteURL(turnRaiders[move.info.userID].species.name)} />
+                                                                                    <Stack direction="row-reverse" spacing="-175px">
+                                                                                        {
+                                                                                            moveGroup[moveIndex].raiderIDs.map(id => 
+                                                                                                <ExecutionMovePokemonIcon src={getPokemonSpriteURL(turnRaiders[id].species.name)} />
+                                                                                            )
+                                                                                        }
+                                                                                    </Stack>
                                                                                 </ExecutionMovePokemonIconWrapper>
                                                                             </ExecutionMovePokemonWrapper>
                                                                             }
@@ -909,7 +963,7 @@ function generateGraphic(theme: any, buildsOnly: boolean, buildInfo: GraphicBuil
                                                                                             <ExecutionMovePokemonIcon src={getPokemonSpriteURL(turnRaiders[3].species.name)} />
                                                                                             <ExecutionMovePokemonIcon src={getPokemonSpriteURL(turnRaiders[4].species.name)} />
                                                                                         </ExecutionMovePokemonIconWrapper>
-
+ 
                                                                                     }
                                                                                 </ExecutionMovePokemonWrapper>
                                                                                 :
@@ -1033,6 +1087,32 @@ function getRelevantBuilds(buildInfo: GraphicBuildInfo[][]) {
     return [...mainBuilds, ...nonNPCSubstituteBuilds];
 }
 
+function getIdenticalBuildIdxs(buildInfo: GraphicBuildInfo[]) {
+    const identicalTo: number[] = [-1,-1];
+    for (let i=2; i<buildInfo.length; i++) {
+        const matchedIdx = buildInfo.slice(0,i).findIndex((b) => b.raider.isIdenticalBuild(buildInfo[i].raider))
+        identicalTo.push!(matchedIdx);
+    }
+    return identicalTo;
+}
+
+function addBuildCopies(buildInfo: GraphicBuildInfo[]) {
+    for (let i=2; i<buildInfo.length; i++) {
+        for (let j=1; j<i; j++) {
+            console.log(i,j)
+            if (buildInfo[i].raider.isIdenticalBuild(buildInfo[j].raider)) {
+                console.log("match")
+                if (!buildInfo[j].extraBuildInfo.copies) {
+                    buildInfo[j].extraBuildInfo.copies = 2;
+                } else {
+                    buildInfo[j].extraBuildInfo.copies! += 1;
+                }
+                break;
+            }
+        }
+    }
+}
+
 function getBuildUniqueness(buildInfo: GraphicBuildInfo[]) {
     const uniqueRaiderIdxs: number[] = [];
     for (let i=0; i < buildInfo.length; i++) {
@@ -1112,7 +1192,7 @@ function GraphicsButton({title, notes, credits, raidInputProps, substitutes, res
     const handleDownload = async () => {
         setLoading(true);
         try {
-            const includedRaidPokemonBuildInfo = processBuildsInfo(buildInfo, pokemonDataMatrix, buildsOrder, buildsEnabled);
+            const includedRaidPokemonBuildInfo = processBuildsInfo(buildInfo, buildsOrder, buildsEnabled);
 
             // sort moves into groups
             const [turnGroups, turnNumbers] = getTurnGroups(raidInputProps.groups, results);
@@ -1292,21 +1372,20 @@ function GraphicsButton({title, notes, credits, raidInputProps, substitutes, res
     }
 
 
-    function processBuildsInfo(buildInfo: GraphicBuildInfo[][], pokemonDataMatrix: PokemonData[][], buildsOrder: number[], buildsEnabled: boolean[]): GraphicBuildInfo[] {
+    function processBuildsInfo(buildInfo: GraphicBuildInfo[][], buildsOrder: number[], buildsEnabled: boolean[], checkForCopies = true): GraphicBuildInfo[] {
         const flatBuildInfo = getRelevantBuilds(buildInfo);
         const buildsOnlyBuildInfo: GraphicBuildInfo[] = [];
 
-        const displayOrder: number[] = [];
-        for (const [index, slot_index] of buildsOrder.entries()) {
-            if (buildsEnabled[index]) {
-                displayOrder.push(slot_index);
-            }
-        }
+        // check for repeated builds
+        if (checkForCopies) { addBuildCopies(flatBuildInfo); }
+        const buildIsUnique = getBuildUniqueness(flatBuildInfo);
 
         // This adds builds according to the order selected via the drag and drop
         // (doesn't really make use of the slots/matrix setup)
-        for (const idx of displayOrder) {
-            buildsOnlyBuildInfo.push(flatBuildInfo[idx]);
+        for (const [index, slot_index] of buildsOrder.entries()) {
+            if (buildsEnabled[index] && (!checkForCopies || buildIsUnique[slot_index])) {
+                buildsOnlyBuildInfo.push(flatBuildInfo[slot_index]);            
+            }
         }
 
         // Add "required" moves from builds that are not enabled if they're identical with an added build

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -668,7 +668,7 @@ function getMoveMethodIcon(moveMethod: string, moveType: TypeName) {
 }
 
 // TODO: move this to a more appropriate place (also used in MoveDisplay)
-function getTurnGroups(groups: TurnGroupInfo[], results: RaidBattleResults): [{id: number, move: string, info: RaidMoveInfo, isSpread: boolean, repeats: number, teraActivated: boolean, raiderIDs: number[]}[][][], number[]] {
+function getTurnGroups(groups: TurnGroupInfo[], results: RaidBattleResults, checkForCopies: boolean): [{id: number, move: string, info: RaidMoveInfo, isSpread: boolean, repeats: number, teraActivated: boolean, raiderIDs: number[]}[][][], number[]] {
     const raiders = results.turnZeroState.raiders;
     const [turnGroups, turnNumbers] = sortGroupsIntoTurns(getTurnNumbersFromGroups(groups), groups);
     const tempTurnGroups = turnGroups.map(groups => groups.map((group, groupIndex) => 
@@ -693,7 +693,7 @@ function getTurnGroups(groups: TurnGroupInfo[], results: RaidBattleResults): [{i
             } 
         })
     ));
-    const preparedTurnGroups = tempTurnGroups.map(tg => 
+    const preparedTurnGroups = !checkForCopies ? tempTurnGroups : tempTurnGroups.map(tg => 
         tg.map(g => {
             const turns = [g[0]];
             for (let i=1; i<g.length; i++) {
@@ -1136,6 +1136,7 @@ function GraphicsButton({title, notes, credits, raidInputProps, substitutes, res
     // const [plotsEnabled, setPlotsEnable] = useState<boolean[]>([false, false, false, false]);
     const [statDisplay, setStatDisplay] = useState<string>("None");
     // const [plotsEnabled, setPlotsEnable] = useState<boolean>(false);
+    const [checkForCopies, setCheckForCopies] = useState(true);
     const [buildInfo, setBuildInfo] = useState([] as GraphicBuildInfo[][]);
     // const [pokemonDataMatrix, setPokemonDataMatrix] = useState([] as PokemonData[][]);
     const [buildsOnly, setBuildsOnly] = useState<boolean>(false);
@@ -1186,7 +1187,7 @@ function GraphicsButton({title, notes, credits, raidInputProps, substitutes, res
             const includedRaidPokemonBuildInfo = processBuildsInfo(buildInfo, buildsOrder, buildsEnabled);
 
             // sort moves into groups
-            const [turnGroups, turnNumbers] = getTurnGroups(raidInputProps.groups, results);
+            const [turnGroups, turnNumbers] = getTurnGroups(raidInputProps.groups, results, checkForCopies);
 
             let statDisplayElements: JSX.Element[] = []
             if (statDisplay === "Stat Plot") {
@@ -1363,7 +1364,7 @@ function GraphicsButton({title, notes, credits, raidInputProps, substitutes, res
     }
 
 
-    function processBuildsInfo(buildInfo: GraphicBuildInfo[][], buildsOrder: number[], buildsEnabled: boolean[], checkForCopies = true): GraphicBuildInfo[] {
+    function processBuildsInfo(buildInfo: GraphicBuildInfo[][], buildsOrder: number[], buildsEnabled: boolean[]): GraphicBuildInfo[] {
         const flatBuildInfo = getRelevantBuilds(buildInfo);
         const buildsOnlyBuildInfo: GraphicBuildInfo[] = [];
 
@@ -1568,6 +1569,20 @@ function GraphicsButton({title, notes, credits, raidInputProps, substitutes, res
                                     <MenuItem value="Full Graphic">{getTranslation("Full Graphic", translationKey)}</MenuItem>
                                     <MenuItem value="Builds Only">{getTranslation("Builds Only", translationKey)}</MenuItem>
                                 </Select>
+                            </Stack>
+                        </Box>
+                    </li>
+                    <li>
+                        <Box width="100%" alignItems="center" justifyContent="center" sx={{ px: "12px" }}>
+                            <Stack direction="row" alignItems="center" justifyContent="center">
+                                <Typography variant="body1" fontWeight={600}>
+                                    {getTranslation("Combine Identical Builds", translationKey) + ":"}
+                                </Typography>
+                                <Box flexGrow={2} />
+                                <Switch
+                                    checked={checkForCopies}
+                                    onChange={(e) => setCheckForCopies(!checkForCopies)}
+                                />
                             </Stack>
                         </Box>
                     </li>

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -544,7 +544,7 @@ const ExecutionMovePokemonIcon = styled("img")({
 
 const ExecutionMovePokemonIconWrapper = styled(Stack)({
     height: "140px",
-    width: "140px",
+    width: "245px",
     marginRight: "15px",
     display: "flex",
     alignItems: "center",
@@ -1087,15 +1087,6 @@ function getRelevantBuilds(buildInfo: GraphicBuildInfo[][]) {
     return [...mainBuilds, ...nonNPCSubstituteBuilds];
 }
 
-function getIdenticalBuildIdxs(buildInfo: GraphicBuildInfo[]) {
-    const identicalTo: number[] = [-1,-1];
-    for (let i=2; i<buildInfo.length; i++) {
-        const matchedIdx = buildInfo.slice(0,i).findIndex((b) => b.raider.isIdenticalBuild(buildInfo[i].raider))
-        identicalTo.push!(matchedIdx);
-    }
-    return identicalTo;
-}
-
 function addBuildCopies(buildInfo: GraphicBuildInfo[]) {
     for (let i=2; i<buildInfo.length; i++) {
         for (let j=1; j<i; j++) {
@@ -1146,7 +1137,7 @@ function GraphicsButton({title, notes, credits, raidInputProps, substitutes, res
     const [statDisplay, setStatDisplay] = useState<string>("None");
     // const [plotsEnabled, setPlotsEnable] = useState<boolean>(false);
     const [buildInfo, setBuildInfo] = useState([] as GraphicBuildInfo[][]);
-    const [pokemonDataMatrix, setPokemonDataMatrix] = useState([] as PokemonData[][]);
+    // const [pokemonDataMatrix, setPokemonDataMatrix] = useState([] as PokemonData[][]);
     const [buildsOnly, setBuildsOnly] = useState<boolean>(false);
     const [buildsOrder, setBuildsOrder] = useState<number[]>([]);
     const [buildsEnabled, setBuildsEnabled] = useState<boolean[]>([]);
@@ -1182,7 +1173,7 @@ function GraphicsButton({title, notes, credits, raidInputProps, substitutes, res
             // contains all the extra info needed for extra elements on the graphics, ability patch icon, learn method icons, move type icons, optional move boolean
             const extraBuildInfoMatrix = createExtraBuildInfoMatrix(isHiddenAbilityMatrix, learnMethodMatrix, moveTypeMatrix, optionalMoveMatrix);
             const bInfo = zipBuildInfo(allRaidPokemonMatrix, extraBuildInfoMatrix);
-            setPokemonDataMatrix(pDataMatrix);
+            // setPokemonDataMatrix(pDataMatrix);
             setBuildInfo(bInfo);
         } catch (e) {
             console.log(e);

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -1090,9 +1090,7 @@ function getRelevantBuilds(buildInfo: GraphicBuildInfo[][]) {
 function addBuildCopies(buildInfo: GraphicBuildInfo[]) {
     for (let i=2; i<buildInfo.length; i++) {
         for (let j=1; j<i; j++) {
-            console.log(i,j)
             if (buildInfo[i].raider.isIdenticalBuild(buildInfo[j].raider)) {
-                console.log("match")
                 if (!buildInfo[j].extraBuildInfo.copies) {
                     buildInfo[j].extraBuildInfo.copies = 2;
                 } else {

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -767,7 +767,7 @@ function generateGraphic(theme: any, buildsOnly: boolean, buildInfo: GraphicBuil
                                                 <BuildArtWrapper direction="row-reverse" spacing={`${hSpacing}px`}>
                                                     {
                                                         [...Array(copies || 1).keys()].map(i =>
-                                                            <BuildArt src={getPokemonArtURL(info.raider.species.name, info.raider.shiny)} sx={{ transform: `translate(0px, ${vSpacing * (i - (copies || 1))}px)` }}/>
+                                                            <BuildArt src={getPokemonArtURL(info.raider.species.name, info.raider.shiny)} sx={{ transform: `translate(0px, ${vSpacing * (i - (copies) + 1)}px)` }}/>
                                                         )
                                                     }
                                                 </BuildArtWrapper>

--- a/src/uicomponents/GraphicsButton.tsx
+++ b/src/uicomponents/GraphicsButton.tsx
@@ -757,17 +757,19 @@ function generateGraphic(theme: any, buildsOnly: boolean, buildInfo: GraphicBuil
                         <BuildsContainer>    
                             {
                                 buildInfo.slice(1, buildsCount + 1).map((info, index) => {
-                                  const copies = info.extraBuildInfo.copies || 1;
-                                  const hSpacing = -120 / (Math.max(copies,2) - 1) - 375;
-                                  const vSpacing = 42 / (Math.max(copies,2) - 1);
+                                  const shiny = info.extraBuildInfo.copiesShiny || [!!info.raider.shiny];
+                                  const numcopies = shiny.length;
+                                  const hArtSpacing = -120 / (Math.max(numcopies,2) - 1) - 375;
+                                  const vArtSpacing = 42 / (Math.max(numcopies,2) - 1);
+                                  const role = numcopies > 1 ? `${info.extraBuildInfo.copiesRole} ×${numcopies}` : info.raider.role;
                                   return (
                                     <BuildWrapper key={index}>
                                         <Build>
                                             <BuildHeader>
-                                                <BuildArtWrapper direction="row-reverse" spacing={`${hSpacing}px`}>
+                                                <BuildArtWrapper direction="row-reverse" spacing={`${hArtSpacing}px`}>
                                                     {
-                                                        [...Array(copies || 1).keys()].map(i =>
-                                                            <BuildArt src={getPokemonArtURL(info.raider.species.name, info.raider.shiny)} sx={{ transform: `translate(0px, ${vSpacing * (i - (copies) + 1)}px)` }}/>
+                                                        shiny.map((c,i) =>
+                                                            <BuildArt src={getPokemonArtURL(info.raider.species.name, shiny[i])} sx={{ transform: `translate(0px, ${vArtSpacing * (i - (numcopies) + 1)}px)` }}/>
                                                         )
                                                     }
                                                 </BuildArtWrapper>
@@ -781,7 +783,7 @@ function generateGraphic(theme: any, buildsOnly: boolean, buildInfo: GraphicBuil
                                                     ))}
                                                     {info.raider.types.length === 1 && <BuildTypeIcon key={1} src={getTypeIconURL("none")}/>}
                                                 </BuildTypes>
-                                                <BuildRole>{copies > 1 ? `${getTranslation(info.raider.name, translationKey, "pokemon")}  ×${copies}` : info.raider.role}</BuildRole>
+                                                <BuildRole>{role}</BuildRole>
                                                 { info.extraBuildInfo.subFor &&
                                                     <BuildSubstituteSubtitle>Substitute for {info.extraBuildInfo.subFor}</BuildSubstituteSubtitle>
                                                 }
@@ -892,6 +894,15 @@ function generateGraphic(theme: any, buildsOnly: boolean, buildInfo: GraphicBuil
                                                                         showTarget = showTarget && (move.move !== "Waits");
                                                                         const turnIndex = results.turnResults.findIndex((t) => t.id === move.id);
                                                                         const turnRaiders = turnIndex > 0 ? results.turnResults[turnIndex-1].state.raiders : results.turnZeroState.raiders;
+                                                                        const raiderIDs = moveGroup[moveIndex].raiderIDs
+                                                                        let role = turnRaiders[move.info.userID].role;
+                                                                        if (raiderIDs.length > 1) {
+                                                                            if (raiderIDs.every(i => turnRaiders[i].role === turnRaiders[raiderIDs[0]].role)) {
+                                                                                role = `${role} ×${raiderIDs.length}`
+                                                                            } else {
+                                                                                role = `${getTranslation(turnRaiders[move.info.userID].name, translationKey, "pokemon")} ×${raiderIDs.length}`;
+                                                                            }
+                                                                        }
                                                                         return ([
                                                                         move.teraActivated ? 
                                                                         <ExecutionMove key={moveIndex - 0.5}>
@@ -919,11 +930,11 @@ function generateGraphic(theme: any, buildsOnly: boolean, buildInfo: GraphicBuil
                                                                                 </ExecutionMovePokemonIconWrapper>
                                                                             </ExecutionMovePokemonWrapperShifted> :
                                                                             <ExecutionMovePokemonWrapper>
-                                                                                <ExecutionMovePokemonName>{moveGroup[moveIndex].raiderIDs.length > 1 ? `${getTranslation(turnRaiders[move.info.userID].name, translationKey, "pokemon")} ×${moveGroup[moveIndex].raiderIDs.length}` : turnRaiders[move.info.userID].role}</ExecutionMovePokemonName>
+                                                                                <ExecutionMovePokemonName>{role}</ExecutionMovePokemonName>
                                                                                 <ExecutionMovePokemonIconWrapper>
                                                                                     <Stack direction="row-reverse" spacing="-175px">
                                                                                         {
-                                                                                            moveGroup[moveIndex].raiderIDs.map(id => 
+                                                                                            raiderIDs.map(id => 
                                                                                                 <ExecutionMovePokemonIcon src={getPokemonSpriteURL(turnRaiders[id].species.name)} />
                                                                                             )
                                                                                         }
@@ -1091,10 +1102,13 @@ function addBuildCopies(buildInfo: GraphicBuildInfo[]) {
     for (let i=2; i<buildInfo.length; i++) {
         for (let j=1; j<i; j++) {
             if (buildInfo[i].raider.isIdenticalBuild(buildInfo[j].raider)) {
-                if (!buildInfo[j].extraBuildInfo.copies) {
-                    buildInfo[j].extraBuildInfo.copies = 2;
-                } else {
-                    buildInfo[j].extraBuildInfo.copies! += 1;
+                if (!buildInfo[j].extraBuildInfo.copiesShiny) {
+                    buildInfo[j].extraBuildInfo.copiesShiny = [!!buildInfo[j].raider.shiny];
+                    buildInfo[j].extraBuildInfo.copiesRole = buildInfo[j].raider.role;
+                }
+                buildInfo[j].extraBuildInfo.copiesShiny?.push(!!buildInfo[i].raider.shiny);
+                if (buildInfo[i].raider.role !== buildInfo[j].extraBuildInfo.copiesRole) {
+                    buildInfo[j].extraBuildInfo.copiesRole = buildInfo[j].raider.name;
                 }
                 break;
             }


### PR DESCRIPTION
Trying to avoid redundant info in graphics by lumping identical builds together.

~~To Do: Add a way to turn off these changes and prevent builds from being lumped together~~ done

<img width="1350" height="1787" alt="double" src="https://github.com/user-attachments/assets/ca82648d-420e-476a-8e64-7eafccb716ee" />

<img width="1350" height="1643" alt="triple" src="https://github.com/user-attachments/assets/b96e9f11-b64b-4623-b945-56307218e138" />

