### PR TITLE
Add (Random Target) option for scripted moves

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -124,7 +124,7 @@ async function resultsFromLightBuild(strategy: LightBuildInfo, skipMoveCountChec
     result = battle.result();
   }
   if (!skipMoveCountCheck) {
-    let totalTurns = strategy.turns.length; 
+    let totalTurns = strategy.turns.length;
     if (strategy.repeats) {
       totalTurns = strategy.groups!.reduce((a, b, i) => b.length * (strategy.repeats![i] || 1) + a, 0);
     }
@@ -205,7 +205,7 @@ describe('Specific Test Cases', () => {
     const hash: string = "#H4sIAAAAAAAAA8VUUU/bMBD+K5H3skme1NACXd/oAI1JbAx4q/Jgkkvw4trR2anIEP99ZyehTcue1m5KZJ3Pd9/35e7iZ5azGUt/WqMZZ47NFosRZ1osgSXcmzLrjBSloxALqdGZwOYizyF1llxolPJBMWe1Bbw690gCC3DBNJWTRlsfccRZgaauyLs0K7jSuSHzwVh73W9bHG0ceOgUIZOBpDIlLFuRNWrvCUi2U/foMYUrac0g9zorEdYsrNCxk1Rg3fdR/INU0jVkSQfL4CdwfwIrzyDDqmAFyvMCivumgk687ZXXyslKSUCf9+RQXIfTJOFsxWbPjGp6whnr3kVwTDlpvhUyi+YEQQe3UEhQUEqy338z0Vkr7QPjulaKsy8CMxIakk8p+fVJXnrnON566SgejVqARRLsRdLHT3ncKgCM3sXEeoVGR/NaZ6FCP2qBZXSOcuV3nx9NpSCaA6Kv1l+LYZcI8As+nge4s6Jtw67Eo7XEIwq8kTqtMX2UfgwuFI0fyjS6q2nU9lanNe49fa0gql1Z47WsMSn5jkIXNdZk3jXLB2ms9C2dG2NpZqILDVjsp2xz0lVGcwRRviFrspY1IbqvsihUU9V5vjNT7AacaMQeG3otrWteS8bZpZK62NCYdIN/zLuUsJu0wvwPQ6piOgvuMc+FstCtbOmb8NJLGeaMKOvNHPEUcvqsY5qlAe9mKamhf0DZC/N4yNyWhrp1SM6TLc6N/+2wZZ4MibfmYnJQ7uP/9dGnQ+L+Qjsw63TIunNx0cgfkv7Tv652Em6Sl98TYWNjswgAAA==";
     const build = deserialize(hash) as LightBuildInfo;
     build.pokemon[0].bossMultiplier = 1000; // ensure the boss isn't KOd early and mess up move counts
-    const result = await resultsFromLightBuild(build); 
+    const result = await resultsFromLightBuild(build);
     // T1 Electric terrain -> QP boost is spe, hasn't used booster
     expect(result.turnResults[0].state.raiders[1].abilityOn).toEqual(true);
     expect(result.turnResults[0].state.raiders[1].boostedStat).toEqual("spe");
@@ -336,7 +336,7 @@ describe('Specific Test Cases', () => {
     expect(result.turnResults[4].state.raiders[1].originalCurHP).toEqual(0); // KO
   })
   test('most_damaging', async() => {
-    const hash = "#H4sIAAAAAAAAA8VUwW7bMAz9FYOnDdAhcZI2yy1rN6zAvMPaXWb4oNh0okWWDEnOEhT591GyjbRbAhTLssIGQVF8fI8S7UcoYQb5D6sVMHAwS9MBA8UrhIx5VxSdkxvhKMVirlXBze5DWWLuLIWMltInDRk0Fs3dra/EzRJdcHXthFbWZ8QMlkY3NUUrvcE7VWpyF9rapF+2dZR26EvnBgsRSGq9xqoV2RjlI6GS7dStfE3u1mQLLL3OmgdbBIsdO0lF6Pqj/IWQwu3IEw6rEKfifgc3nkEEK3GD0vOi4Q+7GjvxtlfeSCdqKdB43NYZnoTdLGOwgdkj0JleMYDuTUNgykhzgj+ht2++6GjeynkLTDVSMvjErRcXANcE6J94Emf7Pjwa/vbS1nAwaEuk8JGvMXpAbrzc97rYRfeS+1bnaASX0Tz3/cyFiW4aRx3SOXl0mvUMUzb0ShrlQoMH77hiUxxTPHip3j/Z6dISvlRY0RXBc/8/KRgxuM93bhW6PnjH2G+4wbKR/5Z/zOBbtTAYhv/gPeeH71pX0WcMX8ZXlHyLxTkyqFGDmK+ezEPWze6EdUlhNW6V+JknGUPaC+ERK7m02FmohAKqsD9gEm1ddMsrvhRqScgBYTukMw22Biq+DbgeOaGsU9zxxbnjk9yji3OPTnKPL849Pf++n/6HXkr77hXH7Or8q/6blq9fYcKy8HXvfwEyTpKzCggAAA==";  
+    const hash = "#H4sIAAAAAAAAA8VUwW7bMAz9FYOnDdAhcZI2yy1rN6zAvMPaXWb4oNh0okWWDEnOEhT591GyjbRbAhTLssIGQVF8fI8S7UcoYQb5D6sVMHAwS9MBA8UrhIx5VxSdkxvhKMVirlXBze5DWWLuLIWMltInDRk0Fs3dra/EzRJdcHXthFbWZ8QMlkY3NUUrvcE7VWpyF9rapF+2dZR26EvnBgsRSGq9xqoV2RjlI6GS7dStfE3u1mQLLL3OmgdbBIsdO0lF6Pqj/IWQwu3IEw6rEKfifgc3nkEEK3GD0vOi4Q+7GjvxtlfeSCdqKdB43NYZnoTdLGOwgdkj0JleMYDuTUNgykhzgj+ht2++6GjeynkLTDVSMvjErRcXANcE6J94Emf7Pjwa/vbS1nAwaEuk8JGvMXpAbrzc97rYRfeS+1bnaASX0Tz3/cyFiW4aRx3SOXl0mvUMUzb0ShrlQoMH77hiUxxTPHip3j/Z6dISvlRY0RXBc/8/KRgxuM93bhW6PnjH2G+4wbKR/5Z/zOBbtTAYhv/gPeeH71pX0WcMX8ZXlHyLxTkyqFGDmK+ezEPWze6EdUlhNW6V+JknGUPaC+ERK7m02FmohAKqsD9gEm1ddMsrvhRqScgBYTukMw22Biq+DbgeOaGsU9zxxbnjk9yji3OPTnKPL849Pf++n/6HXkr77hXH7Or8q/6blq9fYcKy8HXvfwEyTpKzCggAAA==";
     const result = await resultsFromHash(hash);
     // T1 Haunter is damaged most by Aerial Ace (Immune to Body Slam, SpD > Def)
     expect(result.turnResults[0].results[0].desc[1].includes("Aerial Ace")).toEqual(true);
@@ -407,7 +407,7 @@ describe('Specific Test Cases', () => {
     // T1: Annihilape has attacked 1 time, can't activate Tera
     expect(result.turnResults[0].state.raiders[1].teraCharge).toEqual(1);
     expect(result.turnResults[0].state.raiders[1].isTera).toEqual(false);
-    expect(result.turnResults[0].flags[1].length).toEqual(0); // No flag for tera activation 
+    expect(result.turnResults[0].flags[1].length).toEqual(0); // No flag for tera activation
     expect(result.turnResults[0].results[1].desc.includes("Tera Ghost")).toEqual(false); // No Tera in the desc
     // T2: Annihilape has attacked 2 times, can't activate Tera
     expect(result.turnResults[1].state.raiders[1].teraCharge).toEqual(2);
@@ -437,7 +437,7 @@ describe('Specific Test Cases', () => {
     // T2: Seed Sower activates, Grassy Seed consumed
     expect(result.turnResults[1].results[0].flags[3].includes("Grassy Seed lost")).toEqual(true);
     expect(result.turnResults[1].state.raiders[3].item).toEqual(undefined);
-    
+
   })
   test('multi-hit-weak-armor', async() => {
     const hash = "#H4sIAAAAAAAAA61US2/bMAz+K4ZOG+BDnt3aW9quWLelKJoOOwQ5qBZjq5ZFQ5KTGkX/+yhFzqPo1gwYEsgkRZEfP1J6Zkt2xrJHi5qlzLGz+byXMs0rYIvUi1J4oZ+yxoK5vvRO3OTggoi1k6it9xikLDfY1GStcAXXeokkPqC1007dBMyMdLRjIUMtuGm/LJeQOUsmg0rRp5DORt/Ch+OupFXA0p+qeVhFWGHrdm9knoPx6GQFO80WEpS44DoDdckrnsPWuFHvuHvLdA+G/8F8UXCdQyRFowMPPTMgZCiixhKqDZmN0d4SaAn1QQ3cdWxRtT5zoDpk0q0v9kEq6bwkHVRhn+J4D1j5GDKsClbgqXKE576tIZJuO8Yb5WStZKAAnpzh07jbFeQ4WyxStmJnz4x6/jllLP7nwXCaEq13XIrknOLRxhTWbk0dXXJlIWU/tQazory6UYp2UYClroazJ3R2+1u8dMZh/9Wftvo9SnNr26yQGaX2onVGlr6grZnNCi5wnZzzMB6TxvBkVhdgfBOGYwoxZzfcuja5VehHa5J3HMYYCfXNcKnJP4D5dIiww3iaUke/G8QShQzN2Vdi5RNqvkluUWqf6qJAmQFB034iv9EAt3ssDMaDmIWk95kIXBIJuKYMNMM14fX2+XuwB74/uLYZN1xw9kqLwD/cYDLZTNdHcrnCrLHJjNuClK/ciPbf2zc86TBfqQ50Vh6Lekj9QeWA7pb0w3OoRdS/gJfJxFRo/hPmPaJnpVQqma350USPaBgd6kekqx0u14H2NtE/kAsQySXNiZ9NQY+J3l0VPyK7MTke+x1mZXKuaOzfw76IV3oUTEEk5vdqp0ZE+ziWEAup6Mak/V39dOzDFK1LwoModU7l9ejOxLPONLBZWMWf6OQmfTw8Isf+Ns4e/HT0t/Tjw/RErX/KjktMlc97/p1ehMeaPi8vvwHUuEnv8AYAAA==";
@@ -507,7 +507,7 @@ describe('Specific Test Cases', () => {
     // T3: Meowscarada faints
     expect(result.turnResults[2].state.raiders[1].originalCurHP).toEqual(0);
     expect(result.turnResults[2].state.raiders[1].abilityOn).toEqual(false); // ability resets
-    expect(result.turnResults[2].results[1].flags[1].includes("Meowscarada fainted!")).toEqual(true);
+    expect(result.turnResults[2].results[0].flags[1].includes("Meowscarada fainted!")).toEqual(true);
     // T4: Meowscarada switches in, Protean activates (flying)
     expect(result.turnResults[3].state.raiders[1].abilityOn).toEqual(true);
     expect(result.turnResults[3].state.raiders[1].types[0]).toEqual("Flying");
@@ -612,9 +612,9 @@ describe('Specific Test Cases', () => {
     expect(result.turnResults[2].state.raiders[0].isTaunt).toBeGreaterThan(0);
     expect(result.turnResults[2].results[1].flags[0][0]).toEqual(" fell for the taunt!");
     // T4: taunt doesn't effect special actions
-    expect(result.turnResults[3].results[1].desc[1]).toEqual("The Raid Boss nullified all stat boosts and abilities!");
+    expect(result.turnResults[3].results[0].desc[1]).toEqual("The Raid Boss nullified all stat boosts and abilities!");
     // T5: taunt prevents use of Bulk Up
-    expect(result.turnResults[4].results[1].desc[0]).toEqual("Decidueye-Hisui can't use status moves due to Taunt!");
+    expect(result.turnResults[4].results[0].desc[0]).toEqual("Decidueye-Hisui can't use status moves due to Taunt!");
   })
   test('friendguard-counters', async() => {
     const hash = "#H4sIAAAAAAAAA8VWW0/bMBT+K5GfQLK0phegvEEZjGndEGXaQ5UHNzlNvTp2ZjuFDvHfd+w4bTbtAgI6JXWPj8/lOxef9p7MyTFJvxolCSWWHE+nHUokK4Ak1JE8c0RMSWVAX545IaZzsJ5UpeVKGifRpSTXqiqRW6gVXMq5QnKmjBk329pgqrnFEwOpkhnT67fzOaTWIEsrIfBrwa0JsgtnjtklrhnMnVbJ/Jr5FTZiN5rnOWiHjhew3ZkFB5GNmExBnLGC5bBh1ttrZn/HugHN/sAeLZjMISRFKgsOeqoh4z6IUi2hqJNZaek4Pi0+PiiBeSFTzYzltnLKde4wdofDJ977lWsX+owLbh3FLRT+HK06CVg5O9yvAlbgEmcR3c26hFAC0+S/EpaXgvuEwJ3VbBxOm/AsI0lCyYoc3xPsgCNKSHinnjGkmORRZTnMhQOzJedMGKBk76OKTmqs+4TKSghK3jGdoYQ3cIAGNk/y0DB78S8vHsXdWn9KTmZG6Rm6O2dcr6MvXLqqT2wlo0mpfBYmtwA2mqQgLeZx0OmgGtZHF7jzPg5/dty4HlKs3RhLli6YS+uWDAFdYZajK3Xrcva8cBBTiGey5EJEk1vmmvq0Esvoc4k4ncT0X3C7LlYmlCVbIkD9wL9VPIs+qe/wclgvmLEaa5r66/8oiD1KzkCUC3VHWlQAeSrYS8K7xtsSXQnmmvEkr+/II2H2KXmP00Gsy2ruJkp7E8Ceaw4yiy4qxPlymJu+/CvKJNy4vmd5srdtFuzawBwErAFxwXHgxNswUae5PR1UCipWV1AvpGBYm7h2GXT6KBhv1N2NdmNi/0lORwKYjk6VMtZEb8JI4G7WPAFGH7v9OZHvjdF95Ic2l/n+k3x3W77rgtH+bjwPW56blsY7tRPfPXz+V8YHmODGTntCxg3/dd0ftNzvtuCHGHpjpzXPelsLr+n9qOV9t3HHHUx6Y6j9O4MXoLcTAHELwK7aHQf7tOP+M+LHjZkhfvfwM6AHuB7SI3eGduLE/7FsPU4zoc2bJA8PPwBwl796tAsAAA==";
@@ -785,7 +785,7 @@ describe('Specific Test Cases', () => {
     build.pokemon[0].bossMultiplier = 1000; // ensure the boss isn't KOd early and mess up move counts
     build.turns[8].bossMoveInfo.name = "(No Move)";
     build.turns[9].bossMoveInfo.name = "(No Move)";
-    const result = await resultsFromLightBuild(build);     
+    const result = await resultsFromLightBuild(build);
     // T2: Spit-Up should not do any damage
     expect(result.turnResults[1].state.raiders[1].stockpile).toEqual(0);
     expect(result.turnResults[1].results[0].state.raiders[0].originalCurHP).toEqual(Math.floor(result.endState.raiders[0].maxHP()));
@@ -912,7 +912,7 @@ describe('Specific Test Cases', () => {
     expect(result.turnResults[6].results[0].desc[0].includes("does not affect")).toEqual(true);
     // T7: Toedscruel moves first with Mud-Slap, which works normally
     expect(result.turnResults[7].raiderMovesFirst).toEqual(true);
-    expect(result.turnResults[7].state.raiders[0].boosts.acc).toEqual(-1); 
+    expect(result.turnResults[7].state.raiders[0].boosts.acc).toEqual(-1);
   })
   test('multistrike-symbiosis', async() => {
     const hash = "#H4sIAAAAAAAAA9VVUU/bMBD+K5GfNskPbUPH4I1SGEiAEO3EQ5QHN7kmXh07s51u1cTD/t9+1O6cNFDEEGzSpsmJcz6f77777pJ8Y0t2yLJPzmjGmWeHSTLgTIsKWMpJlDkJQ84aB/Z8SkbCFuCDaGovjXZkMeKssKapUVuZNZzrpUFxYZy73C5bh5mVHnccZEbnwm5OlkvIvEOVNUrho5TedbYluRN+hXMOSzpVizDnYYbebG5lUYAldLKC+5UrJaj8WOgM1FRUooBe2S5vhH9KNQcrfqE+LoUuoCNFGw8EPbOQy5BEbVZQtWQ2VpMm0BLygxpEMHLNwnnpGzrccoe5E45AfIirN/iU7khvLmANxItYSCV9UHuogjGGIHNYk1MZZtVZF6DzlhDEPN/U0BXGbavSKC9rJYMNfPVWXHa726S9YGnK2ZodfmPYF+85Y92VBMUBR+pvhMyjCfrDjVkG2A+Ux1IoB93MPupFY3NASnSjFGdnwlEWwcc79NGP9G6rjIePLtwaDjDcJYaZWlEQwQm7ALGMJkrklNzEglhJXUSzLzJk29pFUyo+LudlQ4xE143OSmQ9HqPDzsfMG0uMngjry8+NWFF9A5Z9vj/g+2M+HvDRgOQYYW6BHnBsgSNbCaxw6KwH8g4Fp0q4MjqVoVq3iFODc9G1UTKjek6MyntCRuMRktHOLyPlqmM2ScM66aHvcHsPGtvttim8lfSG9tIO4A/GACG7lTlEFxD6eAfl68rWI2T4atYKoqlcE8UvghsH/hbw4zvd7NFqB/ZsUy2kcdI9SfOZsPnvNt7pKzne+59Ap90bvRdUQUTSH5YKe2bYbox3wYt1wXh8nzmee3NlIvqWvGXo7JlTwxC6O7eHlsN/FTp+EPoMhIqOS6DvYozjeR9/GnmE4y8njcVOBuHvFdOvJw0iDtKnfHul6d3dT+zSthwcCAAA"
@@ -943,7 +943,7 @@ describe('Specific Test Cases', () => {
     expect(result.turnResults[3].results[0].state.raiders[1].boosts.def).toEqual(-1); // White Herb removes -2, Weak Armor applies -1
     // T4: Psych Up copies boosts, White Herb removes debuffs
     expect(result.turnResults[4].results[0].state.raiders[4].boosts.spe).toEqual(6);
-    expect (result.turnResults[4].results[0].state.raiders[4].boosts.def).toEqual(0); 
+    expect (result.turnResults[4].results[0].state.raiders[4].boosts.def).toEqual(0);
   })
   test('white-herb-gooey-npc', async() => {
     const hash = "#H4sIAAAAAAAAA81VTW/bMAz9K4ZOHaCD4zT9unXJ2hRoiqIJ0EPgg2IzjhZZMiQ5XVDkv4+U7aQZVqzbYRts0NQTRfKRtP3KluyKZV+d0Ywzz67m85gzLUpgKSdV5qT0OKsd2LsRGQlbgA+qqbw02pFFwllhTV0hWpoN3OmlQXVhnJt0y8ZhZqXHHQeZ0bmw2y/LJWTeISSUMi8T6Ui3Ril8rKR37bkVuRZ+jTKHJXmoRJB5kLA3m1lZFGApU1nCYeVWElQ+FDoDNRKlKGAPNssn4X8GzcCKd+DhSugC2gJp44FSzyzkMhCqzBrKprC11YSEEgV+UIEIRq5eOC99TYebOiJ3yiM0IcTVW3xKd62397ABqotYSCV9gD2UwRhDkDlsyKkMUrXWBei8KQjmPNtW0DbJdR2qlZeVksEGvnkrJu1uR9oLlqacbdjVK8MZueCMtfc8AJccS39rTB5K1SlLoRy0kkDAhHWtFGdjYXNchLNneDbmveSik+mu2+j3frhx6xIjPbR+5mxkRWF09FhjDIw8rS2NxlTVeQHRZ1MucPVoXsBGzytZYYGTQRzjuSchdTSiWUAsRDvnZzHd/ZgnMT8f8P4g3XWpXHJs8LWsDNW6fR6xm66lUtG91DSfGMpDNAZL0e/KSrrVnmsySJBnI+Nfce3FR2SnOFqQoS82BlVJXURjoWn8ZzJbh5m5qe02mr7IKgwTHZ/v6cWH6y0xHLihgqWQlsbpoB7Ru7ESZyi6rbFv7/cw/gNOt1ZsaJL32RJ+yK6Pto9D1somG29rTOnkwUTXzWvw6TdSOgZ7b1L5YL1O/5uM0vblOw1QULFcXUGxsUkDDo562XZUbArGewdiePJkYpyPwhcOZwsp4Pv4IQ+dj1O07+3dvZ1FhOO/nsy+AP8yGWzSPKYfBH3b0/CnwIvQlHd3mu523wGz2q28iQcAAA==";
@@ -982,7 +982,7 @@ describe('Specific Test Cases', () => {
   })
   test('stomping-tantrum-non-doubled', async() => {
     const hash = "#H4sIAAAAAAAAA8VU32/aMBD+VyI/bZInJRS2ljdGO61aqaqC9oLyYOIjeDh2ZDt0qOr/vjsnobRbu/VpwjrO5/P5++5H7tmajVnxw1vDOAtsvFymnBlRAcs5qUqSknHWeHCX5+QkXAkhqrYOyhpPHgPOSmebGq2V3cGlWVtUV9b7Wb9tAxZOBTzxUFgjhdtfrNdQBI8mobW9mylPurNa499GBd/d21BoEbYoJawpQi2ilFHCwW3hVFmCI6Sqgsed3yjQcipMAfpcVKKEg7Hd3orwJ9MCnHjBPN0IU0KXIGMDEPTCgVSRUG23ULWJbZwhS0xR5Ac1iOjkm5UPKjR0uc0jciccsQjxXbPHf+UnZn8FO6C8iJXSKkRzgCo64xPkDjsKqqLUnXcJRrYJQcyLfQ1dkXxfoUYHVWsVfeBncGLWnfakg2B5ztmOje8Z9sgpZ9fWfJC2WWmg/Me1jGdnHKtwtS+EcbZgx+paaA/cNFpz9g3AJBd7RNLuvwonkU6M8BEjHH75Q288yZ4tPBqOEAk+8kXvlSkRAru1xTaZayWJ5NQ1ptigMimw6IAoqH0WojEBc50N0hRvzIWRPlhXoSk+9YmPUlqDuE5TPkQUPY4zjqWmKyoW6aAdk5tgU7jkxipDnX6DXZCct/38lOZgNOBZ2lPNRqevkyVXYhsfQdzBVjWyThbCBNcQ/HhyEI+Qsam+g7HYJOxIO4Y8xVi2MZJqQoW/2CmLHUYUP1stn0BOO/nX6jwHjJMBXTmUTOa1E9TB863SOpnfCRrwq6YdqJeYnGDAmynrZMsAyQNn765tMmnH4v0buuqpMTvC+zKI4f8EkXdzNoz+UcWk/NYMGKU7HXUIjyUTO5yW7LGtT1rsNPcIHJvxn+72t4fon72KZfBGLDPrQxI/thjoTYgwP8uUvsh5/CxntM95v/L84eEXjaqq6PQGAAA=";
-    const result = await resultsFromHash(hash);  
+    const result = await resultsFromHash(hash);
     // T1: Stomping Tantrum doesn't affect flying type
     expect(result.turnResults[0].results[0].desc[0].includes("does not affect")).toEqual(true);
     // T2-T3: NPC Turns

--- a/src/data/strats/charizard/main.json
+++ b/src/data/strats/charizard/main.json
@@ -8,7 +8,6 @@
             "role": "Charizard",
             "name": "Charizard",
             "shiny": false,
-            "isAnyLevel": false,
             "ability": "Solar Power",
             "nature": "Modest",
             "evs": {
@@ -28,7 +27,7 @@
                 "spe": 31
             },
             "level": 100,
-            "gender": "N",
+            "gender": "M",
             "teraType": "Dragon",
             "moves": [
                 "Dragon Pulse",
@@ -57,7 +56,6 @@
             "role": "Sylveon",
             "name": "Sylveon",
             "shiny": false,
-            "isAnyLevel": false,
             "ability": "Pixilate",
             "item": "Covert Cloak",
             "nature": "Modest",
@@ -84,24 +82,13 @@
                 "Calm Mind",
                 "Draining Kiss",
                 "Fake Tears"
-            ],
-            "bossMultiplier": 100,
-            "extraMoves": [],
-            "shieldData": {
-                "hpTrigger": 0,
-                "timeTrigger": 0,
-                "shieldCancelDamage": 0,
-                "shieldDamageRate": 0,
-                "shieldDamageRateTera": 0,
-                "shieldDamageRateTeraChange": 0
-            }
+            ]
         },
         {
             "id": 2,
             "role": "Pelipper",
             "name": "Pelipper",
             "shiny": false,
-            "isAnyLevel": false,
             "ability": "Drizzle",
             "item": "Sitrus Berry",
             "nature": "Calm",
@@ -127,24 +114,13 @@
                 "Helping Hand",
                 "Rain Dance",
                 "Tailwind"
-            ],
-            "bossMultiplier": 100,
-            "extraMoves": [],
-            "shieldData": {
-                "hpTrigger": 0,
-                "timeTrigger": 0,
-                "shieldCancelDamage": 0,
-                "shieldDamageRate": 0,
-                "shieldDamageRateTera": 0,
-                "shieldDamageRateTeraChange": 0
-            }
+            ]
         },
         {
             "id": 3,
             "role": "Alcremie",
             "name": "Alcremie",
             "shiny": false,
-            "isAnyLevel": false,
             "ability": "(No Ability)",
             "item": "Covert Cloak",
             "nature": "Calm",
@@ -171,24 +147,13 @@
                 "Fake Tears",
                 "Helping Hand",
                 "Light Screen"
-            ],
-            "bossMultiplier": 100,
-            "extraMoves": [],
-            "shieldData": {
-                "hpTrigger": 0,
-                "timeTrigger": 0,
-                "shieldCancelDamage": 0,
-                "shieldDamageRate": 0,
-                "shieldDamageRateTera": 0,
-                "shieldDamageRateTeraChange": 0
-            }
+            ]
         },
         {
             "id": 4,
             "role": "Alcremie",
             "name": "Alcremie",
             "shiny": false,
-            "isAnyLevel": false,
             "ability": "(No Ability)",
             "item": "Covert Cloak",
             "nature": "Calm",
@@ -215,17 +180,7 @@
                 "Fake Tears",
                 "Helping Hand",
                 "Light Screen"
-            ],
-            "bossMultiplier": 100,
-            "extraMoves": [],
-            "shieldData": {
-                "hpTrigger": 0,
-                "timeTrigger": 0,
-                "shieldCancelDamage": 0,
-                "shieldDamageRate": 0,
-                "shieldDamageRateTera": 0,
-                "shieldDamageRateTeraChange": 0
-            }
+            ]
         }
     ],
     "turns": [
@@ -233,25 +188,27 @@
             "id": 0,
             "group": 0,
             "moveInfo": {
-                "name": "(No Move)",
-                "userID": 1,
-                "targetID": 0,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "min",
-                    "hits": 1
-                }
-            },
-            "bossMoveInfo": {
                 "name": "Overheat",
                 "userID": 0,
-                "targetID": 1,
+                "targetID": 5,
                 "options": {
                     "crit": true,
                     "secondaryEffects": true,
                     "roll": "max",
-                    "hits": 10
+                    "hits": 10,
+                    "allowMiss": false
+                }
+            },
+            "bossMoveInfo": {
+                "name": "(No Move)",
+                "userID": 0,
+                "targetID": 0,
+                "options": {
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "roll": "max",
+                    "hits": 10,
+                    "allowMiss": false
                 }
             }
         },
@@ -259,181 +216,27 @@
             "id": 1,
             "group": 0,
             "moveInfo": {
-                "name": "(No Move)",
-                "userID": 1,
-                "targetID": 0,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "min",
-                    "hits": 1
-                }
-            },
-            "bossMoveInfo": {
                 "name": "Remove Negative Effects",
                 "userID": 0,
-                "targetID": 1,
+                "targetID": 0,
                 "options": {
                     "crit": true,
                     "secondaryEffects": true,
                     "roll": "max",
-                    "hits": 10
-                }
-            }
-        },
-        {
-            "id": 2,
-            "group": 0,
-            "moveInfo": {
-                "name": "(No Move)",
-                "userID": 2,
-                "targetID": 0,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "min",
-                    "hits": 1
+                    "hits": 10,
+                    "allowMiss": false
                 }
             },
             "bossMoveInfo": {
-                "name": "Overheat",
-                "userID": 0,
-                "targetID": 1,
-                "options": {
-                    "crit": true,
-                    "secondaryEffects": true,
-                    "roll": "max",
-                    "hits": 10
-                }
-            }
-        },
-        {
-            "id": 3,
-            "group": 0,
-            "moveInfo": {
                 "name": "(No Move)",
-                "userID": 2,
+                "userID": 0,
                 "targetID": 0,
                 "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "min",
-                    "hits": 1
-                }
-            },
-            "bossMoveInfo": {
-                "name": "Remove Negative Effects",
-                "userID": 0,
-                "targetID": 1,
-                "options": {
                     "crit": true,
                     "secondaryEffects": true,
                     "roll": "max",
-                    "hits": 10
-                }
-            }
-        },
-        {
-            "id": 4,
-            "group": 0,
-            "moveInfo": {
-                "name": "(No Move)",
-                "userID": 3,
-                "targetID": 0,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "min",
-                    "hits": 1
-                }
-            },
-            "bossMoveInfo": {
-                "name": "Overheat",
-                "userID": 0,
-                "targetID": 1,
-                "options": {
-                    "crit": true,
-                    "secondaryEffects": true,
-                    "roll": "max",
-                    "hits": 10
-                }
-            }
-        },
-        {
-            "id": 5,
-            "group": 0,
-            "moveInfo": {
-                "name": "(No Move)",
-                "userID": 3,
-                "targetID": 0,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "min",
-                    "hits": 1
-                }
-            },
-            "bossMoveInfo": {
-                "name": "Remove Negative Effects",
-                "userID": 0,
-                "targetID": 1,
-                "options": {
-                    "crit": true,
-                    "secondaryEffects": true,
-                    "roll": "max",
-                    "hits": 10
-                }
-            }
-        },
-        {
-            "id": 6,
-            "group": 0,
-            "moveInfo": {
-                "name": "(No Move)",
-                "userID": 4,
-                "targetID": 0,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "min",
-                    "hits": 1
-                }
-            },
-            "bossMoveInfo": {
-                "name": "Overheat",
-                "userID": 0,
-                "targetID": 1,
-                "options": {
-                    "crit": true,
-                    "secondaryEffects": true,
-                    "roll": "max",
-                    "hits": 10
-                }
-            }
-        },
-        {
-            "id": 7,
-            "group": 0,
-            "moveInfo": {
-                "name": "(No Move)",
-                "userID": 4,
-                "targetID": 0,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "min",
-                    "hits": 1
-                }
-            },
-            "bossMoveInfo": {
-                "name": "Remove Negative Effects",
-                "userID": 0,
-                "targetID": 1,
-                "options": {
-                    "crit": true,
-                    "secondaryEffects": true,
-                    "roll": "max",
-                    "hits": 10
+                    "hits": 10,
+                    "allowMiss": false
                 }
             }
         },
@@ -443,12 +246,13 @@
             "moveInfo": {
                 "name": "Defense Cheer",
                 "userID": 1,
-                "targetID": 0,
+                "targetID": 1,
                 "options": {
                     "crit": false,
                     "secondaryEffects": false,
                     "roll": "min",
-                    "hits": 1
+                    "hits": 1,
+                    "allowMiss": true
                 }
             },
             "bossMoveInfo": {
@@ -459,7 +263,8 @@
                     "crit": true,
                     "secondaryEffects": true,
                     "roll": "max",
-                    "hits": 10
+                    "hits": 10,
+                    "allowMiss": false
                 }
             }
         },
@@ -474,7 +279,8 @@
                     "crit": false,
                     "secondaryEffects": false,
                     "roll": "min",
-                    "hits": 1
+                    "hits": 1,
+                    "allowMiss": true
                 }
             },
             "bossMoveInfo": {
@@ -485,7 +291,8 @@
                     "crit": true,
                     "secondaryEffects": true,
                     "roll": "max",
-                    "hits": 10
+                    "hits": 10,
+                    "allowMiss": false
                 }
             }
         },
