### PR TITLE
fix Mirror Herb and Opportunist

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1008,6 +1008,28 @@ describe('Specific Test Cases', () => {
     // T4: Stomping Tantrum does not have doubled BP
     expect(result.turnResults[3].results[0].desc[2].includes("(150 BP)")).toEqual(false);
   })
+  test('mirror-herb-opportunist-defiant', async() => {
+    // Spicy Extract (+2 Atk, -2 Def) against a Defiant boss; raiders hold Mirror Herb / have Opportunist
+    const hash = "#H4sIAAAAAAAAA61U32/TMBD+VyI/geSHpt0Y9G2sA/awgVjfqj64ySU56tiR7QSiif+dOydtwxjSQFNd9+58P7777OuDKMRSZN+8NUKKIJabzUwKo2oQW8ki5iykUrQe3M2KnZQrIUTRNgGt8ewxl6J0tm3IWtsObkxhSdxZ728P6uDlrAYxlpDCV2h6+lU71Bj6sWjmMPAhZNbkyvXXRQFZ8Oyntf1+i55lyqTpp8Lgx7iKy6uwpz2HgjM0Ku553OHotnZYluC4G6zhpBEc0PmVMhnolapVCUfjoH5V4SnTGpz6i/mqUqaEkURjAzD0zEGOsaHG7qEeyG+dYUukMfYHDajo5NudDxhaDqZE50wfuTMS6NgB466hA2akBJNTO1xyNlzHIQwD1OJ50ZNAzhKolXXfwNE+Xm6rAzYaJ+ytVFBiu5WiE8sHQS/qnRTvrfUhyWzTL5P7BrM+uf4RnMpC0vlkBQUqwxce1yYGpQtJVS+NwQq1inWnSqG0BylOoZc5sc5SjL6g4ONn+/NgXKSPFh2lM6pzRxk+YFkFNCUhEPeNVr6i3hfndByj38Zk87guZnJBaQ+J01TS3X50qlCoUEzFEecXp8zeh8jSGmsaqgOk+fn8X5EyvAmFxPUBx1zSgF1Z1+HecDfikTaieXVnk8th4F6Tyy06Z13yCdyOtHvlff8EvCg9H+DA34ShhRTXNI6hipNyEkdMn5vGutAa9OGlOPoDwtl/kPPCdGzH530Wk0SRiPn9PukxjUdvRlDTXaiOnmh6en2LATP/zRLgGUU/JzZC2cy2PN4s0XdchPLnL6o0U6QXBgAA";
+    const result = await resultsFromHash(hash);
+    const state = result.turnResults[0].state;
+    // T1: boss gets +2 Atk from Spicy Extract and +2 Atk from Defiant (triggered by the -2 Def drop)
+    expect(state.raiders[0].boosts.atk).toEqual(4);
+    expect(state.raiders[0].boosts.def).toEqual(-2);
+    // Mirror Herb and Opportunist copy the accumulated +4, not just the raise from a single source
+    expect(state.raiders[2].boosts.atk).toEqual(4);
+    expect(state.raiders[2].item).toEqual(undefined); // Mirror Herb consumed
+    expect(state.raiders[3].boosts.atk).toEqual(4);
+
+    // Three Intimidate raiders against a Defiant boss; a fourth raider holds Mirror Herb
+    const hash2 = "#H4sIAAAAAAAAA71US2/bMAz+K4ZOG6BDnDTrlluW7BEM6WHtLchBsWmbiywZkuLBKPrfR8rOo0UGtJciikRS/MiPlORHUYiZyP54a4QUQcw2m5EURtUgtpJFzFlIpTh4cKslOylXQoiibQJa49ljLEXp7KEha21bWJnCkriz3q+Pau/lrAYxpJDCV2g6WtUONYZuSJo5DLwJmTW5ct23ooAsePbT2v5do2eZImlaKgx+wFWcXoU9zTkUHKFRcc7jDCe3B4dlCY6rwRrOGtEBnS+UyUAvVa1KOBl79bcK10wP4NR/zItKmRKGJhobgKlnDnKMBTV2D3Xf/IMzbIltjPVBAyo6+cPOBwwHBlOgKbeP3JkJtOyAcdbQAnekBJNTOZxy1B/HEYYBavE69AWQowQq5aFr4GQfDvegAzYaL7q3VEGJ7VaKVsweBd2oL1J8tdaHJLNNN0uCIwAkK0Otx5y6lLQ+WUKByvChx7GJwHQiKfPcGKxQq5j7UimU9iDFGTrPqfMsRfQtgU+/7dPROElfDNpKR5TnjiJ8x7IKaEpiIO4brXxF9U+mtB3Rn2OwcRy3IzmhsMfAaSrpfH85a/c2x3jFL5WB67noK3TH0/FbCZ9ZXvCgR/ajU07llk/pLL4nhwmFdjvLL3FY3y/7WN5IsbCuxb3h8xQvtIHJhzubzPvPzkdyWaNz1iU/we1Iu1fed1d4RentzLbDjb6JQaI46Rnw15HSp0fzp4He5SxUSzcyPV+259gRoV+DjTQ2oy2/aJboPwxi+PQPwjUYxwoGAAA=";
+    const result2 = await resultsFromHash(hash2);
+    // T0: each Intimidate (-1 Atk) triggers Defiant (+2 Atk) on the boss
+    expect(result2.turnZeroState.raiders[0].boosts.atk).toEqual(3);
+    // Mirror Herb copies all the raises accumulated across the simultaneous switch-ins
+    expect(result2.turnZeroState.raiders[4].boosts.atk).toEqual(6);
+    expect(result2.turnZeroState.raiders[4].item).toEqual(undefined); // Mirror Herb consumed
+  })
 })
 
 

