### PR TITLE
Change implementation of cheer boosts

### DIFF
--- a/src/calc/mechanics/gen789.ts
+++ b/src/calc/mechanics/gen789.ts
@@ -1309,12 +1309,6 @@ export function calculateAttackSMSSSV(
     desc.attackBoost = attackSource.boosts[attackStat];
   }
 
-  // unlike all other attack modifiers, Hustle gets applied directly
-  if (attacker.hasAbility('Hustle') && move.category === 'Physical') {
-    attack = pokeRound((attack * 3) / 2);
-    desc.attackerAbility = attacker.ability;
-  }
-
   const attackerAtkCheerStack = getAtkCheerStack(attacker, field.attackerSide);
   const attackerDefCheerStack = getDefCheerStack(attacker, field.attackerSide);
   const defenderAtkCheerStack = getDefCheerStack(defender, field.defenderSide);
@@ -1329,6 +1323,12 @@ export function calculateAttackSMSSSV(
   if (move.named('Body Press') && attackerDefCheerStack) {
     attack = Math.floor(attack * (1 + attackerDefCheerStack/2));
     desc.isDefCheeredBodyPress = attackerDefCheerStack;
+  }
+
+  // unlike all other attack modifiers, Hustle gets applied directly
+  if (attacker.hasAbility('Hustle') && move.category === 'Physical') {
+    attack = pokeRound((attack * 3) / 2);
+    desc.attackerAbility = attacker.ability;
   }
 
   const atMods = calculateAtModsSMSSSV(gen, attacker, defender, move, field, desc);
@@ -1505,6 +1505,12 @@ export function calculateDefenseSMSSSV(
     desc.defenseBoost = defender.boosts[defenseStat];
   }
 
+  const defenderDefCheerStack = getDefCheerStack(defender, field.defenderSide);
+  if (defenderDefCheerStack){
+    defense = Math.floor(defense * (1 + defenderDefCheerStack/2));
+    desc.isDefCheered = defenderDefCheerStack;
+  }
+
   // unlike all other defense modifiers, Sandstorm SpD boost gets applied directly
   if (field.hasWeather('Sand') && defender.hasType('Rock') && !hitsPhysical) {
     defense = pokeRound((defense * 3) / 2);
@@ -1513,12 +1519,6 @@ export function calculateDefenseSMSSSV(
   if (field.hasWeather('Snow') && defender.hasType('Ice') && hitsPhysical) {
     defense = pokeRound((defense * 3) / 2);
     desc.weather = field.weather;
-  }
-
-  const defenderDefCheerStack = getDefCheerStack(defender, field.defenderSide);
-  if (defenderDefCheerStack){
-    defense = Math.floor(defense * (1 + defenderDefCheerStack/2));
-    desc.isDefCheered = defenderDefCheerStack;
   }
 
   const dfMods = calculateDfModsSMSSSV(

--- a/src/calc/mechanics/gen789.ts
+++ b/src/calc/mechanics/gen789.ts
@@ -44,6 +44,8 @@ import {
   OF16, OF32,
   pokeRound,
   isQPActive,
+  getAtkCheerStack,
+  getDefCheerStack,
 } from './util';
 
 export function calculateSMSSSV(
@@ -371,7 +373,7 @@ export function calculateSMSSSV(
       (move.hasType('Water') && defender.hasAbility('Dry Skin', 'Storm Drain', 'Water Absorb')) ||
       (move.hasType('Electric') &&
         defender.hasAbility('Lightning Rod', 'Motor Drive', 'Volt Absorb')) ||
-      (move.hasType('Ground') && 
+      (move.hasType('Ground') &&
         !isGrounded(defender, field) && !move.named('Thousand Arrows') &&
         defender.hasAbility('Levitate')) ||
       (move.flags.bullet && defender.hasAbility('Bulletproof')) ||
@@ -569,7 +571,7 @@ export function calculateSMSSSV(
   }
 
   // In Raids, stellar moves are always boosted
-  const isStellarBoosted = teraType === 'Stellar'; 
+  const isStellarBoosted = teraType === 'Stellar';
   if (isStellarBoosted) {
     if (attacker.hasOriginalType(move.type)) {
       stabMod += 2048;
@@ -627,7 +629,7 @@ export function calculateSMSSSV(
     let usedWhiteHerb = false;
     let dropCount = attacker.boosts[attackStat];
     for (let times = 0; times < move.timesUsed!; times++) {
-      const newAttack = getModifiedStat(attack, dropCount);
+      const newAttack = getModifiedStat(attack, dropCount, gen);
       let damageMultiplier = 0;
       damage = damage.map(affectedAmount => {
         if (times) {
@@ -674,13 +676,13 @@ export function calculateSMSSSV(
   // Tera Raid Shield
   if (defender.shieldData && defender.shieldActive) {
     // TODO: Handle case when attacker tera and move type do not match
-    let damageCoef = atkTeraType === move.type 
-      ? defender.shieldData.shieldDamageRateTera / 100 
-      : atkTeraType ? 
-        defender.shieldData.shieldDamageRateTeraChange / 100 
+    let damageCoef = atkTeraType === move.type
+      ? defender.shieldData.shieldDamageRateTera / 100
+      : atkTeraType ?
+        defender.shieldData.shieldDamageRateTeraChange / 100
         : defender.shieldData.shieldDamageRate / 100;
     damageCoef = damageCoef || 1;
-    result.damage = result.damage.map((dmg) => typeof(dmg) === "number" 
+    result.damage = result.damage.map((dmg) => typeof(dmg) === "number"
       ? Math.max(dmg > 0 ? 1 : 0, pokeRound(dmg * damageCoef))
       : dmg.map((dmg2) => Math.max(dmg2 > 0 ? 1 : 0, pokeRound(dmg2 * damageCoef))
     )) as number[] | [number[], number[]];
@@ -711,7 +713,7 @@ export function calculateBasePowerSMSSSV(
   if (movesFirst === undefined) {
     turnOrder = attacker.stats.spe > defender.stats.spe ? 'first' : 'last';
     turnOrder = field.isTrickRoom ? (turnOrder === 'first' ? 'last' : 'first') : turnOrder;
-  }  
+  }
 
   let basePower: number;
   const atkTeraType = attacker.isTera ? attacker.teraType : undefined;
@@ -1313,6 +1315,22 @@ export function calculateAttackSMSSSV(
     desc.attackerAbility = attacker.ability;
   }
 
+  const attackerAtkCheerStack = getAtkCheerStack(attacker, field.attackerSide);
+  const attackerDefCheerStack = getDefCheerStack(attacker, field.attackerSide);
+  const defenderAtkCheerStack = getDefCheerStack(defender, field.defenderSide);
+  if (attackerAtkCheerStack && !move.named('Body Press') && !move.named('Foul Play')) {
+    attack = Math.floor(attack * (1 + attackerAtkCheerStack/2));
+    desc.isAtkCheered = attackerAtkCheerStack;
+  }
+  if (move.named('Foul Play') && defenderAtkCheerStack) {
+    attack = Math.floor(attack * (1 + defenderAtkCheerStack/2));
+    desc.isAtkCheered = defenderAtkCheerStack;
+  }
+  if (move.named('Body Press') && attackerDefCheerStack) {
+    attack = Math.floor(attack * (1 + attackerDefCheerStack/2));
+    desc.isDefCheeredBodyPress = attackerDefCheerStack;
+  }
+
   const atMods = calculateAtModsSMSSSV(gen, attacker, defender, move, field, desc);
   attack = OF16(Math.max(1, pokeRound((attack * chainMods(atMods, 410, 131072)) / 4096)));
   return attack;
@@ -1416,8 +1434,8 @@ export function calculateAtModsSMSSSV(
     (isQPActive(attacker, field))
   ) {
     if (
-      (move.category === 'Physical' && getQPBoostedStat(attacker) === 'atk') ||
-      (move.category === 'Special' && getQPBoostedStat(attacker) === 'spa')
+      (move.category === 'Physical' && getQPBoostedStat(attacker, getAtkCheerStack(attacker, field.attackerSide), getDefCheerStack(attacker, field.attackerSide)) === 'atk') ||
+      (move.category === 'Special'  && getQPBoostedStat(attacker, getAtkCheerStack(attacker, field.attackerSide), getDefCheerStack(attacker, field.attackerSide)) === 'spa')
     ) {
       atMods.push(5325);
       desc.attackerAbility = attacker.ability;
@@ -1451,25 +1469,6 @@ export function calculateAtModsSMSSSV(
   ) {
     atMods.push(6144);
     desc.attackerItem = attacker.item;
-  }
-
-  const attackerAtkCheerStack = (field.attackerSide.isAtkCheered ? 1 : 0) + attacker.permanentAtkCheers;
-  const attackerDefCheerStack = (field.attackerSide.isDefCheered ? 1 : 0) + attacker.permanentDefCheers;
-  const defenderAtkCheerStack = (field.defenderSide.isAtkCheered ? 1 : 0) + defender.permanentAtkCheers;
-
-  if (attackerAtkCheerStack && !move.named('Body Press') && !move.named('Foul Play')) {
-    atMods.push(4096 * (1 + attackerAtkCheerStack/2));
-    desc.isAtkCheered = attackerAtkCheerStack;
-  }
-
-  if (move.named('Foul Play') && defenderAtkCheerStack) {
-    atMods.push(4096 * (1 + defenderAtkCheerStack/2));
-    desc.isAtkCheered = defenderAtkCheerStack;
-  }
-
-  if (move.named('Body Press') && attackerDefCheerStack) {
-    atMods.push(4096 * (1 + attackerDefCheerStack/2));
-    desc.isDefCheeredBodyPress = attackerDefCheerStack;
   }
 
   return atMods;
@@ -1514,6 +1513,12 @@ export function calculateDefenseSMSSSV(
   if (field.hasWeather('Snow') && defender.hasType('Ice') && hitsPhysical) {
     defense = pokeRound((defense * 3) / 2);
     desc.weather = field.weather;
+  }
+
+  const defenderDefCheerStack = getDefCheerStack(defender, field.defenderSide);
+  if (defenderDefCheerStack){
+    defense = Math.floor(defense * (1 + defenderDefCheerStack/2));
+    desc.isDefCheered = defenderDefCheerStack;
   }
 
   const dfMods = calculateDfModsSMSSSV(
@@ -1590,8 +1595,8 @@ export function calculateDfModsSMSSSV(
     (isQPActive(defender, field))
   ) {
     if (
-      (hitsPhysical && getQPBoostedStat(defender, !!field.isWonderRoom) === 'def') ||
-      (!hitsPhysical && getQPBoostedStat(defender, !!field.isWonderRoom) === 'spd')
+      (hitsPhysical && getQPBoostedStat(defender, field.defenderSide.isAtkCheered, field.defenderSide.isDefCheered, !!field.isWonderRoom) === 'def') ||
+      (!hitsPhysical && getQPBoostedStat(defender, field.defenderSide.isAtkCheered, field.defenderSide.isDefCheered, !!field.isWonderRoom) === 'spd')
     ) {
       desc.defenderAbility = defender.ability;
       dfMods.push(5324);
@@ -1608,12 +1613,6 @@ export function calculateDfModsSMSSSV(
   ) {
     dfMods.push(8192);
     desc.defenderItem = defender.item;
-  }
-
-  const defenderDefCheerStack = (field.defenderSide.isDefCheered ? 1 : 0) + defender.permanentDefCheers;
-  if (defenderDefCheerStack){
-    dfMods.push(4096 * (1 + defenderDefCheerStack/2));
-    desc.isDefCheered = defenderDefCheerStack;
   }
 
   return dfMods;

--- a/src/calc/mechanics/util.ts
+++ b/src/calc/mechanics/util.ts
@@ -111,7 +111,7 @@ export function getFinalSpeed(gen: Generation, pokemon: Pokemon, field: Field, s
     speedMods.push(6144);
   } else if (pokemon.hasAbility('Slow Start') && pokemon.abilityOn) {
     speedMods.push(2048);
-  } else if (isQPActive(pokemon, field) && getQPBoostedStat(pokemon, !!field.isWonderRoom, gen) === 'spe') {
+  } else if (isQPActive(pokemon, field) && getQPBoostedStat(pokemon, getAtkCheerStack(pokemon, side), getDefCheerStack(pokemon, side), !!field.isWonderRoom, gen) === 'spe') {
     speedMods.push(6144);
   }
 
@@ -130,6 +130,20 @@ export function getFinalSpeed(gen: Generation, pokemon: Pokemon, field: Field, s
 
   speed = Math.min(gen.num <= 2 ? 999 : 10000, speed);
   return Math.max(0, speed);
+}
+
+export function getAtkCheerStack(
+  pokemon: Pokemon,
+  side: Side
+) {
+  return pokemon.permanentAtkCheers + (side.isAtkCheered ? 1 : 0);
+}
+
+export function getDefCheerStack(
+  pokemon: Pokemon,
+  side: Side
+) {
+  return pokemon.permanentDefCheers + (side.isDefCheered ? 1 : 0);
 }
 
 export function getMoveEffectiveness(
@@ -417,6 +431,8 @@ export function getBaseDamage(level: number, basePower: number, attack: number, 
  */
 export function getQPBoostedStat(
   pokemon: Pokemon,
+  atkCheers?: number,
+  defCheers?: number,
   isWonderRoom?: boolean,
   gen?: Generation
 ): StatID {
@@ -428,13 +444,15 @@ export function getQPBoostedStat(
     return pokemon.boostedStat; // override.
   }
   let bestStat: StatID = 'atk';
+  let bestCheers = atkCheers || 0;
   for (const stat of ['def', 'spa', 'spd', 'spe'] as StatID[]) {
+    const cheers = (stat === 'spa') ? (atkCheers || 0) : (stat === 'def' || stat === 'spd') ? (defCheers || 0) : 0
     if (
-      // proto/quark ignore boosts when considering their boost
-      getModifiedStat(pokemon.rawStats[stat]!, pokemon.boosts[stat]!, gen) >
-      getModifiedStat(pokemon.rawStats[bestStat]!, pokemon.boosts[bestStat]!, gen)
+      Math.floor(getModifiedStat(pokemon.rawStats[stat]!, pokemon.boosts[stat]!, gen) * (1 + cheers/2)) >
+      Math.floor(getModifiedStat(pokemon.rawStats[bestStat]!, pokemon.boosts[bestStat]!, gen) * (1 + bestCheers/2))
     ) {
       bestStat = stat;
+      bestCheers = cheers;
     }
   }
   if (isWonderRoom) {

--- a/src/data/strats/primarina/mice_tea_party.json
+++ b/src/data/strats/primarina/mice_tea_party.json
@@ -60,8 +60,8 @@
             "item": "Eviolite",
             "nature": "Brave",
             "evs": {
-                "hp": 0,
-                "atk": 252,
+                "hp": 12,
+                "atk": 244,
                 "def": 0,
                 "spa": 0,
                 "spd": 252,

--- a/src/data/strats/serperior/reflected_strength.json
+++ b/src/data/strats/serperior/reflected_strength.json
@@ -186,7 +186,7 @@
             "item": "Eviolite",
             "nature": "Calm",
             "evs": {
-                "hp": 0,
+                "hp": 4,
                 "atk": 0,
                 "def": 0,
                 "spa": 0,

--- a/src/data/strats/serperior/reflected_strength.json
+++ b/src/data/strats/serperior/reflected_strength.json
@@ -186,7 +186,7 @@
             "item": "Eviolite",
             "nature": "Calm",
             "evs": {
-                "hp": 4,
+                "hp": 252,
                 "atk": 0,
                 "def": 0,
                 "spa": 0,

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -1,6 +1,6 @@
 import { Field, Generations, Pokemon, StatsTable, toID } from "../calc";
 import { Raider } from "./Raider";
-import { getModifiedStat, getQPBoostedStat } from "../calc/mechanics/util";
+import { getAtkCheerStack, getDefCheerStack, getModifiedStat, getQPBoostedStat } from "../calc/mechanics/util";
 import * as State from "./interface";
 import { AbilityName, ItemName, SpeciesName, StatIDExceptHP, StatusName, Terrain, TypeName, Weather } from "../calc/data/interface";
 import persistentAbilities from "../data/persistent_abilities.json"
@@ -46,7 +46,7 @@ export class RaidState implements State.RaidState{
                 pokemon.addDamageRoll(damageRolls); // but we should still record the damage rolls
             }
             return damage > 0;
-        } 
+        }
 
         let substituteHit = false;
         if (pokemon.substitute && !bypassSubstitute) {
@@ -81,16 +81,16 @@ export class RaidState implements State.RaidState{
                 pokemon.abilityOn = true;
                 pokemon.originalCurHP = originalHP; // negate damage from attack
                 pokemon.cumDamageRolls = originalDamageRolls;
-                pokemon.applyDamage(Math.floor(pokemon.maxHP()/8)); // bust disguise, 1/8 max HP damage                
+                pokemon.applyDamage(Math.floor(pokemon.maxHP()/8)); // bust disguise, 1/8 max HP damage
                 if (pokemon.originalCurHP === 0) {
                     this.faint(id);
                 }
                 return true; // don't trigger item use (except for Air Balloon)
             }
             if (pokemon.item === "Focus Sash" || pokemon.hasAbility("Sturdy")) {
-                if (pokemon.originalCurHP <= 0 && originalHP === maxHP) { 
+                if (pokemon.originalCurHP <= 0 && originalHP === maxHP) {
                     pokemon.originalCurHP = 1;
-                    if (pokemon.ability !== "Sturdy") { this.consumeItem(id, pokemon.item!, true, blockSymbiosis); } 
+                    if (pokemon.ability !== "Sturdy") { this.consumeItem(id, pokemon.item!, true, blockSymbiosis); }
                     fainted = false;
                 }
             }
@@ -162,7 +162,7 @@ export class RaidState implements State.RaidState{
                     }
                 }
             }
- 
+
             /// abilities triggered by damage even if the target faints
             if (pokemon.hasAbility("Seed Sower")) {
                 this.applyTerrain("Grassy", pokemon.hasItem("Terrain Extender") ? 8 : 5);
@@ -171,18 +171,18 @@ export class RaidState implements State.RaidState{
             }
 
             /// the rest can be skipped if the target faints
-            if (fainted) { 
-                this.faint(id); 
+            if (fainted) {
+                this.faint(id);
                 if (source !== undefined && this.getPokemon(source).hasAbility("Moxie")) {
                     this.applyStatChange(source, {atk: 1}, true, source);
                 }
-                return true; 
+                return true;
             }
 
             /// Non-super effective items consumed after damage if the target survives
             if ( (!unnerve && !isFixedDamage && pokemon.item === "Chilan Berry" && moveType === "Normal") ||
                  (pokemon.item === "Absorb Bulb" && moveType === "Water") ||
-                 (pokemon.item === "Cell Battery" && moveType === "Electric") || 
+                 (pokemon.item === "Cell Battery" && moveType === "Electric") ||
                  (pokemon.item === "Luminous Moss" && moveType === "Water") ||
                  (pokemon.item === "Snowball" && moveType === "Ice") ||
                  (!unnerve && !isFixedDamage && pokemon.item === "Kee Berry" && moveCategory === "Physical" && !isSheerForceBoosted) ||
@@ -192,7 +192,7 @@ export class RaidState implements State.RaidState{
             }
 
             /// abilities triggered by damage if the target survives
-            if (isCrit && !isFixedDamage && pokemon.hasAbility("Anger Point")) { 
+            if (isCrit && !isFixedDamage && pokemon.hasAbility("Anger Point")) {
                 const boost = {atk: 12};
                 this.applyStatChange(id, boost, true, id);
             } else if ((moveType === "Fire" || moveType === "Water" ) && pokemon.hasAbility("Steam Engine")) {
@@ -276,81 +276,81 @@ export class RaidState implements State.RaidState{
             case "White Herb":
                 for (let stat in pokemon.boosts) {
                     const statId = stat as StatIDExceptHP;
-                    if ((pokemon.boosts[statId] || 0) < 0) { 
-                        pokemon.boosts[statId] = 0; 
+                    if ((pokemon.boosts[statId] || 0) < 0) {
+                        pokemon.boosts[statId] = 0;
                         pokemon.lastConsumedItem = item as ItemName;
                     }
                 }
                 break;
             // Status-Curing Berries
             case "Cheri Berry":
-                if (pokemon.status === "par") { 
+                if (pokemon.status === "par") {
                     pokemon.status = "";
-                    pokemon.lastConsumedItem = item as ItemName; 
-                    pokemon.preventBelch = false;
-                    if (pokemon.hasAbility("Cud Chew")) { pokemon.isCudChew = 2; }
-                    else if (pokemon.hasAbility("Cheek Pouch")) { this.applyDamage(id, Math.ceil(-pokemon.maxHP()/3))}
-                }
-                break;
-            case "Chesto Berry":
-                if (pokemon.status === "slp") { 
-                    pokemon.status = "";
-                    pokemon.isSleep = 0;
-                    pokemon.lastConsumedItem = item as ItemName; 
-                    pokemon.preventBelch = false;
-                    if (pokemon.hasAbility("Cud Chew")) { pokemon.isCudChew = 2; }
-                    else if (pokemon.hasAbility("Cheek Pouch")) { this.applyDamage(id, Math.ceil(-pokemon.maxHP()/3))}
-                }
-                break;
-            case "Pecha Berry":
-                if (pokemon.status === "psn") { 
-                    pokemon.status = "";
-                    pokemon.lastConsumedItem = item as ItemName; 
-                    pokemon.preventBelch = false;
-                    if (pokemon.hasAbility("Cud Chew")) { pokemon.isCudChew = 2; }
-                    else if (pokemon.hasAbility("Cheek Pouch")) { this.applyDamage(id, Math.ceil(-pokemon.maxHP()/3))}
-                }
-                break;
-            case "Rawst Berry":
-                if (pokemon.status === "brn") { 
-                    pokemon.status = "";
-                    pokemon.lastConsumedItem = item as ItemName; 
-                    pokemon.preventBelch = false;
-                    if (pokemon.hasAbility("Cud Chew")) { pokemon.isCudChew = 2; }
-                    else if (pokemon.hasAbility("Cheek Pouch")) { this.applyDamage(id, Math.ceil(-pokemon.maxHP()/3))}
-                }
-                break;
-            case "Aspear Berry":
-                if (pokemon.status === "frz") { 
-                    pokemon.status = "";
-                    pokemon.isFrozen = 0;
-                    pokemon.lastConsumedItem = item as ItemName; 
-                    pokemon.preventBelch = false;
-                    if (pokemon.hasAbility("Cud Chew")) { pokemon.isCudChew = 2; }
-                    else if (pokemon.hasAbility("Cheek Pouch")) { this.applyDamage(id, Math.ceil(-pokemon.maxHP()/3))}
-                }
-                break;
-            case "Lum Berry":
-                if (pokemon.status !== "") { 
-                    pokemon.status = "";
-                    pokemon.isFrozen = 0;
-                    pokemon.isSleep = 0;
-                    pokemon.lastConsumedItem = item as ItemName; 
-                    pokemon.preventBelch = false;
-                    if (pokemon.hasAbility("Cud Chew")) { pokemon.isCudChew = 2; }
-                    else if (pokemon.hasAbility("Cheek Pouch")) { this.applyDamage(id, Math.ceil(-pokemon.maxHP()/3))}
-                }
-                if (pokemon.volatileStatus.includes("confusion")) { 
-                    pokemon.volatileStatus = pokemon.volatileStatus.filter(status => status !== "confusion"); 
                     pokemon.lastConsumedItem = item as ItemName;
                     pokemon.preventBelch = false;
                     if (pokemon.hasAbility("Cud Chew")) { pokemon.isCudChew = 2; }
                     else if (pokemon.hasAbility("Cheek Pouch")) { this.applyDamage(id, Math.ceil(-pokemon.maxHP()/3))}
                 }
                 break;
-            case "Persim Berry": 
-                if (pokemon.volatileStatus.includes("confusion")) { 
-                    pokemon.volatileStatus = pokemon.volatileStatus.filter(status => status !== "confusion"); 
+            case "Chesto Berry":
+                if (pokemon.status === "slp") {
+                    pokemon.status = "";
+                    pokemon.isSleep = 0;
+                    pokemon.lastConsumedItem = item as ItemName;
+                    pokemon.preventBelch = false;
+                    if (pokemon.hasAbility("Cud Chew")) { pokemon.isCudChew = 2; }
+                    else if (pokemon.hasAbility("Cheek Pouch")) { this.applyDamage(id, Math.ceil(-pokemon.maxHP()/3))}
+                }
+                break;
+            case "Pecha Berry":
+                if (pokemon.status === "psn") {
+                    pokemon.status = "";
+                    pokemon.lastConsumedItem = item as ItemName;
+                    pokemon.preventBelch = false;
+                    if (pokemon.hasAbility("Cud Chew")) { pokemon.isCudChew = 2; }
+                    else if (pokemon.hasAbility("Cheek Pouch")) { this.applyDamage(id, Math.ceil(-pokemon.maxHP()/3))}
+                }
+                break;
+            case "Rawst Berry":
+                if (pokemon.status === "brn") {
+                    pokemon.status = "";
+                    pokemon.lastConsumedItem = item as ItemName;
+                    pokemon.preventBelch = false;
+                    if (pokemon.hasAbility("Cud Chew")) { pokemon.isCudChew = 2; }
+                    else if (pokemon.hasAbility("Cheek Pouch")) { this.applyDamage(id, Math.ceil(-pokemon.maxHP()/3))}
+                }
+                break;
+            case "Aspear Berry":
+                if (pokemon.status === "frz") {
+                    pokemon.status = "";
+                    pokemon.isFrozen = 0;
+                    pokemon.lastConsumedItem = item as ItemName;
+                    pokemon.preventBelch = false;
+                    if (pokemon.hasAbility("Cud Chew")) { pokemon.isCudChew = 2; }
+                    else if (pokemon.hasAbility("Cheek Pouch")) { this.applyDamage(id, Math.ceil(-pokemon.maxHP()/3))}
+                }
+                break;
+            case "Lum Berry":
+                if (pokemon.status !== "") {
+                    pokemon.status = "";
+                    pokemon.isFrozen = 0;
+                    pokemon.isSleep = 0;
+                    pokemon.lastConsumedItem = item as ItemName;
+                    pokemon.preventBelch = false;
+                    if (pokemon.hasAbility("Cud Chew")) { pokemon.isCudChew = 2; }
+                    else if (pokemon.hasAbility("Cheek Pouch")) { this.applyDamage(id, Math.ceil(-pokemon.maxHP()/3))}
+                }
+                if (pokemon.volatileStatus.includes("confusion")) {
+                    pokemon.volatileStatus = pokemon.volatileStatus.filter(status => status !== "confusion");
+                    pokemon.lastConsumedItem = item as ItemName;
+                    pokemon.preventBelch = false;
+                    if (pokemon.hasAbility("Cud Chew")) { pokemon.isCudChew = 2; }
+                    else if (pokemon.hasAbility("Cheek Pouch")) { this.applyDamage(id, Math.ceil(-pokemon.maxHP()/3))}
+                }
+                break;
+            case "Persim Berry":
+                if (pokemon.volatileStatus.includes("confusion")) {
+                    pokemon.volatileStatus = pokemon.volatileStatus.filter(status => status !== "confusion");
                     pokemon.lastConsumedItem = item as ItemName;
                     pokemon.preventBelch = false;
                     if (pokemon.hasAbility("Cud Chew")) { pokemon.isCudChew = 2; }
@@ -475,7 +475,7 @@ export class RaidState implements State.RaidState{
                 }
                 break;
             // Terrain Seeds
-            case "Electric Seed": 
+            case "Electric Seed":
             case "Grassy Seed":
                 const gsdiff = this.applyStatChange(id, {def: 1}, true, id);
                 if (gsdiff.def){
@@ -536,8 +536,8 @@ export class RaidState implements State.RaidState{
                 if (pokemon.volatileStatus.length < vslen) {
                     pokemon.lastConsumedItem = item as ItemName;
                 }
-                break;                
-            default: 
+                break;
+            default:
                 pokemon.lastConsumedItem = item as ItemName;
                 break;
         }
@@ -623,8 +623,8 @@ export class RaidState implements State.RaidState{
                     }
                     if (hasPositiveBoost) {
                         const changes = this.applyStatChange(opponentId, positiveDiff, false, id);
-                        if (Object.values(changes).some(val => val > 0) && opponent.item === "Mirror Herb") { 
-                            this.consumeItem(opponentId, opponent.item); 
+                        if (Object.values(changes).some(val => val > 0) && opponent.item === "Mirror Herb") {
+                            this.consumeItem(opponentId, opponent.item);
                         }
                     }
                 }
@@ -639,7 +639,7 @@ export class RaidState implements State.RaidState{
                 diff[statId] = (diff[statId] || 0) + (pokemon.boosts[statId] || 0) - (preWhiteHerbBoosts[statId] || 0);
             }
         }
- 
+
         return diff;
     }
 
@@ -670,7 +670,7 @@ export class RaidState implements State.RaidState{
             if ((status === "psn" || status === "tox") && ((!attackerIgnoresAbility && pokemon.hasAbility("Immunity")) || (sourceAbility !== "Corrosion" && pokemon.hasType("Poison", "Steel")))) { success = false; }
             if ((status === "par" && (pokemon.hasType("Electric") || (!attackerIgnoresAbility && pokemon.hasAbility("Limber"))))) { success = false; }
             if (status === "slp" && !attackerIgnoresAbility && (
-                ["Insomnia", "Vital Spirit"].includes(pokemon.ability as string) || 
+                ["Insomnia", "Vital Spirit"].includes(pokemon.ability as string) ||
                 (id === 0 ? [0] : [1,2,3,4]).map(i => this.getPokemon(i)).some(poke => poke.hasAbility("Sweet Veil"))
             )) { success = false; }
             if (pokemon.field.hasWeather("Sun") && !attackerIgnoresAbility && pokemon.hasAbility("Leaf Guard")) { success = false; }
@@ -690,12 +690,12 @@ export class RaidState implements State.RaidState{
         }
 
         // Status curing berries
-        if ( (pokemon.item === "Cheri Berry" && pokemon.status === "par") || 
+        if ( (pokemon.item === "Cheri Berry" && pokemon.status === "par") ||
              (pokemon.item === "Chesto Berry" && pokemon.status === "slp") ||
              (pokemon.item === "Pecha Berry" && pokemon.status === "psn") ||
              (pokemon.item === "Rawst Berry" && pokemon.status === "brn") ||
              (pokemon.item === "Aspear Berry" && pokemon.status === "frz") ||
-             (pokemon.item === "Lum Berry" && pokemon.status !== "") ) { 
+             (pokemon.item === "Lum Berry" && pokemon.status !== "") ) {
             this.consumeItem(id, pokemon.item, true);
         }
     }
@@ -728,7 +728,7 @@ export class RaidState implements State.RaidState{
             // yawn immunity
             } else if (ailment === "yawn" && !attackerIgnoresAbility && (pokemon.hasAbility("Vital Spirit", "Insomnia") || (pokemon.hasAbility("Leaf Guard") && pokemon.field.hasWeather("Sun")))) {
                 success = false;
-            } 
+            }
 
             if (success) {
                 pokemon.volatileStatus.push!(ailment);
@@ -751,10 +751,10 @@ export class RaidState implements State.RaidState{
         }
 
         // Volatile Status curing berries + Mental Herb
-        if ( (pokemon.hasItem("Persim Berry", "Lum Berry") && pokemon.volatileStatus.includes("confusion")) || 
+        if ( (pokemon.hasItem("Persim Berry", "Lum Berry") && pokemon.volatileStatus.includes("confusion")) ||
              (pokemon.hasItem("Mental Herb") && ["infatuation", "taunt", "encore", "disable", "torment", "heal-block"].includes(ailment)) ) {
             this.consumeItem(id, pokemon.item!, true);
-        } 
+        }
     }
 
     public loseItem(id: number, consumed: boolean = false, blockSymbiosis: boolean = false) {
@@ -786,7 +786,7 @@ export class RaidState implements State.RaidState{
                         fastestSymbId = symbiosisIds[i];
                         fastestSymbPoke = poke;
                         fastestSymbSpeed = speed;
-                    } 
+                    }
                 }
                 // symbiosis item transfer
                 const passedItem = fastestSymbPoke.item!;
@@ -807,7 +807,7 @@ export class RaidState implements State.RaidState{
         // Booster Energy
         if (pokemon.item === "Booster Energy" && pokemon.hasAbility("Protosynthesis", "Quark Drive") && !pokemon.abilityOn) {
             pokemon.abilityOn = true;
-            const statId = getQPBoostedStat(pokemon, !!pokemon.field.isWonderRoom, gen) as StatIDExceptHP;
+            const statId = getQPBoostedStat(pokemon, getAtkCheerStack(pokemon, pokemon.field.attackerSide), getDefCheerStack(pokemon, pokemon.field.attackerSide), !!pokemon.field.isWonderRoom, gen) as StatIDExceptHP;
             pokemon.boostedStat = statId;
             pokemon.usedBoosterEnergy = true;
             this.loseItem(id)
@@ -834,7 +834,7 @@ export class RaidState implements State.RaidState{
             if (pokemon.hasAbility("Quark Drive") && !pokemon.usedBoosterEnergy) {
                 if (pokemon.field.hasTerrain("Electric") && !pokemon.abilityOn) {
                     pokemon.abilityOn = true;
-                    const statId = getQPBoostedStat(pokemon, !!pokemon.field.isWonderRoom, gen) as StatIDExceptHP;
+                    const statId = getQPBoostedStat(pokemon, getAtkCheerStack(pokemon, pokemon.field.attackerSide), getDefCheerStack(pokemon, pokemon.field.attackerSide), !!pokemon.field.isWonderRoom, gen) as StatIDExceptHP;
                     pokemon.boostedStat = statId;
                 } else if (!pokemon.field.hasTerrain("Electric") && pokemon.abilityOn) {
                     pokemon.abilityOn = false;
@@ -866,20 +866,20 @@ export class RaidState implements State.RaidState{
             if (pokemon.hasAbility("Protosynthesis") && !pokemon.usedBoosterEnergy) {
                 if (pokemon.field.hasWeather("Sun") && !pokemon.abilityOn) {
                     pokemon.abilityOn = true;
-                    const statId = getQPBoostedStat(pokemon, !!pokemon.field.isWonderRoom, gen) as StatIDExceptHP;
+                    const statId = getQPBoostedStat(pokemon, getAtkCheerStack(pokemon, pokemon.field.attackerSide), getDefCheerStack(pokemon, pokemon.field.attackerSide), !!pokemon.field.isWonderRoom, gen) as StatIDExceptHP;
                     pokemon.boostedStat = statId;
                 } else if (!pokemon.field.hasWeather("Sun") && pokemon.abilityOn) {
                     pokemon.abilityOn = false;
                     pokemon.boostedStat = undefined;
                     if (pokemon.item === "Booster Energy") { this.receiveItem(id, "Booster Energy" as ItemName); }
-                } 
+                }
             }
             // Ice Face
             if ((weather === "Snow" || weather === "Hail") && pokemon.hasAbility("Ice Face") && pokemon.name.includes("Eiscue") && pokemon.abilityOn) {
                 pokemon.changeForm("Eiscue" as SpeciesName);
                 pokemon.abilityOn = false;
             }
-            
+
         }
     }
 
@@ -950,7 +950,7 @@ export class RaidState implements State.RaidState{
                     flags[id].push("Trace copies " + copiedAbility);
                     break;
                 }
-            } 
+            }
         }
 
         // add relevant effects to the damage rolls
@@ -1101,11 +1101,11 @@ export class RaidState implements State.RaidState{
                 break;
             case "Embody Aspect (Hearthflame)":
                 this.applyStatChange(id, {atk: 1}, true, id);
-                break;           
+                break;
             case "Embody Aspect (Cornerstone)":
                 this.applyStatChange(id, {def: 1}, true, id);
-                break;     
-            case "Protosynthesis": 
+                break;
+            case "Protosynthesis":
             case "Quark Drive":
                 if (pokemon.item === "Booster Energy" && !pokemon.abilityOn) {
                     this.receiveItem(id, "Booster Energy" as ItemName); // consume Booster Energy
@@ -1150,8 +1150,8 @@ export class RaidState implements State.RaidState{
                         if (
                             target.hasItem("Ability Shield") ||
                             (targetAbility === "Neutralizing Gas")
-                        ) { 
-                            continue; 
+                        ) {
+                            continue;
                         }
                         if (!target.abilityNullified) {
                             flags[i].push("Ability suppressed by Neutralizing Gas");
@@ -1162,7 +1162,7 @@ export class RaidState implements State.RaidState{
                 }
                 break;
                         case "Cloud Nine":
-            case "Air Lock": 
+            case "Air Lock":
                 this.applyWeather("Cloud Nine");
                 flags[id].push(ability + " negates the weather");
                 break;
@@ -1340,7 +1340,7 @@ export class RaidState implements State.RaidState{
                     }
                     this.applyTerrain(undefined);
                 }
-            
+
                 break;
             case "Sword of Ruin":
                 if (
@@ -1594,14 +1594,14 @@ export class RaidState implements State.RaidState{
         pokemon.substitute = undefined;
         pokemon.moveData = pokemon.originalMoves || pokemon.moveData;
         pokemon.moves = pokemon.moveData.map(m => m.name);
-        
+
         pokemon.delayedMoveCounter = undefined;
         pokemon.delayedMoveSource = undefined;
-        pokemon.delayedMove = undefined;        
+        pokemon.delayedMove = undefined;
 
         // increment fainted count
         pokemon.timesFainted += 1;
-        
+
         // remove ability effects that are removed upon fainting
         this.removeAbilityFieldEffect(id, ability);
     }
@@ -1616,7 +1616,7 @@ export class RaidState implements State.RaidState{
         // check Neutralizing Gas
         const neutralizingGas = this.raiders.reduce((p, c) => p || c.hasAbility("Neutralizing Gas"), false);
         const nullifiedByGas = neutralizingGas && !pokemon.hasItem("Ability Shield") && ability !== "Neutralizing Gas";
-        if (nullifiedByGas) { 
+        if (nullifiedByGas) {
             pokemon.abilityNullified = -1;
         }
         // add abilites that Take Effect upon switch-in


### PR DESCRIPTION
This moves cheer boosts from `calculateAtModsSMSSSV` and `calculateDfModsSMSSSV` to `calculateAttackSMSSSV` and `calculateDefenseSMSSSV`. It also accounts for cheer boosts in `getQPBoostedStat`.

Looking back on the [research from Anubis](https://twitter.com/Sibuna_Switch/status/1772885083696791811), as well as the fact that Quark Drive and Protosynthesis take cheers into account when choosing the stat to boost, it seems Attack and Defense cheer boosts should be directly applied to the relevant stats before other  mods are applied.

Based on the example values for post-cheer stats from Anubis, it seems like these are always floored.

I haven't done so yet, but I may use the old implementation on Dav's calculator to try to look for a test case where the calculated damage rolls disagree in an obvious way. Low-level mons using multihit moves might do the trick.