@@ -500,7 +307,8 @@
                     "crit": false,
                     "secondaryEffects": false,
                     "roll": "min",
-                    "hits": 1
+                    "hits": 1,
+                    "allowMiss": true
                 }
             },
             "bossMoveInfo": {
@@ -511,7 +319,8 @@
                     "crit": true,
                     "secondaryEffects": true,
                     "roll": "max",
-                    "hits": 10
+                    "hits": 10,
+                    "allowMiss": false
                 }
             }
         },
@@ -526,7 +335,8 @@
                     "crit": false,
                     "secondaryEffects": false,
                     "roll": "min",
-                    "hits": 1
+                    "hits": 1,
+                    "allowMiss": true
                 }
             },
             "bossMoveInfo": {
@@ -537,7 +347,8 @@
                     "crit": true,
                     "secondaryEffects": true,
                     "roll": "max",
-                    "hits": 10
+                    "hits": 10,
+                    "allowMiss": false
                 }
             }
         },
@@ -547,12 +358,13 @@
             "moveInfo": {
                 "name": "Attack Cheer",
                 "userID": 2,
-                "targetID": 1,
+                "targetID": 2,
                 "options": {
                     "crit": false,
                     "secondaryEffects": false,
                     "roll": "min",
-                    "hits": 1
+                    "hits": 1,
+                    "allowMiss": true
                 }
             },
             "bossMoveInfo": {
@@ -563,7 +375,8 @@
                     "crit": true,
                     "secondaryEffects": true,
                     "roll": "max",
-                    "hits": 10
+                    "hits": 10,
+                    "allowMiss": false
                 }
             }
         },
@@ -578,7 +391,8 @@
                     "crit": false,
                     "secondaryEffects": false,
                     "roll": "min",
-                    "hits": 1
+                    "hits": 1,
+                    "allowMiss": true
                 }
             },
             "bossMoveInfo": {
@@ -589,7 +403,8 @@
                     "crit": true,
                     "secondaryEffects": true,
                     "roll": "max",
-                    "hits": 10
+                    "hits": 10,
+                    "allowMiss": false
                 }
             }
         },
@@ -604,7 +419,8 @@
                     "crit": false,
                     "secondaryEffects": false,
                     "roll": "min",
-                    "hits": 1
+                    "hits": 1,
+                    "allowMiss": true
                 }
             },
             "bossMoveInfo": {
@@ -615,7 +431,8 @@
                     "crit": true,
                     "secondaryEffects": true,
                     "roll": "max",
-                    "hits": 10
+                    "hits": 10,
+                    "allowMiss": false
                 }
             }
         },
@@ -630,7 +447,8 @@
                     "crit": false,
                     "secondaryEffects": false,
                     "roll": "min",
-                    "hits": 1
+                    "hits": 1,
+                    "allowMiss": true
                 }
             },
             "bossMoveInfo": {
@@ -641,7 +459,8 @@
                     "crit": true,
                     "secondaryEffects": true,
                     "roll": "max",
-                    "hits": 10
+                    "hits": 10,
+                    "allowMiss": false
                 }
             }
         }
@@ -649,13 +468,7 @@
     "groups": [
         [
             0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
+            1
         ],
         [
             8
@@ -717,21 +530,17 @@
                     ]
                 },
                 "substituteMoves": [
-                    "(No Move)",
-                    "(No Move)",
                     "Defense Cheer",
                     "Moonblast"
                 ],
                 "substituteTargets": [
-                    0,
-                    0,
                     0,
                     0
                 ]
             },
             {
                 "raider": {
-                    "id": 2,
+                    "id": 1,
                     "role": "Miraidon",
                     "name": "Miraidon",
                     "shiny": false,
@@ -764,21 +573,17 @@
                     ]
                 },
                 "substituteMoves": [
-                    "(No Move)",
-                    "(No Move)",
                     "Defense Cheer",
                     "Dragon Pulse"
                 ],
                 "substituteTargets": [
-                    0,
-                    0,
                     0,
                     0
                 ]
             },
             {
                 "raider": {
-                    "id": 3,
+                    "id": 1,
                     "role": "Primarina",
                     "name": "Primarina",
                     "shiny": false,
@@ -811,14 +616,10 @@
                     ]
                 },
                 "substituteMoves": [
-                    "(No Move)",
-                    "(No Move)",
                     "Defense Cheer",
                     "Moonblast"
                 ],
                 "substituteTargets": [
-                    0,
-                    0,
                     0,
                     0
                 ]