--- a/src/raidcalc/RaidBattle.ts
+++ b/src/raidcalc/RaidBattle.ts
@@ -160,6 +160,12 @@ export class RaidBattle {
                 }
             }
         }
+        // switch-ins are simultaneous, so Mirror Herb / Opportunist copy stat raises
+        // accumulated across all of them (e.g. Defiant boosts from multiple Intimidates)
+        const copyFlags = this._state.copyStatChanges();
+        for (let i=0; i<5; i++) {
+            this._turnZeroFlags[i] = this._turnZeroFlags[i].concat(copyFlags[i]);
+        }
         // check for item/ability activation by executing dummy moves
         for (let id of speedOrder) {
             const moveResult = new RaidMove(

--- a/src/raidcalc/RaidMove.ts
+++ b/src/raidcalc/RaidMove.ts
@@ -197,6 +197,8 @@ export class RaidMove {
                 this.applyPostMoveEffects();
                 this.storeLastMove();
             }
+            // Mirror Herb / Opportunist copy stat raises accumulated over the course of the move
+            this._raidState.copyStatChanges();
             this._raidState.raiders[0].checkShield(); // check for shield breaking
             this.setFlags();
             // store move data and target
@@ -216,6 +218,8 @@ export class RaidMove {
         if (this.move.hasType("Electric") && !this.move.named("Charge")) {
             this._user.field.attackerSide.isCharged = false;
         }
+        // stat raises accumulated on any path through the move must not leak into the next action
+        this._raidState.copyStatChanges();
         return this.output;
     }
 
@@ -1273,7 +1277,7 @@ export class RaidMove {
                         change = statChange.value;
                     }
                     if (Number.isNaN(change)) { console.log("Stat change info for " + this.moveData.name + " is missing."); continue; }
-                    if (change < 0 && id !== this.userID && (field.attackerSide.isMist && !this._user.hasAbility("Infiltrator"))) {
+                    if (change < 0 && id !== this.userID && (field.attackerSide.isProtected || (field.attackerSide.isMist && this._user.ability !== "Infiltrator"))) {
                         continue;
                     }
                     boost[stat] = change;
@@ -1596,17 +1600,8 @@ export class RaidMove {
                     !persistentAbilities["FailSkillSwap"].includes(target_ability)
                 ) {
                     const tempUserAbility = user_ability;
-                    // both abilities need to be changed *before* new ability effects kick in
-                    // e.g. for Intimidate and Contrary
-                    this._raidState.removeAbilityFieldEffect(this.userID, user_ability);
-                    this._user.ability = target_ability;
-                    this._user.abilityOn = false;
-                    this._raidState.removeAbilityFieldEffect(targetID, target.ability);
-                    target.ability = tempUserAbility;
-                    target.abilityOn = false;
-                    // now effects can be triggered
-                    this._raidState.addAbilityFieldEffect(this.userID, this._user.ability);
-                    this._raidState.addAbilityFieldEffect(targetID, target.ability);
+                    this._raidState.changeAbility(this.userID, target_ability, true);
+                    this._raidState.changeAbility(targetID, tempUserAbility, true);
                 } else {
                     this._desc[targetID] = this._user.name + " " + this.move.name + " vs. " + target.name + " — " + this.move.name + " failed!";
                 }
@@ -2069,13 +2064,8 @@ export class RaidMove {
         /// Item-related effects that occur at the end of a successful move
         // Choice-locking items
         if (this._user.hasItem("Choice Specs", "Choice Band", "Choice Scarf") &&
-            this.raidState.raiders[this.userID].hasItem("Choice Specs", "Choice Band", "Choice Scarf")) {
-            this._user.isChoiceLocked = true;
-        }
-        if (this.instructed &&      // check the instruct user, too
-            this._raidState.raiders[this.raiderID].hasItem("Choice Specs", "Choice Band", "Choice Scarf") &&
             this.raidState.raiders[this.raiderID].hasItem("Choice Specs", "Choice Band", "Choice Scarf")) {
-            this._raidState.raiders[this.raiderID].isChoiceLocked = true;
+            this._user.isChoiceLocked = true;
         }
         // confusion from thrash-like moves (assuming 2 turns instead of 3)
         if (this.move.named("Thrash","Petal Dance","Outrage","Raging Fury") && this._user.moveRepeated && ((this._user.moveRepeated + 1) % 2 === 0)) {

--- a/src/raidcalc/RaidState.ts
+++ b/src/raidcalc/RaidState.ts
@@ -12,16 +12,19 @@ const gen = Generations.get(9);
 export class RaidState implements State.RaidState{
     raiders: Raider[];      // raiders[0] is the boss, while raiders 1-5 are the players
     lastMovedID?: number;   // id of the last Pokemon to move
+    pendingCopyBoosts: Partial<StatsTable>[];   // stat raises not yet seen by opposing Mirror Herb / Opportunist holders
 
-    constructor(raiders: Raider[], lastMovedID?: number) {
+    constructor(raiders: Raider[], lastMovedID?: number, pendingCopyBoosts?: Partial<StatsTable>[]) {
         this.raiders = raiders;
         this.lastMovedID = lastMovedID;
+        this.pendingCopyBoosts = pendingCopyBoosts || [{},{},{},{},{}];
     }
 
     clone(): RaidState {
         return new RaidState(
             this.raiders.map(raider => raider.clone()),
             this.lastMovedID,
+            this.pendingCopyBoosts.map(boosts => ({...boosts})),
         )
     }
 
@@ -601,32 +604,12 @@ export class RaidState implements State.RaidState{
         }
         // Mirror Herb and Opportunist
         if (copyable) { // Stat changes that are being copied shouldn't be copied in turn
-            const opponentIds = id === 0 ? [1,2,3,4] : [0];
-            for (const opponentId of getSpeedRanking(opponentIds, this.raiders)) {
-                const opponent = this.getPokemon(opponentId);
-                const mirrorHerb = opponent.item === "Mirror Herb";
-                const opportunist = opponent.hasAbility("Opportunist");
-                if (mirrorHerb || opportunist)  {
-                    const both = mirrorHerb && opportunist;
-                    const positiveDiff = {...diff};
-                    let hasPositiveBoost = false;
-                    for (const stat in positiveDiff) {
-                        const statId = stat as StatIDExceptHP;
-                        if (both) {
-                            positiveDiff[statId] *= 2;
-                        }
-                        if ((positiveDiff[statId] || 0) <= 0) {
-                            positiveDiff[statId] = 0;
-                        } else {
-                            hasPositiveBoost = true;
-                        }
-                    }
-                    if (hasPositiveBoost) {
-                        const changes = this.applyStatChange(opponentId, positiveDiff, false, id);
-                        if (Object.values(changes).some(val => val > 0) && opponent.item === "Mirror Herb") {
-                            this.consumeItem(opponentId, opponent.item);
-                        }
-                    }
+            // accumulate boosts for eventual copying by Mirror Herb or Opportunist
+            const pending = this.pendingCopyBoosts[id];
+            for (const stat in diff) {
+                const statId = stat as StatIDExceptHP;
+                if ((diff[statId] || 0) > 0) {
+                    pending[statId] = (pending[statId] || 0) + diff[statId]!;
                 }
             }
         }
@@ -641,6 +624,50 @@ export class RaidState implements State.RaidState{
         }
 
         return diff;
+    }
+
+    // Copies stat raises accumulated in pendingCopyBoosts to opposing Mirror Herb / Opportunist holders
+    // and returns flags
+    public copyStatChanges(): string[][] {
+        const flags: string[][] = [[],[],[],[],[]];
+        const statAbbreviations: {[stat in StatIDExceptHP]: string} = {atk: "Atk", def: "Def", spa: "SpA", spd: "SpD", spe: "Spe", acc: "Acc", eva: "Eva"};
+        const displayBoost = (val: number | undefined) => ((val || 0) > 0 ? "+" : "") + (val || 0);
+        for (let id = 0; id < 5; id++) {
+            const pending = this.pendingCopyBoosts[id];
+            this.pendingCopyBoosts[id] = {};
+            if (!Object.values(pending).some(val => (val || 0) > 0)) { continue; }
+            const opponentIds = id === 0 ? [1,2,3,4] : [0];
+            for (const opponentId of getSpeedRanking(opponentIds, this.raiders)) {
+                const opponent = this.getPokemon(opponentId);
+                if (opponent.originalCurHP === 0) { continue; }
+                const mirrorHerb = opponent.item === "Mirror Herb";
+                const opportunist = opponent.hasAbility("Opportunist");
+                if (mirrorHerb || opportunist) {
+                    const copiedBoosts: Partial<StatsTable> = {};
+                    for (const stat in pending) {
+                        const statId = stat as StatIDExceptHP;
+                        if ((pending[statId] || 0) > 0) {
+                            // a Pokemon with both Mirror Herb and Opportunist copies each raise twice
+                            copiedBoosts[statId] = pending[statId]! * (mirrorHerb && opportunist ? 2 : 1);
+                        }
+                    }
+                    const origBoosts = {...opponent.boosts};
+                    const changes = this.applyStatChange(opponentId, copiedBoosts, false, id);
+                    const changedStats = Object.keys(changes).filter(stat => changes[stat as StatIDExceptHP] !== 0) as StatIDExceptHP[];
+                    if (changedStats.length > 0) {
+                        const source = mirrorHerb && opportunist ? "Mirror Herb + Opportunist" : (mirrorHerb ? "Mirror Herb" : "Opportunist");
+                        const boostStrs = changedStats.map(statId =>
+                            statAbbreviations[statId] + ": " + displayBoost(origBoosts[statId]) + " → " + displayBoost(opponent.boosts[statId])
+                        );
+                        flags[opponentId].push(boostStrs.join(", ") + " (" + source + ")");
+                    }
+                    if (Object.values(changes).some(val => val > 0) && opponent.item === "Mirror Herb") {
+                        this.consumeItem(opponentId, opponent.item);
+                    }
+                }
+            }
+        }
+        return flags;
     }
 
     public applyStatus(id: number, status: StatusName, source: number, isSecondaryEffect: boolean = false, fromHeldItem: boolean | undefined = false, roll: "max" | "min" | "avg" | undefined = "avg") {

--- a/src/raidcalc/RaidTurn.ts
+++ b/src/raidcalc/RaidTurn.ts
@@ -311,6 +311,14 @@ export class RaidTurn {
             }
         }
 
+        // Mirror Herb / Opportunist copy stat raises accumulated during end-of-turn effects (e.g. Speed Boost)
+        const copyFlags = this._raidState.copyStatChanges();
+        for (let i=0; i<5; i++) {
+            for (const flag of copyFlags[i]) {
+                this._endFlags.push(this._raidState.raiders[i].role + " — " + flag);
+            }
+        }
+
         return {
             state: this._raidState,
             results: [this._result1, this._result2, ...this._delayedResults],


### PR DESCRIPTION
Accumulates boosts across an entire move (which can combine things like Defiant's +2 Atk with Spicy Extract's +2 Atk, or multiple Stamina procs from a multihit move) that are all copied by a Mirror Herb rather than just the first one.