@@ -827,7 +628,7 @@
         [
             {
                 "raider": {
-                    "id": 1,
+                    "id": 2,
                     "role": "Politoed",
                     "name": "Politoed",
                     "shiny": false,
@@ -859,14 +660,10 @@
                     ]
                 },
                 "substituteMoves": [
-                    "(No Move)",
-                    "(No Move)",
                     "Helping Hand",
                     "Attack Cheer"
                 ],
                 "substituteTargets": [
-                    0,
-                    0,
                     1,
                     1
                 ]
@@ -904,14 +701,10 @@
                     ]
                 },
                 "substituteMoves": [
-                    "(No Move)",
-                    "(No Move)",
-                    "(No Move)",
+                    "Helping Hand",
                     "Attack Cheer"
                 ],
                 "substituteTargets": [
-                    0,
-                    0,
                     1,
                     1
                 ]

--- a/src/data/strats/charizard/meteor_shower.json
+++ b/src/data/strats/charizard/meteor_shower.json
@@ -27,7 +27,7 @@
                 "spe": 31
             },
             "level": 100,
-            "gender": "N",
+            "gender": "M",
             "teraType": "Dragon",
             "moves": [
                 "Dragon Pulse",

--- a/src/data/strats/charizard/meteor_shower_3.json
+++ b/src/data/strats/charizard/meteor_shower_3.json
@@ -1,5 +1,5 @@
 {
-    "name": "Meteor Shower Trio",
+    "name": "Meteor Shower (Trio)",
     "notes": "- Disclaimer: If the NPC brings Arboliva while playing as a trio, Grassy Terrain will override Electric Terrain and cause the OHKO to fail. If this happens, the group should allow Miraidon to faint, and Miraidon should switch to using Dragon Pulse when it respawns.",
     "credits": "The r/PokePortal Team and Team Rocket",
     "pokemon": [
@@ -27,7 +27,7 @@
                 "spe": 31
             },
             "level": 100,
-            "gender": "N",
+            "gender": "M",
             "teraType": "Dragon",
             "moves": [
                 "Dragon Pulse",
@@ -179,176 +179,64 @@
     ],
     "turns": [
         {
-            "id": 3,
-            "group": 1,
+            "id": 0,
+            "group": 0,
             "moveInfo": {
-                "name": "(No Move)",
-                "userID": 1,
-                "targetID": 1,
+                "name": "Overheat",
+                "userID": 0,
+                "targetID": 5,
                 "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
+                    "crit": true,
+                    "secondaryEffects": true,
                     "allowMiss": false,
-                    "roll": "avg",
-                    "hits": 1
+                    "roll": "max",
+                    "hits": 10
                 }
             },
             "bossMoveInfo": {
-                "name": "Overheat",
+                "name": "(No Move)",
                 "userID": 0,
-                "targetID": 1,
+                "targetID": 0,
                 "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
+                    "crit": true,
+                    "secondaryEffects": true,
                     "allowMiss": false,
-                    "roll": "avg",
-                    "hits": 1
+                    "roll": "max",
+                    "hits": 10
                 }
             }
         },
         {
             "id": 1,
-            "group": 1,
+            "group": 0,
             "moveInfo": {
-                "name": "(No Move)",
-                "userID": 1,
-                "targetID": 1,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "avg",
-                    "allowMiss": false,
-                    "hits": 1
-                }
-            },
-            "bossMoveInfo": {
                 "name": "Remove Negative Effects",
                 "userID": 0,
-                "targetID": 1,
+                "targetID": 0,
                 "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "avg",
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "roll": "max",
                     "allowMiss": false,
-                    "hits": 1
-                }
-            }
-        },
-        {
-            "id": 7,
-            "group": 1,
-            "moveInfo": {
-                "name": "(No Move)",
-                "userID": 2,
-                "targetID": 2,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "avg",
-                    "allowMiss": false,
-                    "hits": 1
+                    "hits": 10
                 }
             },
             "bossMoveInfo": {
-                "name": "Overheat",
-                "userID": 0,
-                "targetID": 1,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "avg",
-                    "allowMiss": false,
-                    "hits": 1
-                }
-            }
-        },
-        {
-            "id": 10,
-            "group": 1,
-            "moveInfo": {
                 "name": "(No Move)",
-                "userID": 2,
-                "targetID": 2,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "avg",
-                    "allowMiss": false,
-                    "hits": 1
-                }
-            },
-            "bossMoveInfo": {
-                "name": "Remove Negative Effects",
                 "userID": 0,
-                "targetID": 1,
+                "targetID": 0,
                 "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "avg",
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "roll": "max",
                     "allowMiss": false,
-                    "hits": 1
+                    "hits": 10
                 }
             }
         },
         {
-            "id": 11,
+            "id": 2,
             "group": 1,
-            "moveInfo": {
-                "name": "(No Move)",
-                "userID": 3,
-                "targetID": 3,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "avg",
-                    "allowMiss": false,
-                    "hits": 1
-                }
-            },
-            "bossMoveInfo": {
-                "name": "Overheat",
-                "userID": 0,
-                "targetID": 1,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "avg",
-                    "allowMiss": false,
-                    "hits": 1
-                }
-            }
-        },
-        {
-            "id": 12,
-            "group": 1,
-            "moveInfo": {
-                "name": "(No Move)",
-                "userID": 3,
-                "targetID": 3,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "avg",
-                    "allowMiss": false,
-                    "hits": 1
-                }
-            },
-            "bossMoveInfo": {
-                "name": "Remove Negative Effects",
-                "userID": 0,
-                "targetID": 1,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "avg",
-                    "allowMiss": false,
-                    "hits": 1
-                }
-            }
-        },
-        {
-            "id": 6,
-            "group": 4,
             "moveInfo": {
                 "name": "Defense Cheer",
                 "userID": 1,
@@ -356,8 +244,8 @@
                 "options": {
                     "crit": false,
                     "secondaryEffects": false,
-                    "allowMiss": false,
-                    "roll": "avg",
+                    "allowMiss": true,
+                    "roll": "min",
                     "hits": 1
                 }
             },
@@ -366,17 +254,17 @@
                 "userID": 0,
                 "targetID": 1,
                 "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
+                    "crit": true,
+                    "secondaryEffects": true,
                     "allowMiss": false,
-                    "roll": "avg",
-                    "hits": 1
+                    "roll": "max",
+                    "hits": 10
                 }
             }
         },
         {
-            "id": 2,
-            "group": 0,
+            "id": 3,
+            "group": 2,
             "moveInfo": {
                 "name": "Helping Hand",
                 "userID": 2,
@@ -384,8 +272,8 @@
                 "options": {
                     "crit": false,
                     "secondaryEffects": false,
-                    "roll": "avg",
-                    "allowMiss": false,
+                    "allowMiss": true,
+                    "roll": "min",
                     "hits": 1
                 }
             },
@@ -394,95 +282,11 @@
                 "userID": 0,
                 "targetID": 1,
                 "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "avg",
+                    "crit": true,
+                    "secondaryEffects": true,
                     "allowMiss": false,
-                    "hits": 1
-                }
-            }
-        },
-        {
-            "id": 0,
-            "group": 0,
-            "moveInfo": {
-                "name": "Gravity",
-                "userID": 3,
-                "targetID": 3,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "allowMiss": false,
-                    "roll": "avg",
-                    "hits": 1
-                }
-            },
-            "bossMoveInfo": {
-                "name": "(Most Damaging)",
-                "userID": 0,
-                "targetID": 1,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "allowMiss": false,
-                    "roll": "avg",
-                    "hits": 1
-                }
-            }
-        },
-        {
-            "id": 8,
-            "group": 5,
-            "moveInfo": {
-                "name": "Attack Cheer",
-                "userID": 2,
-                "targetID": 2,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "avg",
-                    "allowMiss": false,
-                    "hits": 1
-                }
-            },
-            "bossMoveInfo": {
-                "name": "(Most Damaging)",
-                "userID": 0,
-                "targetID": 1,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "avg",
-                    "allowMiss": false,
-                    "hits": 1
-                }
-            }
-        },
-        {
-            "id": 9,
-            "group": 5,
-            "moveInfo": {
-                "name": "Metal Sound",
-                "userID": 3,
-                "targetID": 0,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "avg",
-                    "allowMiss": false,
-                    "hits": 1
-                }
-            },
-            "bossMoveInfo": {
-                "name": "(Most Damaging)",
-                "userID": 0,
-                "targetID": 1,
-                "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
-                    "roll": "avg",
-                    "allowMiss": false,
-                    "hits": 1
+                    "roll": "max",
+                    "hits": 10
                 }
             }
         },
@@ -490,14 +294,14 @@
             "id": 4,
             "group": 2,
             "moveInfo": {
-                "name": "Metal Sound",
+                "name": "Gravity",
                 "userID": 3,
-                "targetID": 0,
+                "targetID": 3,
                 "options": {
                     "crit": false,
                     "secondaryEffects": false,
-                    "allowMiss": false,
-                    "roll": "avg",
+                    "roll": "min",
+                    "allowMiss": true,
                     "hits": 1
                 }
             },
@@ -506,11 +310,11 @@
                 "userID": 0,
                 "targetID": 1,
                 "options": {
-                    "crit": false,
-                    "secondaryEffects": false,
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "roll": "max",
                     "allowMiss": false,
-                    "roll": "avg",
-                    "hits": 1
+                    "hits": 10
                 }
             }
         },
@@ -518,14 +322,14 @@
             "id": 5,
             "group": 3,
             "moveInfo": {
-                "name": "Draco Meteor",
-                "userID": 1,
-                "targetID": 0,
+                "name": "Attack Cheer",
+                "userID": 2,
+                "targetID": 2,
                 "options": {
                     "crit": false,
                     "secondaryEffects": false,
-                    "allowMiss": false,
-                    "roll": "avg",
+                    "allowMiss": true,
+                    "roll": "min",
                     "hits": 1
                 }
             },
@@ -534,40 +338,120 @@
                 "userID": 0,
                 "targetID": 1,
                 "options": {
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "allowMiss": false,
+                    "roll": "max",
+                    "hits": 10
+                }
+            }
+        },
+        {
+            "id": 6,
+            "group": 3,
+            "moveInfo": {
+                "name": "Metal Sound",
+                "userID": 3,
+                "targetID": 0,
+                "options": {
                     "crit": false,
                     "secondaryEffects": false,
-                    "allowMiss": false,
-                    "roll": "avg",
+                    "roll": "min",
+                    "allowMiss": true,
                     "hits": 1
+                }
+            },
+            "bossMoveInfo": {
+                "name": "(Most Damaging)",
+                "userID": 0,
+                "targetID": 1,
+                "options": {
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "roll": "max",
+                    "allowMiss": false,
+                    "hits": 10
+                }
+            }
+        },
+        {
+            "id": 7,
+            "group": 4,
+            "moveInfo": {
+                "name": "Metal Sound",
+                "userID": 3,
+                "targetID": 0,
+                "options": {
+                    "crit": false,
+                    "secondaryEffects": false,
+                    "allowMiss": true,
+                    "roll": "min",
+                    "hits": 1
+                }
+            },
+            "bossMoveInfo": {
+                "name": "(Most Damaging)",
+                "userID": 0,
+                "targetID": 1,
+                "options": {
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "allowMiss": false,
+                    "roll": "max",
+                    "hits": 10
+                }
+            }
+        },
+        {
+            "id": 8,
+            "group": 5,
+            "moveInfo": {
+                "name": "Draco Meteor",
+                "userID": 1,
+                "targetID": 0,
+                "options": {
+                    "crit": false,
+                    "secondaryEffects": false,
+                    "allowMiss": true,
+                    "roll": "min",
+                    "hits": 1
+                }
+            },
+            "bossMoveInfo": {
+                "name": "(Most Damaging)",
+                "userID": 0,
+                "targetID": 1,
+                "options": {
+                    "crit": true,
+                    "secondaryEffects": true,
+                    "allowMiss": false,
+                    "roll": "max",
+                    "hits": 10
                 }
             }
         }
     ],
     "groups": [
         [
+            0,
+            1
+        ],
+        [
+            2
+        ],
+        [
             3,
-            1,
-            7,
-            10,
-            11,
-            12
-        ],
-        [
-            6
-        ],
-        [
-            2,
-            0
-        ],
-        [
-            8,
-            9
-        ],
-        [
             4
         ],
         [
-            5
+            5,
+            6
+        ],
+        [
+            7
+        ],
+        [
+            8
         ]
     ],
     "repeats": [

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -1041,7 +1041,9 @@ export class RaidMove {
                         }
                     }
                     catch {
-                        this._desc[id] = this._user.name + " used " + this.move.name + " on " + this.getPokemon(id).name + "!";
+                        if (!this.move.named("(No Move)", "(Wait)")) {
+                            this._desc[id] = this._user.name + " used " + this.move.name + " on " + this.getPokemon(id).name + "!";
+                        }
                     }
 
                     // add accuracy to desc if there is a chance to miss

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -150,19 +150,21 @@ export class RaidMove {
         this.instructed = instructed || false;
         this.delayed = delayed || false;
         this.hits = this.move.category === "Status" ? 0 : Math.max(this.moveData.minHits || 1, Math.min(this.moveData.maxHits || 1, this.options.hits || 1));
-        this.hits = this.raidState.raiders[this.userID].hasAbility("Skill Link") ? (this.moveData.maxHits || 1) : this.hits;
-        this.hits = this.raidState.raiders[this.userID].hasItem("Loaded Dice") && this.moveData.maxHits ? Math.max(this.moveData.maxHits - 1, this.hits) : this.hits;
+        this.hits = (this.userID < 5 && this.raidState.raiders[this.userID].hasAbility("Skill Link")) ? (this.moveData.maxHits || 1) : this.hits;
+        this.hits = (this.userID < 5 && this.raidState.raiders[this.userID].hasItem("Loaded Dice")) && this.moveData.maxHits ? Math.max(this.moveData.maxHits - 1, this.hits) : this.hits;
     }
 
     public result(): RaidMoveResult {
         this.setOutputRaidState();
-        if (this.checkIfMoves() && !this.checkIfFails()) {
+        if ((this.isBossAction && this.move.named("(No Move)")) || this.userID === 5) {
+            return this.output;
+        } else if (this.checkIfMoves() && !this.checkIfFails()) {
             this._raidState.raiders[0].checkShield(); // check for shield activation
             this.checkSheerForce();
             this.setAffectedPokemon();
             if (!this.checkIfCharging()) {
-                if (!this._user.isCharging && 
-                    chargeMoves.includes(this.move.name) && 
+                if (!this._user.isCharging &&
+                    chargeMoves.includes(this.move.name) &&
                     !(this._user.field.hasWeather("Sun") && ["Solar Beam", "Solar Blade"].includes(this.move.name)) &&
                     !(this._user.field.hasWeather("Rain") && this.move.name === "Electro Shot") &&
                     this._user.hasItem("Power Herb")
@@ -195,10 +197,10 @@ export class RaidMove {
                 this.applyPostMoveEffects();
                 this.storeLastMove();
             }
-            this._raidState.raiders[0].checkShield(); // check for shield breaking 
+            this._raidState.raiders[0].checkShield(); // check for shield breaking
             this.setFlags();
             // store move data and target
-            if (isRegularMove(this.moveData.name)) { 
+            if (isRegularMove(this.moveData.name)) {
                 // remove Micle boost
                 this._user.isMicle = false;
                 if (this.userID !== 0) {
@@ -240,7 +242,7 @@ export class RaidMove {
         this._raidState = this.raidState.clone();
         this._raiders = this._raidState.raiders;
         this._fields = this._raidState.fields;
-        this._user = this._raiders[this.userID];
+        this._user = this._raiders[this.userID === 5 ? 1 : this.userID];
         this._targetID = this.targetID;
 
         // initialize arrays
@@ -265,12 +267,12 @@ export class RaidMove {
         const monsToCheck = (this.userID && (this.raiderID !== this.userID)) ? [this._raidState.getPokemon(this.raiderID), this._user] : [this._user];
         for (let mon of monsToCheck) {
             if ( // prevent the boss from moving if it's shield has just been broken
-                mon.id === 0 && 
+                mon.id === 0 &&
                 mon.shieldBreakStun &&
                 mon.shieldBreakStun![this._targetID-1]
             ) {
-                this._desc[this.userID] = this._user.name + " is stunned after having its shield broken!";         
-                this._user.shieldBreakStun![this._targetID-1] = false;           
+                this._desc[this.userID] = this._user.name + " is stunned after having its shield broken!";
+                this._user.shieldBreakStun![this._targetID-1] = false;
             } else if (mon.originalCurHP === 0) {
                 if (mon.id !== 0) {
                     this._warnings.push(mon.name + " fainted before moving.");
@@ -300,8 +302,8 @@ export class RaidMove {
                     this._warnings.push(mon.name + " is frozen and skips its move.");
                     return false;
                 } else if (
-                    mon.isTaunt && 
-                    this.move.category === "Status" && 
+                    mon.isTaunt &&
+                    this.move.category === "Status" &&
                     !isRaidAction(this.moveData.name)
                 ) {
                     this._desc[mon.id] = mon.name + " can't use status moves due to Taunt!";
@@ -319,18 +321,18 @@ export class RaidMove {
                     mon.lastMoveFailed = 2;
                     this._warnings.push("Throat Chop prevents the use of " + this.moveData.name + ".");
                     return false;
-                } else if (mon.status === "par" && this.options.allowMiss && 
+                } else if (mon.status === "par" && this.options.allowMiss &&
                     ((mon.id !== 0 && this.targetID !== 0 && this.moveData.moveCategory !== "Status") ? this.options.roll === "max" : this.options.roll === "min")
                 ) {
                     this._desc[mon.id] = mon.name + " is fully paralyzed and can't move!";
                     mon.lastMoveFailed = 2;
                     this._warnings.push(mon.name + " is fully paralyzed and can't move.");
                     return false;
-                } else if (mon.volatileStatus.includes("confusion") && this.options.allowMiss && 
+                } else if (mon.volatileStatus.includes("confusion") && this.options.allowMiss &&
                     ((mon.id !== 0 && this.targetID !== 0 && this.moveData.moveCategory !== "Status") ? this.options.roll === "max" : this.options.roll === "min")
                 ) {
                     mon.lastMoveFailed = 2;
-                    this.applyConfusionDamage();                
+                    this.applyConfusionDamage();
                     return false;
                 } else {
                     if (mon.status === "par") {
@@ -387,7 +389,7 @@ export class RaidMove {
         if (
             // TO DO: consolidate other failure checks here, add missing ones (?)
             (this.move.named("Self-Destruct", "Explosion", "Misty Explosion", "Final Gambit", "Healing Wish", "Lunar Dance", "Memento")) || // Moves that cause the user to faint
-            (target.isTaunt && this.move.named("Taunt")) ||
+            (target && target.isTaunt && this.move.named("Taunt")) ||
             (this._user.field.isGravity && this.move.named("Bounce", "Fly", "Flying Press", "High Jump Kick", "Jump Kick", "Magnet Rise", "Sky Drop", "Splash", "Telekenesis")) ||
             (this._user.cheersLeft < 1 && this.move.named("Attack Cheer", "Defense Cheer", "Heal Cheer")) ||
             (this.move.named("Last Resort") && !this._user.movesUsed.every((m) => m) && this._user.moves.filter((m) => m !== "Last Resort" && m !== "(No Move)").length > 0) ||
@@ -397,7 +399,7 @@ export class RaidMove {
             // if (actionLockMoves.includes(this.moveData.name)) {
             //     this._user.moveRepeated = 0;
             // }
-            this._desc[this.userID] = this._user.name + " " + this.move.name + " vs. " + this._raidState.getPokemon(this._targetID).name + " — " + this.move.name + " failed!";
+            this._desc[this.userID] = this._user.name + " " + this.move.name + (target ? (" vs. " + this._raidState.getPokemon(this._targetID).name) : "") + " — " + this.move.name + " failed!";
             return true;
         }
         return false;
@@ -406,7 +408,7 @@ export class RaidMove {
     private checkSheerForce() {
         this._isSheerForceBoosted = (
             this._user.hasAbility("Sheer Force") && (
-                this.move.secondaries || 
+                this.move.secondaries ||
                 ((this.moveData.flinchChance || 0) > 0) ||
                 (this.moveData.category === "damage+ailment") ||
                 (this.moveData.category === "damage+lower" && Object.values(this.moveData.statChanges!).some((val) => val.change < 0)) ||
@@ -420,7 +422,7 @@ export class RaidMove {
         const targetType = this.moveData.target;
         if (this.moveData.name === "Heal Cheer") { this._affectedIDs = [1,2,3,4]; }
         else if (targetType === "user") { this._affectedIDs = [this.userID]; }
-        else if (this.isBossAction && (targetType === "all-other-pokemon" || targetType === "all-opponents")) { this._affectedIDs = [1,2,3,4]; }
+        else if (this.isBossAction && (targetType === "all-other-pokemon" || targetType === "all-opponents" || this.targetID === 5)) { this._affectedIDs = [1,2,3,4]; }
         else if (targetType === "selected-pokemon" || targetType === "all-opponents" || targetType === "all-other-pokemon") { this._affectedIDs = [this._targetID]; }
         else if (targetType === "all-allies") { this._affectedIDs = this.userID === 0 ? [] : [1,2,3,4].filter((i) => i !== this.userID); }
         else if (targetType === "user-and-allies") { this._affectedIDs = this.userID === 0 ? [0] : [1,2,3,4]; }
@@ -486,7 +488,7 @@ export class RaidMove {
                     this._moveType = this._user.types[0];
                 }
                 return;
-            case "Revelation Dance": 
+            case "Revelation Dance":
                 this._moveType = this._user.types[0];
                 return;
             case "Aura Wheel":
@@ -510,7 +512,7 @@ export class RaidMove {
                 this._moveType = (this._user.isTera && this._user.teraType) ? this._user.teraType : "Normal";
                 return;
             case "Ivy Cudgel":
-                this._moveType =  this._user.named("Ogerpon-Wellspring") ? "Water" : 
+                this._moveType =  this._user.named("Ogerpon-Wellspring") ? "Water" :
                             this._user.named("Ogerpon-Hearthflame") ? "Fire" :
                             this._user.named("Ogerpon-Cornerstone") ? "Rock" :
                             "Grass";
@@ -549,11 +551,11 @@ export class RaidMove {
         const moveName = this.move.name;
         for (let i=0; i<this._affectedIDs.length; i++) {
             let id = this._affectedIDs[i];
-            if (this.userID === id) { 
+            if (this.userID === id) {
                 if (moveName === "Stockpile" && this._user.stockpile === 3) {
                     this._doesNotAffect[id] = "does not affect " + this.getPokemon(id).name;
                 }
-                continue; 
+                continue;
             }
             let pokemon = this.getPokemon(id);
             const field = pokemon.field;
@@ -590,43 +592,43 @@ export class RaidMove {
                 switch (pokemon.ability) {
                     case "Good as Gold":
                     case "Good As Gold":
-                        if (category === "Status" && targetType !== "user") { 
+                        if (category === "Status" && targetType !== "user") {
                             this._doesNotAffect[id] = "does not affect " + pokemon.name + " due to " + pokemon.ability;
-                            continue; 
+                            continue;
                         }
                         break;
                     case "Dry Skin":
                     case "Water Absorb":
-                        if (this._moveType === "Water") { 
-                            this._doesNotAffect[id] = "heals " + pokemon.name + " due to " + pokemon.ability; 
+                        if (this._moveType === "Water") {
+                            this._doesNotAffect[id] = "heals " + pokemon.name + " due to " + pokemon.ability;
                             this._healing[id] = Math.floor(pokemon.maxHP() * 0.25);
                             continue;
                         }
                         break;
                     case "Volt Absorb":
-                        if (this._moveType === "Electric") { 
-                            this._doesNotAffect[id] = "heals " + pokemon.name + " due to " + pokemon.ability; 
+                        if (this._moveType === "Electric") {
+                            this._doesNotAffect[id] = "heals " + pokemon.name + " due to " + pokemon.ability;
                             this._healing[id] = Math.floor(pokemon.maxHP() * 0.25);
                             continue;
                         }
                         break;
                     case "Earth Eater":
                         if (this._moveType === "Ground") {
-                            this._doesNotAffect[id] = "heals " + pokemon.name + " due to " + pokemon.ability; 
+                            this._doesNotAffect[id] = "heals " + pokemon.name + " due to " + pokemon.ability;
                             this._healing[id] = Math.floor(pokemon.maxHP() * 0.25);
                             continue;
                         }
                         break;
                     case "Flash Fire":
-                        if (this._moveType === "Fire") { 
-                            this._doesNotAffect[id] = "boosts " + pokemon.name + " due to " + pokemon.ability; 
+                        if (this._moveType === "Fire") {
+                            this._doesNotAffect[id] = "boosts " + pokemon.name + " due to " + pokemon.ability;
                             this._raidState.getPokemon(id).abilityOn = true;
                             continue;
                         }
                         break;
                     case "Well-Baked Body":
                         if (this._moveType === "Fire") {
-                            this._doesNotAffect[id] = "boosts " + pokemon.name + " due to " + pokemon.ability; 
+                            this._doesNotAffect[id] = "boosts " + pokemon.name + " due to " + pokemon.ability;
                             const boost = {def: 2};
                             this._raidState.applyStatChange(id, boost);
                             continue;
@@ -634,7 +636,7 @@ export class RaidMove {
                         break;
                     case "Sap Sipper":
                         if (this._moveType === "Grass") {
-                            this._doesNotAffect[id] = "boosts " + pokemon.name + " due to " + pokemon.ability; 
+                            this._doesNotAffect[id] = "boosts " + pokemon.name + " due to " + pokemon.ability;
                             const boost = {atk: 1};
                             this._raidState.applyStatChange(id, boost);
                             continue;
@@ -642,7 +644,7 @@ export class RaidMove {
                         break;
                     case "Motor Drive":
                         if (this._moveType === "Electric") {
-                            this._doesNotAffect[id] = "boosts " + pokemon.name + " due to " + pokemon.ability; 
+                            this._doesNotAffect[id] = "boosts " + pokemon.name + " due to " + pokemon.ability;
                             const boost = {spe: 1};
                             this._raidState.applyStatChange(id, boost);
                             continue;
@@ -650,7 +652,7 @@ export class RaidMove {
                         break;
                     case "Storm Drain":
                         if (this._moveType === "Water") {
-                            this._doesNotAffect[id] = "boosts " + pokemon.name + " due to " + pokemon.ability; 
+                            this._doesNotAffect[id] = "boosts " + pokemon.name + " due to " + pokemon.ability;
                             const boost = {spa: 1};
                             this._raidState.applyStatChange(id, boost);
                             continue;
@@ -658,7 +660,7 @@ export class RaidMove {
                         break;
                     case "Lightning Rod":
                         if (this._moveType === "Electric") {
-                            this._doesNotAffect[id] = "boosts " + pokemon.name + " due to " + pokemon.ability; 
+                            this._doesNotAffect[id] = "boosts " + pokemon.name + " due to " + pokemon.ability;
                             const boost = {spa: 1};
                             this._raidState.applyStatChange(id, boost);
                             continue;
@@ -679,7 +681,7 @@ export class RaidMove {
                         }
                         break;
                     case "Levitate":
-                        if (!pokemonIsGrounded(pokemon, field) && this._moveType === "Ground") { 
+                        if (!pokemonIsGrounded(pokemon, field) && this._moveType === "Ground") {
                             this._doesNotAffect[id] = "does not affect " + pokemon.name + " due to " + pokemon.ability;
                             continue;
                         }
@@ -696,12 +698,12 @@ export class RaidMove {
             // Type-based immunities
             const targetTypes = (pokemon.isTera && pokemon.teraType) ? [pokemon.teraType] : pokemon.types;
             if (category !== "Status" && pokemon.item !== "Ring Target") {
-                if (this._moveType === "Ground" && !pokemonIsGrounded(pokemon, field)) { 
+                if (this._moveType === "Ground" && !pokemonIsGrounded(pokemon, field)) {
                     this._doesNotAffect[id] = "does not affect " + pokemon.name;
                     continue;
                 }
-                if (this._moveType === "Electric" && targetTypes.includes("Ground")) { 
-                    this._doesNotAffect[id] = "does not affect " + pokemon.name; 
+                if (this._moveType === "Electric" && targetTypes.includes("Ground")) {
+                    this._doesNotAffect[id] = "does not affect " + pokemon.name;
                     continue;
                 }
                 if (["Normal", "Fighting"].includes(this._moveType || "") && targetTypes.includes("Ghost") && !(["Scrappy", "Mind's Eye"] as (AbilityName | undefined)[]).includes(this._user.ability)) {
@@ -803,7 +805,7 @@ export class RaidMove {
     private applyDamage() {
         const moveUser = this.getPokemon(this.userID);
         // check for spread damage (boss actions only)
-        this._isSpread = this.moveData.category?.includes("damage") && (this._affectedIDs.length > 1);
+        this._isSpread = this.moveData.category?.includes("damage") && (this._affectedIDs.length > 1) && this.targetID < 5;
         // protean / libero check
         if (this.moveData.name !== "(No Move)" && this.moveData.type && moveUser.hasAbility("Protean", "Libero") && !moveUser.abilityOn && !moveUser.isTera) {
             moveUser.types = [this._moveType];
@@ -841,7 +843,7 @@ export class RaidMove {
                 this._user.lastAccuracy = accuracy;
                 const bpModifier = getBpModifier(this.moveData, target, this._damaged[this.userID], this._damaged[id], this.statLowered);
                 const accFraction = Math.min(1,accuracy/100);
-                const rollChance = accFraction * (crit ? critChance : (1 - critChance));
+                const rollChance = accFraction * (crit ? critChance : (1 - critChance)) * (this.targetID === 5 ? 0.25 : 1);
                 if (this.options.allowMiss ? (accuracy >= 100 || roll !== "min") : (accuracy > 0)) {
                     try {
                         const preDamageItem = target.item;
@@ -850,7 +852,7 @@ export class RaidMove {
                         let changingBP = false;
                         // calculate each hit from a multi-hit move
                         this.move.hits = this.hits;
-                        for (let i=0; i<this.hits; i++) { 
+                        for (let i=0; i<this.hits; i++) {
                             const calcMove = this.move.clone();
                             calcMove.isCrit = crit;
                             calcMove.isSpread = !!this._isSpread;
@@ -920,21 +922,21 @@ export class RaidMove {
                                 hitDamage = Math.min(hitDamage, target.originalCurHP - 1);
                             }
                             if (otherResult) {
-                                const otherRollChance = accFraction * (crit ? 1 - critChance : critChance);
+                                const otherRollChance = accFraction * (crit ? 1 - critChance : critChance) * (this.targetID === 5 ? 0.25 : 1);
                                 if (typeof(otherResult.damage) === "number") {
                                     hitRoll = catRollCounts(hitRoll, getRollCounts([[otherResult.damage as number]], 0, target.maxHP(), [otherRollChance]));
                                 } else {
                                     hitRoll = catRollCounts(hitRoll, getRollCounts([otherResult.damage as number[]], 0, target.maxHP(), [otherRollChance]));
                                 }
                             }
-                            if (accFraction > 0 && accFraction < 1) {
-                                hitRoll = catRollCounts(hitRoll, getRollCounts([[0]], 0, target.maxHP(), [1 - accFraction]));
+                            if (this.targetID === 5 || (accFraction > 0 && accFraction < 1)) {
+                                hitRoll = catRollCounts(hitRoll, getRollCounts([[0]], 0, target.maxHP(), [1 - accFraction * (this.targetID === 5 ? 0.25 : 1)]));
                             }
                             const bypassSubstitute = this.moveData.bypassSub || moveUser.hasAbility("Infiltrator");
                             this._damaged[id] = this._raidState.applyDamage(id, hitDamage, hitRoll, 1, result.rawDesc.isCritical, superEffective, this._moveType, this.move.category, true, this.moveData.isWind, bypassSubstitute, this._isSheerForceBoosted, i !== (this.hits - 1), this.userID, calcMove.named("False Swipe"), fixedDamageMoves.includes(calcMove.name)) || this._damaged[id];
                             totalDamage += hitDamage;
                             this._damageRolls[id].push(hitRoll);
-        
+
                             // remove buffs to user after damage
                             if (totalDamage > 0) {
                                 hasCausedDamage = true;
@@ -987,14 +989,14 @@ export class RaidMove {
                                         // Guessing NoReceiver
                                         case "Mummy":
                                         case "Lingering Aroma":
-                                            if (!this._user.hasItem("Ability Shield") && 
+                                            if (!this._user.hasItem("Ability Shield") &&
                                                 !(!this._user.abilityNullified && (
                                                     this._user.hasAbility("Lingering Aroma","Mummy") || persistentAbilities["NoReceiver"].includes(this._user.ability || "")
                                                 ))) {
                                                 this._raidState.changeAbility(this._user.id, target.ability!)
                                             }
                                             break;
-                                        // TO DO: status-inflicting contact abilities. 
+                                        // TO DO: status-inflicting contact abilities.
                                         default: break;
                                     }
                                 }
@@ -1009,7 +1011,7 @@ export class RaidMove {
                                             this._raidState.receiveItem(this.userID, "Sticky Barb" as ItemName);
                                         }
                                         break;
-                                    default: break; 
+                                    default: break;
                                 }
                             }
                         }
@@ -1037,7 +1039,7 @@ export class RaidMove {
                                 this._user.isCudChew = 2;
                             }
                         }
-                    } 
+                    }
                     catch {
                         this._desc[id] = this._user.name + " used " + this.move.name + " on " + this.getPokemon(id).name + "!";
                     }
@@ -1085,7 +1087,7 @@ export class RaidMove {
                                 this._raidState.applyStatus(this.userID, "brn", target.id, false, false, this.options.roll);
                             }
                             break;
-                        case "King's Shield": 
+                        case "King's Shield":
                             this._raidState.applyStatChange(this.userID, {atk: -1});
                             break;
                         case "Obstruct":
@@ -1097,7 +1099,7 @@ export class RaidMove {
                         }
                         default: break;
                     }
-                }   
+                }
             }
         }
         // simplify/remove descs
@@ -1117,7 +1119,7 @@ export class RaidMove {
         // adjust tera charge
         if ((this.moveData.category?.includes("damage") || (this.moveData.category === "unique" && this.moveData.power)) && hasCausedDamage && this._user.teraCharge < 3) {
             this._user.teraCharge++;
-        } 
+        }
     }
 
     private applyDrain() { // this also accounts for recoil
@@ -1183,7 +1185,7 @@ export class RaidMove {
                     healingPercent = (healingPercent || 0) * 1.5;
                 }
                 // TODO: moveData.healing is missing, healPercents are manually set even if default value of 50
-                switch(this.moveData.name) {  // Bulbapedia says 2/3, not sure what should be used here for perfect accuracy 
+                switch(this.moveData.name) {  // Bulbapedia says 2/3, not sure what should be used here for perfect accuracy
                     case "Floral Healing":
                         healingPercent = this._user.field.hasTerrain("Grassy") ? 66.66 : 50;
                         break;
@@ -1235,7 +1237,7 @@ export class RaidMove {
 
     private applyStatChanges() {
         const category = this.moveData.category;
-        if (this._isSheerForceBoosted) { return; } 
+        if (this._isSheerForceBoosted) { return; }
         const affectedIDs = category === "damage+raise" ? [this.userID] : this._affectedIDs;
         let statChanges = this.moveData.statChanges;
         // handle Growth
@@ -1307,7 +1309,7 @@ export class RaidMove {
 
     private applySelfDamage() {
         if (this._user.hasAbility("Magic Guard")) { return; }
-        const selfDamage = Math.floor((this._user.maxHP() * (this.moveData.selfDamage || 0) / 100) / ((this._user.bossMultiplier || 100) / 100)); 
+        const selfDamage = Math.floor((this._user.maxHP() * (this.moveData.selfDamage || 0) / 100) / ((this._user.bossMultiplier || 100) / 100));
         const lifeOrbDamage = (this._user.item === "Life Orb" && !this._isSheerForceBoosted && this._damage.reduce((a,b) => a + b, 0) > 0) ? Math.floor(this._user.maxHP() * 0.1) : 0;
         if (selfDamage !== 0) {
             const selfDamagePercent = this.moveData.selfDamage;
@@ -1404,8 +1406,10 @@ export class RaidMove {
             this._user.isFrozen = 0;
         }
 
-        if (this._doesNotAffect[this._targetID]) { return; }
-        const target = this.getPokemon(this._targetID);
+        for (let targetID of this._affectedIDs) {
+
+        if (this._doesNotAffect[targetID]) { return; }
+        const target = this.getPokemon(targetID);
 
         switch (this.move.name) {
             case "Brick Break":
@@ -1430,7 +1434,7 @@ export class RaidMove {
                 }
                 break;
             case "Alluring Voice": // putting this here because stat changes need to be checked before the execution of the move
-                if (this.statRaised[this._targetID]) {
+                if (this.statRaised[targetID]) {
                     this._alluringVoiceEffect = true;
                 }
                 break;
@@ -1456,7 +1460,7 @@ export class RaidMove {
                         case "Rawst Berry":
                         case "Aspear Berry":
                         case "Lum Berry":
-                        case "Persim Berry": 
+                        case "Persim Berry":
                         case "Liechi Berry":
                         case "Kee Berry":
                         case "Ganlon Berry":
@@ -1470,13 +1474,14 @@ export class RaidMove {
                         case "Sitrus Berry":
                         case "Oran Berry":
                         case "Mental Herb":
-                            this._raidState.consumeItem(this._targetID, this._user.item, false);
+                            this._raidState.consumeItem(targetID, this._user.item, false);
                             break;
                         default: break;
                     }
                 }
                 break;
             default: break;
+        }
         }
     }
 
@@ -1492,12 +1497,13 @@ export class RaidMove {
     }
 
     private applyUniqueMoveEffects() {
-        const target = this.getPokemon(this._targetID);
+        for (let targetID of this._affectedIDs) {
+        const target = this.getPokemon(targetID);
 
         const user_ability = this._user.ability as AbilityName;
         const target_ability = target.ability as AbilityName;
 
-        if (this._doesNotAffect[this._targetID]) { return; }
+        if (this._doesNotAffect[targetID]) { return; }
 
         switch (this.move.name) {
             /// Ability-affecting moves
@@ -1505,13 +1511,13 @@ export class RaidMove {
                 if (this.userID !== 0) {
                     throw new Error("Only the Raid boss can remove stat boosts and abilities!")
                 }
-                this._desc[this._targetID] = "The Raid Boss nullified all stat boosts and abilities!"
+                this._desc[targetID] = "The Raid Boss nullified all stat boosts and abilities!"
                 for (let i=1; i<5; i++) {
                     const pokemon = this.getPokemon(i);
                     if (pokemon.originalCurHP <= 0) { continue; }
                     // Helping Hand is NOT cleared
                     // if (
-                    //     !persistentAbilities.unsuppressable.includes(pokemon.ability as AbilityName) 
+                    //     !persistentAbilities.unsuppressable.includes(pokemon.ability as AbilityName)
                     //     && !pokemon.hasItem("Ability Shield")
                     //     && pokemon.ability !== "(No Ability)"
                     // ) { // abilities that are not unsupressable are nullified
@@ -1534,7 +1540,7 @@ export class RaidMove {
                 if (this.userID !== 0) {
                     throw new Error("Only the Raid boss can remove negative effects!")
                 }
-                this._desc[this._targetID] = "The Raid Boss removed all negative effects from itself!"
+                this._desc[targetID] = "The Raid Boss removed all negative effects from itself!"
                 const boss = this.getPokemon(0);
                 boss.status = "";
                 boss.volatileStatus = boss.volatileStatus.filter(status => ignoredVolatileStatuses.includes(status));
@@ -1563,27 +1569,27 @@ export class RaidMove {
                     throw new Error("Only the Raid boss can activate its shield!")
                 }
                 if (!this._user.shieldBroken && !this._user.shieldActive && this._user.shieldData?.shieldCancelDamage) {
-                    this._desc[this._targetID] = "The Raid Boss activated its shield and cleared statuses!";
+                    this._desc[targetID] = "The Raid Boss activated its shield and cleared statuses!";
                     this._user.shieldActive = true;
                     this._user.shieldActivateHP = this._user.originalCurHP;
                     this._user.status = "";
                 } else {
-                    this._desc[this._targetID] = "The Boss Shield is already active. You might need to change the shield's HP activation threshold.";
+                    this._desc[targetID] = "The Boss Shield is already active. You might need to change the shield's HP activation threshold.";
                 }
                 break;
-            case "Skill Swap": 
+            case "Skill Swap":
                 if (
                     // !this._user.abilityNullified && !target.abilityNullified &&
-                    !this._user.hasItem("Ability Shield") && 
+                    !this._user.hasItem("Ability Shield") &&
                     !target.hasItem("Ability Shield") &&
                     !persistentAbilities["FailSkillSwap"].includes(user_ability) &&
                     !persistentAbilities["FailSkillSwap"].includes(target_ability)
                 ) {
                     const tempUserAbility = user_ability;
                     this._raidState.changeAbility(this.userID, target_ability, true);
-                    this._raidState.changeAbility(this._targetID, tempUserAbility, true);
+                    this._raidState.changeAbility(targetID, tempUserAbility, true);
                 } else {
-                    this._desc[this._targetID] = this._user.name + " " + this.move.name + " vs. " + target.name + " — " + this.move.name + " failed!";
+                    this._desc[targetID] = this._user.name + " " + this.move.name + " vs. " + target.name + " — " + this.move.name + " failed!";
                 }
                 break;
             case "Core Enforcer":
@@ -1595,7 +1601,7 @@ export class RaidMove {
                     this._raidState.removeAbilityFieldEffect(target.id, target.ability);
                     target.abilityNullified = -1;
                 } else {
-                    this._desc[this._targetID] = this._user.name + " " + this.move.name + " vs. " + target.name + " — " + this.move.name + " failed!";
+                    this._desc[targetID] = this._user.name + " " + this.move.name + " vs. " + target.name + " — " + this.move.name + " failed!";
                 }
                 break;
             case "Entrainment":
@@ -1603,9 +1609,9 @@ export class RaidMove {
                     !persistentAbilities["NoEntrain"].includes(user_ability) &&
                     !target.hasItem("Ability Shield")
                 ) {
-                    this._raidState.changeAbility(this._targetID, user_ability);
+                    this._raidState.changeAbility(targetID, user_ability);
                 } else {
-                    this._desc[this._targetID] = this._user.name + " " + this.move.name + " vs. " + target.name + " — " + this.move.name + " failed!";
+                    this._desc[targetID] = this._user.name + " " + this.move.name + " vs. " + target.name + " — " + this.move.name + " failed!";
                 }
                 break;
             // Worry Seed is weird, using FailSkillSwap as an approximation
@@ -1614,9 +1620,9 @@ export class RaidMove {
                     !persistentAbilities["FailSkillSwap"].includes(target_ability) &&
                     !target.hasItem("Ability Shield")
                 ) {
-                    this._raidState.changeAbility(this._targetID, "Insomnia" as AbilityName);
+                    this._raidState.changeAbility(targetID, "Insomnia" as AbilityName);
                 } else {
-                    this._desc[this._targetID] = this._user.name + " " + this.move.name + " vs. " + target.name + " — " + this.move.name + " failed!";
+                    this._desc[targetID] = this._user.name + " " + this.move.name + " vs. " + target.name + " — " + this.move.name + " failed!";
                 }
                 break;
             case "Role Play":
@@ -1627,7 +1633,7 @@ export class RaidMove {
                 ) {
                     this._raidState.changeAbility(this.userID, target_ability);
                 } else {
-                    this._desc[this._targetID] = this._user.name + " " + this.move.name + " vs. " + target.name + " — " + this.move.name + " failed!";
+                    this._desc[targetID] = this._user.name + " " + this.move.name + " vs. " + target.name + " — " + this.move.name + " failed!";
                 }
                 break;
             // Using CantSuppress as a guess
@@ -1636,9 +1642,9 @@ export class RaidMove {
                     !persistentAbilities["CantSuppress"].includes(target_ability) &&
                     !target.hasItem("Ability Shield")
                 ) {
-                    this._raidState.changeAbility(this._targetID, "Simple" as AbilityName);
+                    this._raidState.changeAbility(targetID, "Simple" as AbilityName);
                 } else {
-                    this._desc[this._targetID] = this._user.name + " " + this.move.name + " vs. " + target.name + " — " + this.move.name + " failed!";
+                    this._desc[targetID] = this._user.name + " " + this.move.name + " vs. " + target.name + " — " + this.move.name + " failed!";
                 }
                 break;
             case "Minimize":
@@ -1652,7 +1658,7 @@ export class RaidMove {
                 if (
                     !persistentAbilities["NoReceiver"].includes(target_ability) &&
                     !this._user.hasItem("Ability Shield")
-                ) {           
+                ) {
                     this._raidState.changeAbility(this.userID, target_ability);
                     if (this.userID !== 0) {
                         for (let i of getSpeedRanking([1,2,3,4], this._raidState.raiders)) {
@@ -1697,7 +1703,7 @@ export class RaidMove {
                     this._desc[target.id] = this._user.name + " Forest's Curse vs. " + target.name + " — the Grass type was added to " + target.name + "!";
                 } else {
                     this._desc[target.id] = this._user.name + " Forest's Curse vs. " + target.name + " — Forest's Curse failed!";
-                } 
+                }
                 break;
             case "Trick-or-Treat":
                 if (!target.isTera || !(target.teraType !== undefined || target.teraType !== "???") && !target.types.includes("Ghost")) {
@@ -1710,7 +1716,7 @@ export class RaidMove {
                     this._desc[target.id] = this._user.name + " Trick-or-Treat vs. " + target.name + " — the Ghost type was added to " + target.name + "!";
                 } else {
                     this._desc[target.id] = this._user.name + " Trick-or-Treat vs. " + target.name + " — Trick-or-Treat failed!";
-                } 
+                }
                 break;
             case "Conversion":
                 const firstMoveType = this._user.moveData[0].type;
@@ -1735,7 +1741,7 @@ export class RaidMove {
             case "Knock Off":
                 // Knock Off doesn't remove raiders' items when used by the boss
                 if (this.userID !== 0 && target.item) {
-                    this._raidState.loseItem(this._targetID);
+                    this._raidState.loseItem(targetID);
                 }
                 break;
             case "Switcheroo":
@@ -1743,7 +1749,7 @@ export class RaidMove {
                 // These moves don't work in Tera raids
                 // const tempUserItem = this._user.item;
                 // const tempTargetItem = target.item;
-                // this._raidState.receiveItem(this._targetID, tempUserItem);
+                // this._raidState.receiveItem(targetID, tempUserItem);
                 // this._raidState.receiveItem(this.userID, tempTargetItem);
                 break;
             case "Recycle":
@@ -1773,7 +1779,7 @@ export class RaidMove {
                     field.terrain = undefined;
                 }
                 break;
-            case "Court Change": 
+            case "Court Change":
                 const tempUserSide = {...(this._fields[this.userID].attackerSide)};
                 const sameSides = this.userID === 0 ? [this._fields[0]] : this._fields.slice(1);
                 const targetSides = this.userID === 0 ? this._fields.slice(1) : [this._fields[0]];
@@ -1868,7 +1874,7 @@ export class RaidMove {
                 this._user.stats.spe = target.stats.spe;
                 target.stats.spe = tempSpe;
                 break;
-            case "Topsy-Turvy": 
+            case "Topsy-Turvy":
                 for (let stat in target.boosts) {
                     target.boosts[stat as StatIDExceptHP] = -(target.boosts[stat as StatIDExceptHP] || 0);
                 }
@@ -1879,8 +1885,8 @@ export class RaidMove {
                 break;
             case "Rest":
                 if ((this._user.status !== "slp")
-                    && !(pokemonIsGrounded(this._user, this._user.field) && this._user.field.hasTerrain("Misty") || this._user.field.hasTerrain("Electric")) 
-                    && (this._user.abilityNullified || !["Insomnia", "Purifying Salt", "Vital Spirit"].includes(this._user.ability as string)) 
+                    && !(pokemonIsGrounded(this._user, this._user.field) && this._user.field.hasTerrain("Misty") || this._user.field.hasTerrain("Electric"))
+                    && (this._user.abilityNullified || !["Insomnia", "Purifying Salt", "Vital Spirit"].includes(this._user.ability as string))
                     && !(this._user.field.hasWeather("Sun") && this._user.hasAbility("Leaf Guard"))
                 ) {
                     this._user.originalCurHP = this._user.maxHP();
@@ -1898,10 +1904,10 @@ export class RaidMove {
                 if (!this._user.isPumped) {
                     this._user.isPumped = 2;
                 } else {
-                    this._desc[this._targetID] = this._user.name + " - " + this.move.name + " failed!"
+                    this._desc[targetID] = this._user.name + " - " + this.move.name + " failed!"
                 }
                 break;
-            case "Dragon Cheer": 
+            case "Dragon Cheer":
                 const allyIDs = this.userID !== 0 ? [1,2,3,4].filter((id) => id !== this.userID) : [];
                 for (let allyID of getSpeedRanking(allyIDs, this._raidState.raiders)) {
                     const ally = this._raidState.getPokemon(allyID);
@@ -1915,7 +1921,7 @@ export class RaidMove {
             case "Syrup Bomb":
                 if (!target.syrupBombDrops) {
                     target.syrupBombDrops = 3;
-                    this._flags[this._targetID].push("Covered in Sticky Syrup!");
+                    this._flags[targetID].push("Covered in Sticky Syrup!");
                 }
                 break;
             case "Tailwind":
@@ -1930,7 +1936,7 @@ export class RaidMove {
                     }
                 }
                 break;
-            case "Curse": 
+            case "Curse":
                 if (this._user.hasType("Ghost")) {
                     this._damaged[this.userID] = this._raidState.applyDamage(this.userID, this._user.maxHP() / 2) || this._damaged[this.userID];
                     // (Ghost) Curse probably doesn't work in raids
@@ -1992,21 +1998,21 @@ export class RaidMove {
                 break;
             case "Alluring Voice":
                 if (this._alluringVoiceEffect) {
-                    this._raidState.applyVolatileStatus(this._targetID, "confusion", true, this.userID, this.movesFirst);
+                    this._raidState.applyVolatileStatus(targetID, "confusion", true, this.userID, this.movesFirst);
                 }
                 break;
             case "Tri Attack":
                 if (this.options.secondaryEffects) {
-                    this._raidState.applyStatus(this._targetID, "frz", this._user.id, true, false, this.options.roll)
-                    this._raidState.applyStatus(this._targetID, "par", this._user.id, true, false, this.options.roll)
-                    this._raidState.applyStatus(this._targetID, "brn", this._user.id, true, false, this.options.roll)
+                    this._raidState.applyStatus(targetID, "frz", this._user.id, true, false, this.options.roll)
+                    this._raidState.applyStatus(targetID, "par", this._user.id, true, false, this.options.roll)
+                    this._raidState.applyStatus(targetID, "brn", this._user.id, true, false, this.options.roll)
                 }
                 break;
             case "Dire Claw":
                 if (this._user.hasAbility("Serene Grace") || this.options.secondaryEffects) {
-                    this._raidState.applyStatus(this._targetID, "slp", this._user.id, true, false, this.options.roll)
-                    this._raidState.applyStatus(this._targetID, "par", this._user.id, true, false, this.options.roll)
-                    this._raidState.applyStatus(this._targetID, "psn", this._user.id, true, false, this.options.roll)
+                    this._raidState.applyStatus(targetID, "slp", this._user.id, true, false, this.options.roll)
+                    this._raidState.applyStatus(targetID, "par", this._user.id, true, false, this.options.roll)
+                    this._raidState.applyStatus(targetID, "psn", this._user.id, true, false, this.options.roll)
                 }
                 break;
             case "Glaive Rush":
@@ -2029,6 +2035,7 @@ export class RaidMove {
                 break;
             default: break;
             }
+        }
     }
 
     public applyPostMoveEffects() {

--- a/src/raidcalc/RaidTurn.ts
+++ b/src/raidcalc/RaidTurn.ts
@@ -14,7 +14,7 @@ const gen = Generations.get(9);
 const dummyMove = new Move(gen, "Splash");
 
 const STRUGGLE_DATA: MoveData = { // duplicated in MoveSelection.tsx
-    name: "Struggle" as MoveName, 
+    name: "Struggle" as MoveName,
     moveCategory: "Physical",
     category: "damage",
     target: "selected-pokemon",
@@ -61,7 +61,7 @@ export class RaidTurn {
 
     _raiderMovesFirst!: boolean;
     _raider!:           Raider;
-    _boss!:             Raider;  
+    _boss!:             Raider;
     _raiderMove!:       Move;
     _bossMove!:         Move;
     _raiderMoveData!:   MoveData;
@@ -80,7 +80,7 @@ export class RaidTurn {
     _delayedResults!:   RaidMoveResult[];
     _raidState!:        RaidState; // This tracks changes during this turn
 
-    _flags!:            string[][]; 
+    _flags!:            string[][];
     _endFlags!:         string[];
 
 
@@ -89,7 +89,7 @@ export class RaidTurn {
         this.raiderID = info.moveInfo.userID;
         this.targetID = info.moveInfo.targetID;
         this.raiderMoveData = {...info.moveInfo.moveData};  // prevent mutating the original data
-        if (Object.keys(info.moveInfo.moveData).length === 1) { // Transform or Mimic can cause issues with loading full movedata from hashes
+        if (this.raiderID < 5 && Object.keys(info.moveInfo.moveData).length === 1) { // Transform or Mimic can cause issues with loading full movedata from hashes
             const raiderMoveData = this.raidState.raiders[this.raiderID].moveData.find((move) => move.name === info.moveInfo.moveData.name) || {name: info.moveInfo.moveData.name} as MoveData;
             this.raiderMoveData = {...raiderMoveData};
         }
@@ -115,7 +115,7 @@ export class RaidTurn {
         // check if this marks the end of a 4-move "turn"
         this._turnMoveNumber = this.turnNumber % 4;
         this._isEndOfFullTurn = !this._isBossAction && !this._isEmptyTurn && (
-            (this._turnMoveNumber === 3) // || 
+            (this._turnMoveNumber === 3) // ||
             // (this.raiderID === 1 && ((this.numNPCs + turnMoveNumber) >= 3))
         );
         // set up moves
@@ -133,13 +133,13 @@ export class RaidTurn {
         this._endFlags = [];
 
         // switch-in if previously fainted
-        if (this._raidState.raiders[this.raiderID].originalCurHP === 0) {
+        if (this.raiderID < 5 && this._raidState.raiders[this.raiderID].originalCurHP === 0) {
             this._flags[this.raiderID].push("Switched in");
             this._raidState.switchIn(this.raiderID);
             // use dummy move to activate conditional items/abilities
             const moveResult = new RaidMove(
-                {name: "(No Move)" as MoveName, target: "user"}, 
-                new Move(gen, "(No Move)"), 
+                {name: "(No Move)" as MoveName, target: "user"},
+                new Move(gen, "(No Move)"),
                 this._raidState,
                 this.raiderID,
                 this.raiderID,
@@ -171,9 +171,9 @@ export class RaidTurn {
 
         if (!this._isEmptyTurn) {
             this.applyChangedMove();
-        }        
+        }
 
-        // steal tera charge 
+        // steal tera charge
         // deprecated, kept for compaitiblity of old links
         if (this.bossOptions.stealTeraCharge) {
             this._flags[0].push("The Raid Boss stole a Tera charge!");
@@ -212,9 +212,9 @@ export class RaidTurn {
             this.applyRaiderIndirectMove();
             this._raidMove1 = new RaidMove(
                 this._raiderMoveData,
-                this._raiderMove, 
-                this._raidState, 
-                this._raiderMoveID, 
+                this._raiderMove,
+                this._raidState,
+                this._raiderMoveID,
                 this._raiderMoveTarget,
                 this.raiderID,
                 this._turnMoveNumber,
@@ -232,10 +232,10 @@ export class RaidTurn {
             this.applyBossIndirectMove();
             this._raidMove2 = new RaidMove(
                 this._bossMoveData,
-                this._bossMove, 
-                this._raidState, 
-                0, 
-                ["all-opponents","all-other-pokemon","all-pokemon"].includes(this._bossMoveData.target || "") ? this._raiderMoveID : this.raiderID, // If Instruct is used before the boss moves, spread moves from the boss will hit the target of instruct 
+                this._bossMove,
+                this._raidState,
+                0,
+                ["all-opponents","all-other-pokemon","all-pokemon"].includes(this._bossMoveData.target || "") ? this._raiderMoveID : this.raiderID, // If Instruct is used before the boss moves, spread moves from the boss will hit the target of instruct
                 this.raiderID,
                 this._turnMoveNumber,
                 !this._raiderMovesFirst,
@@ -249,10 +249,10 @@ export class RaidTurn {
         } else {
             this.applyBossIndirectMove();
             this._raidMove1 = new RaidMove(
-                this._bossMoveData, 
-                this._bossMove, 
-                this._raidState, 
-                0, 
+                this._bossMoveData,
+                this._bossMove,
+                this._raidState,
+                0,
                 this.raiderID,
                 this.raiderID,
                 this._turnMoveNumber,
@@ -264,10 +264,10 @@ export class RaidTurn {
             this._raidState = this._result1.state;
             this.applyRaiderIndirectMove();
             this._raidMove2 = new RaidMove(
-                this._raiderMoveData, 
-                this._raiderMove, 
-                this._raidState, 
-                this._raiderMoveID, 
+                this._raiderMoveData,
+                this._raiderMove,
+                this._raidState,
+                this._raiderMoveID,
                 this._raiderMoveTarget,
                 this.raiderID,
                 this._turnMoveNumber,
@@ -315,7 +315,7 @@ export class RaidTurn {
             state: this._raidState,
             results: [this._result1, this._result2, ...this._delayedResults],
             raiderMovesFirst: this._raiderMovesFirst,
-            raiderMoveUsed: this._raiderMoveUsed + (this._raidState.raiders[this.raiderID].isCharging ? " (Charging)" : "") + (this.raidState.raiders[this.raiderID].isRecharging ? " (Recharging)" : ""),
+            raiderMoveUsed: this._raiderMoveUsed + (this.raiderID < 5 && this._raidState.raiders[this.raiderID].isCharging ? " (Charging)" : "") + (this.raiderID < 5 && this.raidState.raiders[this.raiderID].isRecharging ? " (Recharging)" : ""),
             bossMoveUsed: this._bossMoveUsed + (this._raidState.raiders[0].isCharging ? " (Charging)" : "") + (this.raidState.raiders[0].isRecharging ? " (Recharging)" : ""),
             id: this.id,
             group: this.group,
@@ -339,7 +339,7 @@ export class RaidTurn {
     }
 
     private applyChangedMove() {
-        const raiderSelectableMoves = getSelectableMoves(this.raidState.raiders[this.raiderID], false)[0];
+        const raiderSelectableMoves = this.raiderID === 5 ? ["(No Move)"] : getSelectableMoves(this.raidState.raiders[this.raiderID], false)[0];
         const bossSelectableMoves = getSelectableMoves(this.raidState.raiders[0], this._isBossAction)[0];
         // handle invalid move selection
         if (isRegularMove(this.raiderMoveData.name) && !raiderSelectableMoves.includes(this.raiderMoveData.name)) {
@@ -349,7 +349,7 @@ export class RaidTurn {
             this._bossMoveData = bossSelectableMoves.length > 0 ? {name: "(Most Damaging)" as MoveName} : {...STRUGGLE_DATA}
         }
         // Charge up moves (should be redundant with the above now)
-        // if (this._raider.isCharging) { 
+        // if (this._raider.isCharging) {
         //     this._raiderMoveData = this.raidState.raiders[this.raiderID].lastMove!;
         //     this._raiderMove = new Move(9, this._raiderMoveData.name, this.raiderOptions);
         //     if (this.raiderOptions.crit) this._raiderMove.isCrit = true;
@@ -376,7 +376,7 @@ export class RaidTurn {
         // }
         // pollen puff
         if (this.raiderMoveData.name === "Pollen Puff") {
-            if (this.targetID !== 0) { 
+            if (this.targetID !== 0) {
                 this._raiderMoveData = {
                     ...this.raiderMoveData,
                     power: 0,
@@ -428,7 +428,7 @@ export class RaidTurn {
                         damage = result.damage;
                     } else {
                         damage = (this.bossOptions.roll === "min" ? result.damage[0] :
-                                this.bossOptions.roll === "max" ? result.damage[result.damage.length - 1] : 
+                                this.bossOptions.roll === "max" ? result.damage[result.damage.length - 1] :
                                 result.damage[Math.floor(result.damage.length / 2)]) as number;
                     }
                     damage = damage * hits; // since this isn't being handled by calculate
@@ -462,7 +462,7 @@ export class RaidTurn {
                         damage = result.damage;
                     } else {
                         damage = (this.raiderOptions.roll === "min" ? result.damage[0] :
-                                this.raiderOptions.roll === "max" ? result.damage[result.damage.length - 1] : 
+                                this.raiderOptions.roll === "max" ? result.damage[result.damage.length - 1] :
                                 result.damage[Math.floor(result.damage.length / 2)]) as number;
                     }
                     damage = damage * hits; // since this isn't being handled by calculate
@@ -483,7 +483,7 @@ export class RaidTurn {
         //     if (this.raiderOptions.crit) this._raiderMove.isCrit = true;
         //     if (this.raiderOptions.hits !== undefined) this._raiderMove.hits = this.raiderOptions.hits;
         //     this._raiderMoveUsed = this._raiderMoveData.name;
-        // } 
+        // }
     }
 
     private applyRaiderIndirectMove() {
@@ -528,6 +528,10 @@ export class RaidTurn {
     }
 
     private setTurnOrder() {
+        if (this._isBossAction || this.targetID === 5) {
+            this._raiderMovesFirst = false;
+            return;
+        }
         this._raider = this._raidState.raiders[this.raiderID];
         this._boss = this._raidState.raiders[0];
 
@@ -557,7 +561,7 @@ export class RaidTurn {
             } else {
                 const raiderSpeed = this._raider.effectiveSpeed;
                 const bossSpeed = this._boss.effectiveSpeed;
-    
+
                 const bossField = this._raidState.fields[0];
                 this._raiderMovesFirst = bossField.isTrickRoom ? (raiderSpeed < bossSpeed) : (raiderSpeed > bossSpeed);
             }
@@ -677,7 +681,7 @@ export class RaidTurn {
             const pokemon =  this._raidState.raiders[id];
             if (!pokemon.abilityNullified && (pokemon.id !== 0 || this._isEndOfFullTurn) && (pokemon.originalCurHP > 0)) {
                 switch (pokemon.ability) {
-                    case "Slow Start": 
+                    case "Slow Start":
                         if (pokemon.slowStartCounter) {
                             pokemon.slowStartCounter--;
                             if (pokemon.slowStartCounter === 0) {
@@ -724,7 +728,7 @@ export class RaidTurn {
                             pokemon.status = "";
                         }
                         break;
-                    case "Harvest": 
+                    case "Harvest":
                         if (pokemon.field.hasWeather("Sun") && !pokemon.item && (pokemon.lastConsumedItem || "").includes("Berry")) {
                             this._raidState.receiveItem(pokemon.id, pokemon.lastConsumedItem!);
                             this._endFlags.push(pokemon.role + ` — ${pokemon.lastConsumedItem} restored (Harvest)`);
@@ -752,7 +756,9 @@ export class RaidTurn {
 
     private removeProtection() {
         const fields = this._raidState.fields;
-        fields[this.raiderID].attackerSide.isProtected = false;
+        if (this.raiderID < 5) {
+            fields[this.raiderID].attackerSide.isProtected = false;
+        }
         fields[0].attackerSide.isProtected = false;
         for (let field of fields) {
             if (this._isEndOfFullTurn) {
@@ -831,7 +837,7 @@ export class RaidTurn {
             if (pokemon.isYawn && this._isEndOfFullTurn) {
                 pokemon.isYawn--;
                 if (pokemon.isYawn === 0) {
-                    const sleepTurns = pokemon.id === 0 ? (this.bossOptions.roll === "max" ? 1 : (this.bossOptions.roll === "min" ? 3 : 2)) : 
+                    const sleepTurns = pokemon.id === 0 ? (this.bossOptions.roll === "max" ? 1 : (this.bossOptions.roll === "min" ? 3 : 2)) :
                                                 (this.raiderOptions.roll === "max" ? 1 : (this.raiderOptions.roll === "min" ? 3 : 2));
                     this._raidState.applyStatus(pokemon.id, "slp", pokemon.id, false);
                     if (pokemon.status === "slp") {

--- a/src/uicomponents/MoveDisplay.tsx
+++ b/src/uicomponents/MoveDisplay.tsx
@@ -10,17 +10,17 @@ import { RaidBattleResults } from "../raidcalc/RaidBattle";
 
 function MoveText({raiders, turn, result, translationKey}: {raiders: Raider[], turn: RaidTurnInfo, result: RaidTurnResult, translationKey: any}) {
 
-    let name = raiders[turn.moveInfo.userID].name;
-    let user = raiders[turn.moveInfo.userID].role;
+    let name = raiders[turn.moveInfo.userID]?.name;
+    let user = raiders[turn.moveInfo.userID]?.role;
 
-    let target = raiders[turn.moveInfo.targetID].role;
-    if (turn.moveInfo.userID === turn.moveInfo.targetID) { 
+    let target = raiders[turn.moveInfo.targetID]?.role;
+    if (turn.moveInfo.userID === turn.moveInfo.targetID) {
         target = ""
     }
     if ([undefined, "user", "user-and-allies", "all-allies", "users-field", "opponents-field", "entire-field", ].includes(turn.moveInfo.moveData.target)) {
         target = "";
     }
-    let targetName = raiders[turn.moveInfo.targetID].name;
+    let targetName = raiders[turn.moveInfo.targetID]?.name;
 
     let move: string = result ? result.raiderMoveUsed : "";
     if (move ==="(No Move)") {
@@ -32,7 +32,7 @@ function MoveText({raiders, turn, result, translationKey}: {raiders: Raider[], t
         name = raiders[0].name;
         user = raiders[0].role;
         target = raiders[turn.moveInfo.userID].role;
-        if (turn.bossMoveInfo.targetID === turn.bossMoveInfo.userID) { 
+        if (turn.bossMoveInfo.targetID === turn.bossMoveInfo.userID) {
             target = ""
         }
         if ([undefined, "user", "user-and-allies", "all-allies", "users-field", "opponents-field", "entire-field", "all-opponents", "all-pokemon", "all-other-pokemon"].includes(turn.bossMoveInfo.moveData.target)) {
@@ -69,7 +69,7 @@ function MoveText({raiders, turn, result, translationKey}: {raiders: Raider[], t
                     { move === "Waits" ? "" : getTranslation("uses", translationKey) }
                 </Typography>
                 <Stack direction="row" spacing={0} alignItems="center" justifyContent="center">
-                    {teraActivated && 
+                    {teraActivated &&
                         <Box
                             sx={{
                                 width: "25px",
@@ -118,7 +118,7 @@ function MoveGroup({group, results, raiders, index, max, translationKey}: {group
             <Stack direction="row" alignItems="center" justifyContent="center">
                 <Stack direction="column" spacing={1}>
                     {
-                        turns.map((t, i) => { 
+                        turns.map((t, i) => {
                             const turnIndex = results.turnResults.findIndex((r) => r.id === t.id)!;
                             const turnRaiders = turnIndex > 0 ? results.turnResults[turnIndex-1].state.raiders : results.turnZeroState.raiders;
                             return (
@@ -126,14 +126,14 @@ function MoveGroup({group, results, raiders, index, max, translationKey}: {group
                             )
                         })
                     }
-                </Stack>                    
-                { (group.repeats && group.repeats > 1) && 
+                </Stack>
+                { (group.repeats && group.repeats > 1) &&
                     <Typography variant="h6" fontWeight="bold" margin="15px">
                         {"×"+group.repeats}
                     </Typography>
                 }
             </Stack>
-            {index !== max - 1  && 
+            {index !== max - 1  &&
                 <Typography align="center" variant="h5" fontWeight="bold" sx={{ my: 0.5}}>
                     ↓
                 </Typography>
@@ -166,7 +166,7 @@ function MoveTurn({turnNumber, groups, raiders, results, index, translationKey}:
     )
 }
 
-function MoveDisplay({groups, raiders, results, translationKey}: {groups: TurnGroupInfo[], raiders: Raider[], results: RaidBattleResults, translationKey: any}) { 
+function MoveDisplay({groups, raiders, results, translationKey}: {groups: TurnGroupInfo[], raiders: Raider[], results: RaidBattleResults, translationKey: any}) {
     const turnNumbers = getTurnNumbersFromGroups(groups);
     const [turnGroups, turnLabels] = sortGroupsIntoTurns(turnNumbers, groups);
     const resultsLen = results.turnResults.length;

--- a/src/uicomponents/MoveSelection.tsx
+++ b/src/uicomponents/MoveSelection.tsx
@@ -412,11 +412,10 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
         }
         if (userID === 0) {
             newMoveInfo.moveData = turn.bossMoveInfo.moveData;
-            if (!raiders[0].extraMoves?.includes(newMoveInfo.moveData.name)) {
+            if (!raiders[0].extraMoves?.includes(newMoveInfo.moveData.name) && !["Remove Negative Effects", "Clear Boosts / Abilities", "Steal Tera Charge", "Activate Shield"].includes(newMoveInfo.moveData.name)) {
                 newMoveInfo.moveData = raiders[0].extraMoveData ? raiders[0].extraMoveData[0] : {name: "Remove Negative Effects" as MoveName};
-            } else {
-                newMoveInfo.targetID = 5;
             }
+            newMoveInfo.targetID = 5;
         } else if (moveInfo.userID === 0) {
             newMoveInfo.moveData = turn.bossMoveInfo.moveData;
             newMoveInfo.moveData = {name: "(No Move)" as MoveName};

--- a/src/uicomponents/MoveSelection.tsx
+++ b/src/uicomponents/MoveSelection.tsx
@@ -67,7 +67,7 @@ const handleAddGroup = (groups: TurnGroupInfo[], setGroups: (t: TurnGroupInfo[])
         }
     }
     let newGroups = [...groups];
-    const newGroup: TurnGroupInfo = 
+    const newGroup: TurnGroupInfo =
     {   id: uniqueGroupId,
         repeats: 1,
         turns: [
@@ -75,27 +75,27 @@ const handleAddGroup = (groups: TurnGroupInfo[], setGroups: (t: TurnGroupInfo[])
                 id: uniqueTurnId,
                 group: uniqueGroupId,
                 moveInfo: {
-                    userID: 1, 
-                    targetID: 0, 
-                    moveData: {name: "(No Move)" as MoveName}, 
+                    userID: 1,
+                    targetID: 0,
+                    moveData: {name: "(No Move)" as MoveName},
                     options: {
-                        crit: rollCase === "max", 
-                        secondaryEffects: rollCase === "max", 
+                        crit: rollCase === "max",
+                        secondaryEffects: rollCase === "max",
                         allowMiss: rollCase === "min",
-                        roll: rollCase, 
+                        roll: rollCase,
                         hits: rollCase === "max" ? 10 : 1,
                     }
                 },
                 bossMoveInfo: {
-                    userID: 0, 
+                    userID: 0,
                     targetID: 1,
-                    moveData: {name: "(Most Damaging)" as MoveName}, 
+                    moveData: {name: "(Most Damaging)" as MoveName},
                     options: {
-                        crit: rollCase === "min", 
-                        secondaryEffects: rollCase === "min", 
+                        crit: rollCase === "min",
+                        secondaryEffects: rollCase === "min",
                         allowMiss: rollCase === "max",
-                        roll: rollCase === "max" ? "min" : (rollCase === "min" ? "max" : rollCase), 
-                        hits: rollCase === "min" ? 10 : 1, 
+                        roll: rollCase === "max" ? "min" : (rollCase === "min" ? "max" : rollCase),
+                        hits: rollCase === "min" ? 10 : 1,
                     }
                 },
             }
@@ -120,27 +120,27 @@ const handleAddTurn = (groupIndex: number, groups: TurnGroupInfo[], setGroups: (
         id: uniqueId,
         group: newGroups[groupIndex].id,
         moveInfo: {
-            userID: 1, 
-            targetID: 0, 
-            moveData: {name: "(No Move)" as MoveName}, 
+            userID: 1,
+            targetID: 0,
+            moveData: {name: "(No Move)" as MoveName},
             options: {
-                crit: rollCase === "max", 
-                secondaryEffects: rollCase === "max", 
-                roll: rollCase, 
+                crit: rollCase === "max",
+                secondaryEffects: rollCase === "max",
+                roll: rollCase,
                 allowMiss: rollCase === "min",
                 hits: rollCase === "max" ? 10 : 1,
             }
         },
         bossMoveInfo: {
-            userID: 0, 
+            userID: 0,
             targetID: 1,
-            moveData: {name: "(Most Damaging)" as MoveName}, 
+            moveData: {name: "(Most Damaging)" as MoveName},
             options: {
-                crit: rollCase === "min", 
-                secondaryEffects: rollCase === "min", 
-                roll: rollCase === "max" ? "min" : (rollCase === "min" ? "max" : rollCase), 
+                crit: rollCase === "min",
+                secondaryEffects: rollCase === "min",
+                roll: rollCase === "max" ? "min" : (rollCase === "min" ? "max" : rollCase),
                 allowMiss: rollCase === "max",
-                hits: rollCase === "min" ? 10 : 1, 
+                hits: rollCase === "min" ? 10 : 1,
             }
         },
     };
@@ -158,8 +158,8 @@ function MoveOptionsControls({moveInfo, setMoveInfo, raider, isBoss = false, tra
     const handleClose = () => {
       setAnchorEl(null);
     };
-    
-    const critChecked = moveInfo.options ? (moveInfo.options.crit || false) : false; 
+
+    const critChecked = moveInfo.options ? (moveInfo.options.crit || false) : false;
     const effectChecked = moveInfo.options ? (moveInfo.options.secondaryEffects || false) : false;
     const allowMissChecked = moveInfo.options ? (moveInfo.options.allowMiss || false) : false;
     const roll = moveInfo.options ? (moveInfo.options.roll) || "avg" : "avg";
@@ -167,7 +167,7 @@ function MoveOptionsControls({moveInfo, setMoveInfo, raider, isBoss = false, tra
 
     return (
         <Box>
-            <IconButton 
+            <IconButton
                 onClick={handleClick}
             >
                 <MenuIcon />
@@ -198,8 +198,8 @@ function MoveOptionsControls({moveInfo, setMoveInfo, raider, isBoss = false, tra
                                             {getTranslation("Tera",translationKey)}
                                         </TableCell>
                                         <TableCell>
-                                            <Switch 
-                                                size="small" 
+                                            <Switch
+                                                size="small"
                                                 style={{ padding: "4px"}}
                                                 checked={activateTeraChecked}
                                                 onChange={
@@ -216,8 +216,8 @@ function MoveOptionsControls({moveInfo, setMoveInfo, raider, isBoss = false, tra
                                         {getTranslation("Crit",translationKey)}
                                     </TableCell>
                                     <TableCell>
-                                        <Switch 
-                                            size="small" 
+                                        <Switch
+                                            size="small"
                                             style={{ padding: "4px"}}
                                             checked={critChecked}
                                             onChange={
@@ -233,8 +233,8 @@ function MoveOptionsControls({moveInfo, setMoveInfo, raider, isBoss = false, tra
                                         {getTranslation("Effect",translationKey)}
                                     </TableCell>
                                     <TableCell>
-                                        <Switch 
-                                            size="small" 
+                                        <Switch
+                                            size="small"
                                             style={{ padding: "4px"}}
                                             checked={effectChecked}
                                             onChange={
@@ -250,8 +250,8 @@ function MoveOptionsControls({moveInfo, setMoveInfo, raider, isBoss = false, tra
                                         {getTranslation("Allow Miss",translationKey)}
                                     </TableCell>
                                     <TableCell>
-                                        <Switch 
-                                            size="small" 
+                                        <Switch
+                                            size="small"
                                             style={{ padding: "4px"}}
                                             checked={allowMissChecked}
                                             onChange={
@@ -305,8 +305,8 @@ function MoveOptionsControls({moveInfo, setMoveInfo, raider, isBoss = false, tra
                                             {getTranslation("Steal Tera Charge", translationKey)}
                                         </TableCell>
                                         <TableCell sx={{ borderBottom: 0 }}>
-                                            <Switch 
-                                                size="small" 
+                                            <Switch
+                                                size="small"
                                                 style={{ padding: "4px"}}
                                                 checked={moveInfo.options?.stealTeraCharge || false}
                                                 onChange={
@@ -327,8 +327,8 @@ function MoveOptionsControls({moveInfo, setMoveInfo, raider, isBoss = false, tra
     )
 }
 
-function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, selectableMoves, isActionLocked, translationKey}: 
-    {groupIndex: number, turnIndex: number, raiders: Raider[], groups: TurnGroupInfo[], setGroups: (t: TurnGroupInfo[]) => void, selectableMoves: MoveName[], isActionLocked: boolean, translationKey: any}) 
+function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, selectableMoves, isActionLocked, translationKey}:
+    {groupIndex: number, turnIndex: number, raiders: Raider[], groups: TurnGroupInfo[], setGroups: (t: TurnGroupInfo[]) => void, selectableMoves: MoveName[], isActionLocked: boolean, translationKey: any})
 {
     const roles = raiders.map((raider) => raider.role);
     const moveInfo = groups[groupIndex].turns[turnIndex].moveInfo;
@@ -347,7 +347,7 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
             moveInfo.moveData.target === "user" ||
             moveInfo.moveData.target === "user-and-allies" ||
             moveInfo.moveData.target === "all-allies" ||
-            ( moveInfo.userID === 0 && 
+            ( moveInfo.userID === 0 &&
                 (
                     moveInfo.moveData.target === "all-opponents" ||
                     moveInfo.moveData.target === "all-other-pokemon" ||
@@ -358,8 +358,8 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
             moveInfo.moveData.target === "opponents-field" ||
             moveInfo.moveData.target === "entire-field"
     );
-    const [validTargets, setValidTargets] = useState<number[]>(disableTarget ? [moveInfo.userID] : getSelectableTargets(moveInfo.moveData.target).filter((id) => id !== moveInfo.userID));
-    
+    const [validTargets, setValidTargets] = useState<number[]>(disableTarget ? [moveInfo.userID] : getSelectableTargets(moveInfo.userID, moveInfo.moveData.target, moveInfo.userID === 0));
+
     const setMoveInfo = (moveInfo: RaidMoveInfo) => {
         const newGroups = [...groups];
         newGroups[groupIndex].turns[turnIndex].moveInfo = moveInfo;
@@ -371,7 +371,7 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
             moveInfo.moveData.target === "user" ||
             moveInfo.moveData.target === "user-and-allies" ||
             moveInfo.moveData.target === "all-allies" ||
-            ( moveInfo.userID === 0 && 
+            ( moveInfo.userID === 0 &&
                 (
                     moveInfo.moveData.target === "all-opponents" ||
                     moveInfo.moveData.target === "all-other-pokemon" ||
@@ -382,8 +382,8 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
             moveInfo.moveData.target === "opponents-field" ||
             moveInfo.moveData.target === "entire-field"
         );
-        const newValidTargets = newDisableTarget ? [moveInfo.userID] : getSelectableTargets(moveInfo.moveData.target).filter((id) => id !== moveInfo.userID)
-    
+        const newValidTargets = newDisableTarget ? [moveInfo.userID] : getSelectableTargets(moveInfo.userID, moveInfo.moveData.target, moveInfo.userID === 0);
+
         setDisableTarget(newDisableTarget);
         setValidTargets(newValidTargets);
         if (!newValidTargets.includes(moveInfo.targetID)) {
@@ -414,6 +414,8 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
             newMoveInfo.moveData = turn.bossMoveInfo.moveData;
             if (!raiders[0].extraMoves?.includes(newMoveInfo.moveData.name)) {
                 newMoveInfo.moveData = raiders[0].extraMoveData ? raiders[0].extraMoveData[0] : {name: "Remove Negative Effects" as MoveName};
+            } else {
+                newMoveInfo.targetID = 5;
             }
         } else if (moveInfo.userID === 0) {
             newMoveInfo.moveData = turn.bossMoveInfo.moveData;
@@ -425,7 +427,7 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
                 newMoveInfo.moveData = {name: "(No Move)" as MoveName};
                 newMoveInfo.userID = userID;
                 newMoveInfo.targetID = userID;
-            } 
+            }
         }
         if (bossSwap) {
             turn.bossMoveInfo = {
@@ -437,7 +439,7 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
         }
         setMoveInfo(newMoveInfo);
     }
-    
+
     useEffect(() => {
         if (!moveSet.includes(moveName)) {
             setMoveInfo({...moveInfo, moveData: {name: "(No Move)" as MoveName}});
@@ -471,7 +473,7 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
         //             newMoveInfo.moveData = {name: "(No Move)" as MoveName};
         //             newMoveInfo.userID = raider.id;
         //             newMoveInfo.targetID = raider.id;
-        //         } 
+        //         }
         //     }
         //     turn.bossMoveInfo = {
         //         moveData: userIDRef.current === 0 ? {...moveInfo.moveData} : {name: "(No Move)" as MoveName},
@@ -490,7 +492,7 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
             moveInfo.moveData.target === "user" ||
             moveInfo.moveData.target === "user-and-allies" ||
             moveInfo.moveData.target === "all-allies" ||
-            ( moveInfo.userID === 0 && 
+            ( moveInfo.userID === 0 &&
                 (
                     moveInfo.moveData.target === "all-opponents" ||
                     moveInfo.moveData.target === "all-other-pokemon" ||
@@ -501,9 +503,10 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
             moveInfo.moveData.target === "opponents-field" ||
             moveInfo.moveData.target === "entire-field"
         );
-        const newValidTargets = newDisableTarget ? [moveInfo.userID] : getSelectableTargets(moveInfo.moveData.target).filter((id) => id !== moveInfo.userID)
+        const newValidTargets = newDisableTarget ? [moveInfo.userID] : getSelectableTargets(moveInfo.userID, moveInfo.moveData.target, moveInfo.userID === 0);
         setDisableTarget(newDisableTarget);
         setValidTargets(newValidTargets);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [moveInfo.userID])
 
     return (
@@ -564,7 +567,7 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
                         />
 
                     } */}
-                    <Select 
+                    <Select
                         size="small"
                         variant="standard"
                         value = {moveInfo.moveData.name}
@@ -596,12 +599,12 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
                         }
                         sx={{ maxWidth : "130px" }}
                     >
-                        {moveSet.map((move, i) => 
-                        <MenuItem 
-                            key={i} 
+                        {moveSet.map((move, i) =>
+                        <MenuItem
+                            key={i}
                             value={move}
                         >
-                            <Typography 
+                            <Typography
                                 variant="body2"
                             >
                                 { getTranslation(move, translationKey, "moves") }
@@ -625,6 +628,15 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
                         sx={{ maxWidth : "175px"}}
                     >
                         {validTargets.map((id, i) => {
+                            if (id === 5) {
+                                return (
+                                <MenuItem key={i} value={id}>
+                                    <Stack direction="row" spacing={0.5} justifyContent="center" alignItems="center">
+                                        <Typography variant="body2">{getTranslation("(Random Target)", translationKey)}</Typography>
+                                    </Stack>
+                                </MenuItem>
+                                )
+                            }
                             const raider = disableTarget ? raiders[moveInfo.userID] : raiders[id];
                             const role = raider.role;
                             const name = raider.name;
@@ -653,12 +665,12 @@ function MoveDropdown({groupIndex, turnIndex, raiders, groups, setGroups, select
     )
 }
 
-function BossMoveDropdown({groupIndex, turnIndex, boss, groups, setGroups, selectableMoves, translationKey}: 
-    {groupIndex: number, turnIndex: number, boss: Raider, groups: TurnGroupInfo[], setGroups: (t: TurnGroupInfo[]) => void, selectableMoves: MoveName[], translationKey: any}) 
+function BossMoveDropdown({groupIndex, turnIndex, boss, groups, setGroups, selectableMoves, translationKey}:
+    {groupIndex: number, turnIndex: number, boss: Raider, groups: TurnGroupInfo[], setGroups: (t: TurnGroupInfo[]) => void, selectableMoves: MoveName[], translationKey: any})
 {
     const moveInfo = groups[groupIndex].turns[turnIndex].bossMoveInfo;
     const moveSet = [
-        "(No Move)", "(Most Damaging)", "(Optimal Move)", ...selectableMoves, 
+        "(No Move)", "(Most Damaging)", "(Optimal Move)", ...selectableMoves,
         ...(groups[groupIndex].turns[turnIndex].moveInfo.moveData.name === "(No Move)" ? ["Remove Negative Effects", "Clear Boosts / Abilities", "Steal Tera Charge", "Activate Shield"] : [])
     ];
 
@@ -675,7 +687,7 @@ function BossMoveDropdown({groupIndex, turnIndex, boss, groups, setGroups, selec
     useEffect(() => {
         if (!moveSet.includes(moveName)) {
             setMoveInfo({...moveInfo, moveData: {name: "(Most Damaging)" as MoveName}});
-        } 
+        }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [moveSet])
 
@@ -699,7 +711,7 @@ function BossMoveDropdown({groupIndex, turnIndex, boss, groups, setGroups, selec
                     {getTranslation("uses", translationKey)}
                 </Typography>
                 <Box flexGrow={1} />
-                <Select 
+                <Select
                     size="small"
                     variant="standard"
                     value = {moveName}
@@ -718,12 +730,12 @@ function BossMoveDropdown({groupIndex, turnIndex, boss, groups, setGroups, selec
                     }
                     sx={{ maxWidth : "150px"}}
                 >
-                    {moveSet.map((move, i) => 
-                        <MenuItem 
-                            key={i} 
+                    {moveSet.map((move, i) =>
+                        <MenuItem
+                            key={i}
                             value={move}
                         >
-                            <Typography 
+                            <Typography
                                 variant="body2"
                             >
                                 { getTranslation(move, translationKey, "moves") }
@@ -738,15 +750,15 @@ function BossMoveDropdown({groupIndex, turnIndex, boss, groups, setGroups, selec
     )
 }
 
-function MoveSelectionContainer({raiders, turnIndex, groupIndex, groups, setGroups, buttonsVisible, transitionIn, setTransitionIn, transitionOut, setTransitionOut, translationKey}: 
-    {raiders: Raider[], turnIndex: number, groupIndex: number, groups: TurnGroupInfo[], setGroups: (t: TurnGroupInfo[]) => void, buttonsVisible: boolean, transitionIn: number, setTransitionIn: (i: number) => void, transitionOut: number, setTransitionOut: (i: number) => void, translationKey: any}) 
+function MoveSelectionContainer({raiders, turnIndex, groupIndex, groups, setGroups, buttonsVisible, transitionIn, setTransitionIn, transitionOut, setTransitionOut, translationKey}:
+    {raiders: Raider[], turnIndex: number, groupIndex: number, groups: TurnGroupInfo[], setGroups: (t: TurnGroupInfo[]) => void, buttonsVisible: boolean, transitionIn: number, setTransitionIn: (i: number) => void, transitionOut: number, setTransitionOut: (i: number) => void, translationKey: any})
 {
     const turn = groups[groupIndex].turns[turnIndex];
     const turnID = turn.id;
     const collapseIn = transitionOut !== turnID && transitionIn !== turnID;
 
     const bossSelectableMoves = getSelectableMoves(
-        raiders[0], 
+        raiders[0],
         (
             turn.moveInfo.moveData.name === "(No Move)" ||
             turn.moveInfo.userID === 0
@@ -776,19 +788,19 @@ function MoveSelectionContainer({raiders, turnIndex, groupIndex, groups, setGrou
                         {...provided.dragHandleProps}
                     >
                         <Collapse in={collapseIn} timeout={250}>
-                            <MoveSelectionCardMemo 
-                                raiders={raiders} 
-                                groupIndex={groupIndex} 
-                                turnIndex={turnIndex} 
-                                groups={groups} 
-                                setGroups={setGroups} 
+                            <MoveSelectionCardMemo
+                                raiders={raiders}
+                                groupIndex={groupIndex}
+                                turnIndex={turnIndex}
+                                groups={groups}
+                                setGroups={setGroups}
                                 raiderSelectableMoves={raiderSelectableMoves}
                                 isActionLocked={isActionLocked}
                                 bossSelectableMoves={bossSelectableMoves}
-                                buttonsVisible={buttonsVisible} 
+                                buttonsVisible={buttonsVisible}
                                 bossVisible={bossVisible}
-                                setTransitionIn={setTransitionIn} 
-                                setTransitionOut={setTransitionOut} 
+                                setTransitionIn={setTransitionIn}
+                                setTransitionOut={setTransitionOut}
                                 translationKey={translationKey}
                             />
                         </Collapse>
@@ -799,8 +811,8 @@ function MoveSelectionContainer({raiders, turnIndex, groupIndex, groups, setGrou
     )
 }
 
-function AddButton({label, onClick, visible, disabled=false, size="small"}: 
-    {label: string, onClick: () => void, visible: boolean, disabled?: boolean, size?: "small" | "medium" | "large"}) 
+function AddButton({label, onClick, visible, disabled=false, size="small"}:
+    {label: string, onClick: () => void, visible: boolean, disabled?: boolean, size?: "small" | "medium" | "large"})
 {
     const [color, setColor] = useState<"inherit" | "primary">("inherit");
     return (
@@ -840,8 +852,8 @@ function CloseButton({onClick, visible, disabled=false}: {onClick: () => void, v
     )
 }
 
-function MoveSelectionCard({raiders, groupIndex, turnIndex, groups, setGroups, raiderSelectableMoves, isActionLocked, bossSelectableMoves, buttonsVisible, bossVisible, setTransitionIn, setTransitionOut, translationKey}: 
-    {raiders: Raider[], groupIndex: number, turnIndex: number, groups: TurnGroupInfo[], setGroups: (t: TurnGroupInfo[]) => void, raiderSelectableMoves: MoveName[], isActionLocked: boolean, bossSelectableMoves: MoveName[], buttonsVisible: boolean, bossVisible: boolean, setTransitionIn: (i: number) => void, setTransitionOut: (i: number) => void, translationKey: any}) 
+function MoveSelectionCard({raiders, groupIndex, turnIndex, groups, setGroups, raiderSelectableMoves, isActionLocked, bossSelectableMoves, buttonsVisible, bossVisible, setTransitionIn, setTransitionOut, translationKey}:
+    {raiders: Raider[], groupIndex: number, turnIndex: number, groups: TurnGroupInfo[], setGroups: (t: TurnGroupInfo[]) => void, raiderSelectableMoves: MoveName[], isActionLocked: boolean, bossSelectableMoves: MoveName[], buttonsVisible: boolean, bossVisible: boolean, setTransitionIn: (i: number) => void, setTransitionOut: (i: number) => void, translationKey: any})
 {
     const timer = useRef<NodeJS.Timeout | null>(null);
     const handleRemoveTurn = () => {
@@ -858,10 +870,10 @@ function MoveSelectionCard({raiders, groupIndex, turnIndex, groups, setGroups, r
     const theme = useTheme();
     const color = alpha(theme.palette.background.paper, 0.5);
 
-    return (        
+    return (
         <Stack direction="column" spacing={0}>
-            <Paper 
-                sx={{ width: "550px", backgroundColor: color }} 
+            <Paper
+                sx={{ width: "550px", backgroundColor: color }}
             >
                 <Stack direction="row">
                     <Stack alignItems="center" justifyContent={"center"} paddingLeft={0.5}>
@@ -878,7 +890,7 @@ function MoveSelectionCard({raiders, groupIndex, turnIndex, groups, setGroups, r
                         {/* <Box width="80%">
                             <Divider />
                         </Box> */}
-                        { bossVisible && 
+                        { bossVisible &&
                             <BossMoveDropdown groupIndex={groupIndex} turnIndex={turnIndex} boss={raiders[0]} groups={groups} setGroups={setGroups} selectableMoves={bossSelectableMoves} translationKey={translationKey} />
                         }
                     </Stack>
@@ -899,7 +911,7 @@ const MoveSelectionCardMemo = React.memo(MoveSelectionCard, (prevProps, nextProp
     const nRaider = nTurn ? nextProps.raiders[nTurn.moveInfo.userID] : undefined;
     return (
         prevProps.groupIndex === nextProps.groupIndex &&
-        prevProps.turnIndex === nextProps.turnIndex && 
+        prevProps.turnIndex === nextProps.turnIndex &&
         pGroup.id === nGroup.id &&
         pGroup.repeats === nGroup.repeats &&
         (!!pTurn && !!nTurn) &&
@@ -930,7 +942,7 @@ const MoveSelectionCardMemo = React.memo(MoveSelectionCard, (prevProps, nextProp
         arraysEqual(prevProps.raiders.map((r) => r.name), nextProps.raiders.map((r) => r.name)) &&
         arraysEqual(prevProps.raiders.map((r) => r.role), nextProps.raiders.map((r) => r.role)) &&
         arraysEqual(prevProps.raiderSelectableMoves, nextProps.raiderSelectableMoves) &&
-        prevProps.isActionLocked === nextProps.isActionLocked && 
+        prevProps.isActionLocked === nextProps.isActionLocked &&
         arraysEqual(prevProps.bossSelectableMoves, nextProps.bossSelectableMoves) &&
         prevProps.buttonsVisible === nextProps.buttonsVisible &&
         prevProps.bossVisible === nextProps.bossVisible &&
@@ -939,9 +951,9 @@ const MoveSelectionCardMemo = React.memo(MoveSelectionCard, (prevProps, nextProp
     )
 });
 
-function MoveGroupContainer({raidInputProps, results, groupIndex, firstMoveIndex, rollCase, buttonsVisible, transitionIn, setTransitionIn, transitionOut, setTransitionOut, translationKey}: 
+function MoveGroupContainer({raidInputProps, results, groupIndex, firstMoveIndex, rollCase, buttonsVisible, transitionIn, setTransitionIn, transitionOut, setTransitionOut, translationKey}:
     {raidInputProps: RaidInputProps, results: RaidBattleResults, groupIndex: number, firstMoveIndex: number, rollCase: "min" | "avg" | "max", buttonsVisible: boolean, transitionIn: number, setTransitionIn: (i: number) => void, transitionOut: number, setTransitionOut: (i: number) => void, translationKey: any}) {
-    
+
     const color = "group" + raidInputProps.groups[groupIndex].id.toString().slice(-1) + ".main";
     const timer = useRef<NodeJS.Timeout | null>(null);
 
@@ -980,7 +992,7 @@ function MoveGroupContainer({raidInputProps, results, groupIndex, firstMoveIndex
                                 <Box
                                     ref={provided.innerRef}
                                     {...provided.droppableProps}
-                                    // sx={{ minHeight: "60px" }} 
+                                    // sx={{ minHeight: "60px" }}
                                 >
                                     <MoveGroupCard raidInputProps={raidInputProps} results={results} groupIndex={groupIndex} firstMoveIndex={firstMoveIndex} buttonsVisible={buttonsVisible} transitionIn={transitionIn} setTransitionIn={setTransitionIn} transitionOut={transitionOut} setTransitionOut={setTransitionOut} translationKey={translationKey} />
                                     {provided.placeholder}
@@ -994,9 +1006,9 @@ function MoveGroupContainer({raidInputProps, results, groupIndex, firstMoveIndex
                                 }
                             </Typography>
                             <Box flexGrow={5} />
-                            <AddButton 
+                            <AddButton
                                 label={ getTranslation("Add Move", translationKey) }
-                                onClick={handleAddTurn(groupIndex, raidInputProps.groups, raidInputProps.setGroups, rollCase, setTransitionIn)(raidInputProps.groups[groupIndex].turns.length)} 
+                                onClick={handleAddTurn(groupIndex, raidInputProps.groups, raidInputProps.setGroups, rollCase, setTransitionIn)(raidInputProps.groups[groupIndex].turns.length)}
                                 visible={buttonsVisible}
                             />
                             <Box flexGrow={2} />
@@ -1006,14 +1018,14 @@ function MoveGroupContainer({raidInputProps, results, groupIndex, firstMoveIndex
                                 }
                             </Typography>
                             <RepeatsInput
-                                value={(raidInputProps.groups[groupIndex].repeats || 1).toString()} 
+                                value={(raidInputProps.groups[groupIndex].repeats || 1).toString()}
                                 onChange={(e) => {
                                     let val = e.target.value ? parseInt(e.target.value) : 1;
                                     val = Math.max(1, Math.min(20, val));
                                     const newGroups = [...raidInputProps.groups];
                                     newGroups[groupIndex].repeats = val;
                                     raidInputProps.setGroups(newGroups);
-                                }} 
+                                }}
                                 inputProps={{
                                     step: 0,
                                     min: 1,
@@ -1039,16 +1051,16 @@ function MoveGroupContainer({raidInputProps, results, groupIndex, firstMoveIndex
                 {(provided) => (
                     <div
                         ref={provided.innerRef}
-                        {...provided.droppableProps} 
+                        {...provided.droppableProps}
                     > */}
             <Stack
                 direction="row"
                 sx = {{ width: "100%"}}
-            >   
+            >
                 <Box flexGrow={1} />
-                <AddButton 
+                <AddButton
                     label={ getTranslation("Add Group", translationKey) }
-                    onClick={handleAddGroup(raidInputProps.groups, raidInputProps.setGroups, rollCase, setTransitionIn)(groupIndex+1)} 
+                    onClick={handleAddGroup(raidInputProps.groups, raidInputProps.setGroups, rollCase, setTransitionIn)(groupIndex+1)}
                     visible={buttonsVisible}
                 />
                 <Box flexGrow={1} />
@@ -1060,10 +1072,10 @@ function MoveGroupContainer({raidInputProps, results, groupIndex, firstMoveIndex
         </Stack>
     )
 }
-   
-   
-function MoveGroupCard({raidInputProps, results, groupIndex, firstMoveIndex, buttonsVisible, transitionIn, setTransitionIn, transitionOut, setTransitionOut, translationKey}: 
-    {raidInputProps: RaidInputProps, results: RaidBattleResults, groupIndex: number, firstMoveIndex: number, buttonsVisible: boolean, transitionIn: number, setTransitionIn: (i: number) => void, transitionOut: number, setTransitionOut: (i: number) => void, translationKey: any}) 
+
+
+function MoveGroupCard({raidInputProps, results, groupIndex, firstMoveIndex, buttonsVisible, transitionIn, setTransitionIn, transitionOut, setTransitionOut, translationKey}:
+    {raidInputProps: RaidInputProps, results: RaidBattleResults, groupIndex: number, firstMoveIndex: number, buttonsVisible: boolean, transitionIn: number, setTransitionIn: (i: number) => void, transitionOut: number, setTransitionOut: (i: number) => void, translationKey: any})
 {
     return  (
         <Stack direction="column" spacing={0.5} sx={{ minHeight: "1px" }}>
@@ -1079,10 +1091,10 @@ function MoveGroupCard({raidInputProps, results, groupIndex, firstMoveIndex, but
                         }
                     }
                     return (
-                        <MoveSelectionContainer 
+                        <MoveSelectionContainer
                             key={turn.id}
-                            raiders={raiders}    
-                            turnIndex={turnIndex} 
+                            raiders={raiders}
+                            turnIndex={turnIndex}
                             groupIndex={groupIndex}
                             groups={raidInputProps.groups}
                             setGroups={raidInputProps.setGroups}
@@ -1100,15 +1112,15 @@ function MoveGroupCard({raidInputProps, results, groupIndex, firstMoveIndex, but
    }
 
 
- 
+
 const reorder = (list: RaidTurnInfo[] | TurnGroupInfo[], startIndex: number, endIdex: number) => {
    const result = [...list];
    const [removed] = result.splice(startIndex, 1);
    result.splice(endIdex, 0, removed);
- 
+
    return result;
 };
- 
+
 const move = (source: TurnGroupInfo, destination: TurnGroupInfo, sourceIndex: number, destIndex: number) => {
     const sourceClone = {
         id: source.id,
@@ -1138,10 +1150,10 @@ function MoveSelection({raidInputProps, results, rollCase, translationKey}: {rai
     const onDragEnd = (result: DropResult) => {
         setButtonsVisible(true);
         const {destination, source, type} = result;
-        if (!destination) { 
+        if (!destination) {
             return;
         }
-        if (destination.droppableId === source.droppableId && 
+        if (destination.droppableId === source.droppableId &&
             destination.index === source.index
         ) {
             return;
@@ -1196,27 +1208,27 @@ function MoveSelection({raidInputProps, results, rollCase, translationKey}: {rai
                     {(provided) => (
                         <div
                             ref={provided.innerRef}
-                            {...provided.droppableProps} 
+                            {...provided.droppableProps}
                         >
-                            <Stack 
-                                direction="column" 
-                                spacing={0.25} 
+                            <Stack
+                                direction="column"
+                                spacing={0.25}
                                 sx={{ marginTop: 0.25 }}
                             >
                                 {/* <Droppable droppableId={`${-0.5}`} type="turn">
                                     {(provided) => (
                                         <div
                                             ref={provided.innerRef}
-                                            {...provided.droppableProps} 
+                                            {...provided.droppableProps}
                                         > */}
                                 <Stack
                                     direction="row"
                                     sx={{ width: "100%" }}
                                 >
                                     <Box flexGrow={1} />
-                                    <AddButton 
+                                    <AddButton
                                         label={ getTranslation("Add Group", translationKey) }
-                                        onClick={handleAddGroup(raidInputProps.groups, raidInputProps.setGroups, rollCase, setTransitionIn)(0)} 
+                                        onClick={handleAddGroup(raidInputProps.groups, raidInputProps.setGroups, rollCase, setTransitionIn)(0)}
                                         visible={buttonsVisible}
                                     />
                                     <Box flexGrow={1} />
@@ -1226,13 +1238,13 @@ function MoveSelection({raidInputProps, results, rollCase, translationKey}: {rai
                                     )}
                                 </Droppable> */}
                                 {
-                                    raidInputProps.groups.map((group, index) => { 
+                                    raidInputProps.groups.map((group, index) => {
                                         const firstMoveIndex = raidInputProps.groups.slice(0, index).reduce(
                                             (acc, g) => acc + (
                                                 // number of regular moves
                                                 g.turns.length +
                                                 // ... plus the number of NPC moves (assumes NPC isn't in the first slot, so maybe we should enforce that)
-                                                g.turns.filter(t => t.moveInfo.userID === 1 && t.moveInfo.moveData.name !== "(No Move)" && t.moveInfo.moveData.name !== "(Wait)").length * raidInputProps.pokemon.slice(1).filter(p => p.name === "NPC").length    
+                                                g.turns.filter(t => t.moveInfo.userID === 1 && t.moveInfo.moveData.name !== "(No Move)" && t.moveInfo.moveData.name !== "(Wait)").length * raidInputProps.pokemon.slice(1).filter(p => p.name === "NPC").length
                                             ) * (g.repeats || 1), 0
                                         );
                                         return (
@@ -1247,11 +1259,11 @@ function MoveSelection({raidInputProps, results, rollCase, translationKey}: {rai
                                                     {...provided.draggableProps}
                                                     {...provided.dragHandleProps}
                                                 >
-                                                    <MoveGroupContainer 
+                                                    <MoveGroupContainer
                                                         key={index}
-                                                        raidInputProps={raidInputProps} 
+                                                        raidInputProps={raidInputProps}
                                                         results={results}
-                                                        groupIndex={index} 
+                                                        groupIndex={index}
                                                         firstMoveIndex={firstMoveIndex}
                                                         rollCase={rollCase}
                                                         buttonsVisible={buttonsVisible}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -139,7 +139,7 @@ export function getAilmentReadableName(ailment?: string) {
 
 export function getLearnMethodReadableName(learnMethod: string) {
     return (
-        learnMethod === "level-up" ? "Level Up" : 
+        learnMethod === "level-up" ? "Level Up" :
         learnMethod === "machine" ? "TM" :
         learnMethod === "egg" ? "Egg" :
         "Special"
@@ -151,8 +151,8 @@ export function getStatusReadableName(status: string) {
         status === "slp" ? "Asleep" :
         status === "psn" ? "Poisoned" :
         status === "brn" ? "Burned" :
-        status === "frz" ? "Frozen" : 
-        status === "par" ? "Paralyzed" : 
+        status === "frz" ? "Frozen" :
+        status === "par" ? "Paralyzed" :
         status === "tox" ? "Toxic" :
         "???"
     )
@@ -218,7 +218,7 @@ export function getIVDescription(ivs: StatsTable, translationKey: any) {
     for (let stat in ivs) {
         const statid = stat as StatID;
         displayedIVs.push(`${ivs[statid]}`);
-    } 
+    }
     return displayedIVs.join(' / ');
 }
 
@@ -253,7 +253,7 @@ export function getTurnNumbersFromGroups(groups: TurnGroupInfo[]) {
         }
         for (let i=0; i<4; i++) {
             // Attempt to handle weird situations where a raider falls behind in move count,
-            // then moves several times in a row. 
+            // then moves several times in a row.
             if (g.turns.find(t => (t.moveInfo.userID === i+1) && (t.moveInfo.moveData.name !== "(No Move)"))) {
                 moveCounters[i] = currentTurn;
             } else if (moveCounters[i] < currentTurn - 1) {
@@ -280,7 +280,7 @@ export function sortGroupsIntoTurns(turnNumbers: number[], groups: TurnGroupInfo
             turns[turns.length-1].push(groups[currentGroupIndex]);
             currentGroupIndex += 1;
             if ( tn === 0 ) { break; }
-        } 
+        }
     }
     return [turns, labels];
 }
@@ -348,16 +348,24 @@ export function setdexToOptions(dex: Object): SetOption[] {
     return options.sort((a,b) => (a.pokemon + a.name) < (b.pokemon + b.name) ? -1 : 1);
 }
 
-export function getSelectableTargets(moveTarget?: MoveTarget): number[] {
+export function getSelectableTargets(userID: number, moveTarget?: MoveTarget, isBossAction?: boolean): number[] {
     switch (moveTarget) {
+        case "user":
+        case "user-and-allies":
+        case "all-allies":
+            return [userID];
         case "ally":
-            return [1,2,3,4];
+            return [1,2,3,4].filter((id) => id !== userID);
         case "opponent":
         case "all-opponents":
         case "all-other-pokemon":
             return [0];
         default:
-            return [0,1,2,3,4]
+            if (isBossAction) {
+                return [1,2,3,4,5];
+            } else {
+                return [0,1,2,3,4].filter((id) => id !== userID);;
+            }
     }
 }
 
@@ -378,7 +386,7 @@ export function getTranslationWithoutCategory(word: string, translationKey: any)
 }
 
 export function convertCamelCaseToWords(input: string): string {
-    const words = input.replace(/([a-z])([A-Z])/g, '$1 $2');  
+    const words = input.replace(/([a-z])([A-Z])/g, '$1 $2');
     const capitalizedWords = words.replace(/\b\w/g, (match) => match.toUpperCase());
     return capitalizedWords;
 }
@@ -387,12 +395,12 @@ export function arraysEqual(a: any[], b: any[]) {
     if (a === b) return true;
     if (a === null || b === null) return false;
     if (a.length !== b.length) return false;
-  
+
     // If you don't care about the order of the elements inside
     // the array, you should sort both arrays here.
     // Please note that calling sort on an array will modify that array.
     // you might want to clone your array first.
-  
+
     for (var i = 0; i < a.length; ++i) {
       if (a[i] !== b[i]) return false;
     }
@@ -411,10 +419,10 @@ export function deepEqual(a: any, b: any) {
     if ((typeof a == "object" && a !== null) && (typeof b === "object" && b !== null)) {
         if (Object.keys(a).length !== Object.keys(b).length) { return false; }
         for (var prop in a) {
-            if (b.hasOwnProperty(prop)) {  
+            if (b.hasOwnProperty(prop)) {
                 if (!deepEqual(a[prop], b[prop])) { return false; }
-            } else { 
-                return false; 
+            } else {
+                return false;
             }
         }
         return true;
@@ -430,7 +438,7 @@ export function recursiveEmptiesToNull(obj: any) {
         for (let key in obj) {
             obj[key] = recursiveEmptiesToNull(obj[key]) as any;
         }
-    } 
+    }
     return obj as any;
 }
 

--- a/src/workers/raidcalc.worker.ts
+++ b/src/workers/raidcalc.worker.ts
@@ -29,7 +29,7 @@ self.onmessage = (event: MessageEvent<{raiders: Raider[], groups: TurnGroupInfo[
 
     raiders[0].isTera = true; // ensure the boss is Tera'd on T0
     for (let i = 0; i < raiders.length; i++) {
-        raiders[i].field.gameType = 'Doubles'; // affects Reflect/Light Screen/Aurora Veil 
+        raiders[i].field.gameType = 'Doubles'; // affects Reflect/Light Screen/Aurora Veil
     }
 
     // handle alt UI format for scripted boss moves...
@@ -58,7 +58,7 @@ self.onmessage = (event: MessageEvent<{raiders: Raider[], groups: TurnGroupInfo[
                 startingState: state,
                 groups: event.data.groups,
             }
-        
+
             const battle = new RaidBattle(info);
             const result = battle.result();
             self.postMessage(JSON.parse(JSON.stringify(result)));


### PR DESCRIPTION
Adds a "(Random Target)" option to the UI for scripted boss moves, which is intended to replace the need to repeat scripted actions for each raider to check worst-case defensive calcs, which can be really chunky for events like Charizard.

The intended behavior:
- the move is performed against each raider in a similar way to a spread move (but without the spread damage reduction)
- additional move effects like user stat changes only occur once
- the 25% chance to hit each raider is accounted for in the total cumulative % chance to faint
- this target option is only available when the boss is selected as the user, and then only for single-target moves not directed at the user

So what used to look like this:
<img width="879" height="645" alt="old" src="https://github.com/user-attachments/assets/92890a5a-6089-46e9-a748-84b6156b89b2" />

...should now have identical damage calcs (and slightly different %chance to faint calcs, when applicable) to this:
<img width="878" height="217" alt="new" src="https://github.com/user-attachments/assets/21830e5e-d8af-477e-bca3-f7a18b3a153b" />


